### PR TITLE
Bug fix: use public interface to ccpp_fields_get_

### DIFF
--- a/IPD_layer/IPD_driver_cap.f90
+++ b/IPD_layer/IPD_driver_cap.f90
@@ -243,7 +243,7 @@ module IPD_driver_cap
 
         call c_f_pointer(ptr, cdata)
 
-        call ccpp_fields_get(cdata, 'IPD_Control', tmp, ierr)
+        call ccpp_fields_get(cdata, 'IPD_Control', ptr, ierr)
         if (ierr /= 0) then
             call ccpp_error('Unable to retrieve IPD_Control')
             return
@@ -306,7 +306,7 @@ module IPD_driver_cap
 
         call c_f_pointer(ptr, cdata)
 
-        call ccpp_fields_get(cdata, 'IPD_Control', tmp, ierr)
+        call ccpp_fields_get(cdata, 'IPD_Control', ptr, ierr)
         if (ierr /= 0) then
             call ccpp_error('Unable to retrieve IPD_Control')
             return


### PR DESCRIPTION
   Bug fix:
    
    In the gfsphyics IPD_driver_cap.f90 there were two references to
    "ccpp_fields_get_ptr":
    
    https://github.com/NCAR/gmtb-gfsphysics/blob/features/ccpp/IPD_layer/IPD_driver_cap.f90
    
    lines 246 & 309.
    
    The subroutine is not public. I (Tim) wrapped it with an interface/module
    procedure as ccpp_fields_get() so as to be able to get an int, real,
    logical and pointer. We should not be calling the _ptr subroutine.
    
        modified:   IPD_layer/IPD_driver_cap.f90

