### PR TITLE
Reduce optimization for GFS_diagnostics.F90

### DIFF
--- a/makefile
+++ b/makefile
@@ -173,6 +173,9 @@ $(LIBRARY): $(OBJS)
 ./radiation_aerosols.o : ./gfsphys/radiation_aerosols.f
 	$(FC) $(FFLAGS) $(OTHER_FFLAGS) -xCORE-AVX-I -c $< -o $@
 
+./GFS_layer/GFS_diagnostics.o : ./GFS_layer/GFS_diagnostics.F90
+	$(FC) $(FFLAGS) $(OTHER_FFLAGS) -O0 -c $< -o $@
+
 .PHONY: clean
 clean:
 	@echo "Cleaning gfsphysics  ... "


### PR DESCRIPTION
This PR addresses a compile failure of GFS_diagnostics.F90 with Intel > 17.x by reducing the optimization from the standard value (-O2) to -O0. Because right now the routine is computationally inexpensive, an attempt to try -O1 has not been made.

Edit: A try to compile with -O1 also failed on Cheyenne using the Intel 17 compiler.

M	modified:   makefile