### PR TITLE
Add nceplibs to libgfsphys.so

### DIFF
--- a/makefile
+++ b/makefile
@@ -163,7 +163,7 @@ OBJS = $(OBJS_f) $(OBJS_f90) $(OBJS_F) $(OBJS_F90) $(OBJS_c)
 all default: depend $(LIBRARY)
 
 $(LIBRARY): $(OBJS)
-	$(FC) -shared -Wl,-soname,$(LIBRARY).$(VER_MAJOR) $(OBJS)  $(LDFLAGS) -o $(LIBRARY).$(VER_MAJOR).$(VER_MINOR).$(VER_PATCH)
+	$(FC) -shared -Wl,-soname,$(LIBRARY).$(VER_MAJOR) $(OBJS) $(LDFLAGS) $(NCEPLIBS) -o $(LIBRARY).$(VER_MAJOR).$(VER_MINOR).$(VER_PATCH)
 	ln -sf $(LIBRARY).$(VER_MAJOR).$(VER_MINOR).$(VER_PATCH) $(LIBRARY)
 	ln -sf $(LIBRARY).$(VER_MAJOR).$(VER_MINOR).$(VER_PATCH) $(LIBRARY).$(VER_MAJOR)
 


### PR DESCRIPTION
This PR adds the NCEP LIBS to the compile/link command for libgfsphys.so. If these are not linked in, the code aborts because of undefined symbols in the library.