### PR TITLE
Commit GFS_diagnostics.F90 without optimization

### DIFF
--- a/makefile
+++ b/makefile
@@ -171,6 +171,9 @@ $(LIBRARY): $(OBJS)
 ./radiation_aerosols.o : ./gfsphys/radiation_aerosols.f
 	$(FC) $(FFLAGS) $(OTHER_FFLAGS) -xCORE-AVX-I -c $< -o $@
 
+./GFS_layer/GFS_diagnostics.o : ./GFS_layer/GFS_diagnostics.F90
+	$(FC) $(FFLAGS) $(OTHER_FFLAGS) -O0 -c $< -o $@
+
 .PHONY: clean
 clean:
 	@echo "Cleaning gfsphysics  ... "


### PR DESCRIPTION
This is necessary to avoid compilation failure with Intel > 17.x.