### PR TITLE
Optimization of input arguments to time vary steps, moving of sec and…

### DIFF
--- a/GFS_layer/GFS_driver.F90
+++ b/GFS_layer/GFS_driver.F90
@@ -151,7 +151,7 @@ module GFS_driver
                      Init_parm%gnx, Init_parm%gny,                 &
                      Init_parm%dt_dycore, Init_parm%dt_phys,       &
                      Init_parm%bdat, Init_parm%cdat,               &
-                     Init_parm%tracer_names)
+                     Init_parm%tracer_names, Init_parm%blksz)
 
     call read_o3data  (Model%ntoz, Model%me, Model%master)
     call read_h2odata (Model%h2o_phys, Model%me, Model%master)
@@ -163,7 +163,7 @@ module GFS_driver
       call Sfcprop      (nb)%create (Init_parm%blksz(nb), Model)
       call Coupling     (nb)%create (Init_parm%blksz(nb), Model)
       call Grid         (nb)%create (Init_parm%blksz(nb), Model)
-      call Tbd          (nb)%create (Init_parm%blksz(nb), Init_parm%blksz(:), nb, Model)
+      call Tbd          (nb)%create (Init_parm%blksz(nb), nb, Model)
       call Cldprop      (nb)%create (Init_parm%blksz(nb), Model)
       call Radtend      (nb)%create (Init_parm%blksz(nb), Model)
       !--- internal representation of diagnostics
@@ -264,7 +264,6 @@ module GFS_driver
   subroutine GFS_time_vary_step (Model, Statein, Stateout, Sfcprop, Coupling, &
                                  Grid, Tbd, Cldprop, Radtend, Diag, Sfccycle)
 
-    use physparam,             only: ictmflg, isolar
     use GFS_phys_time_vary_1,  only: GFS_phys_time_vary_1_run
     use GFS_phys_time_vary_2,  only: GFS_phys_time_vary_2_run
     use GFS_rad_time_vary,     only: GFS_rad_time_vary_run 
@@ -283,12 +282,9 @@ module GFS_driver
     type(GFS_diag_type),      intent(inout) :: Diag
     type(GFS_sfccycle_type),  intent(inout) :: Sfccycle
 
-    !--- local variables
-    real(kind=kind_phys) :: sec
+    call GFS_phys_time_vary_1_run (Model, Tbd)
 
-    call GFS_phys_time_vary_1_run (Model, sec, Tbd%blkno)
-
-    call GFS_rad_time_vary_run (Model, Statein, Tbd, sec, ictmflg, isolar)
+    call GFS_rad_time_vary_run (Model, Statein, Tbd)
 
     call GFS_phys_time_vary_2_run (Grid, Model, Tbd, Sfcprop, Cldprop, Diag, Sfccycle)
 

--- a/IPD_layer/IPD_CCPP_driver.F90
+++ b/IPD_layer/IPD_CCPP_driver.F90
@@ -38,7 +38,7 @@ module IPD_CCPP_driver
   !-------------------------------
   ! DH* TODO - CHECK IF WE CAN REMOVE Atm_block completely?
   subroutine IPD_step (IPD_Control, IPD_Data, IPD_Diag, IPD_Restart, IPD_Interstitial, &
-                       nBlocks, Atm_block, Init_parm, l_salp_data, l_snupx, ccpp_suite, step, ierr)
+                       nBlocks, Init_parm, l_salp_data, l_snupx, ccpp_suite, step, ierr)
 
     use namelist_soilveg,  only: salp_data, snupx, max_vegtyp
     use block_control_mod, only: block_control_type
@@ -55,7 +55,6 @@ module IPD_CCPP_driver
     type(IPD_restart_type),      target, intent(inout)           :: IPD_Restart
     type(IPD_interstitial_type), target, intent(inout)           :: IPD_Interstitial(:)
     integer,                     target, intent(in)              :: nBlocks
-    type (block_control_type),   target, intent(in)   , optional :: Atm_block
     type(IPD_init_type),         target, intent(in)   , optional :: Init_parm
     real(kind=kind_phys),                intent(inout), optional :: l_salp_data
     real(kind=kind_phys),                intent(inout), optional :: l_snupx(max_vegtyp)
@@ -76,11 +75,7 @@ module IPD_CCPP_driver
 
     if (step==0) then
 
-      if (.not. present(Atm_block)) then
-        call ccpp_error('Error, IPD init step called without mandatory Atm_block argument')
-        ierr = 1
-        return
-      else if (.not. present(Init_parm)) then
+      if (.not. present(Init_parm)) then
         call ccpp_error('Error, IPD init step called without mandatory Init_parm argument')
         ierr = 1
         return
@@ -106,7 +101,6 @@ module IPD_CCPP_driver
       call ccpp_fields_add(cdata, 'IPD_Diag',         '', c_loc(IPD_Diag),         rank=size(shape(IPD_Diag)),         dims=shape(IPD_Diag),         ierr=ierr)
       call ccpp_fields_add(cdata, 'IPD_Restart',      '', c_loc(IPD_Restart),      ierr=ierr)
       call ccpp_fields_add(cdata, 'IPD_Interstitial', '', c_loc(IPD_Interstitial), rank=size(shape(IPD_Interstitial)), dims=shape(IPD_Interstitial), ierr=ierr)
-      call ccpp_fields_add(cdata, 'Atm_block',        '', c_loc(Atm_block),        ierr=ierr)
       call ccpp_fields_add(cdata, 'Init_parm',        '', c_loc(Init_parm),        ierr=ierr)
       call ccpp_fields_add(cdata, 'salp_data',            l_salp_data,             ierr=ierr)
       call ccpp_fields_add(cdata, 'snupx',                l_snupx,                 ierr=ierr)
@@ -132,11 +126,11 @@ module IPD_CCPP_driver
         end do
       end do
 
+    ! Time vary steps
     else if (step==1) then
 
-      ! DH* TODO - TEST RUNNING THIS OVER ALL BLOCKS USING THREADING?
-      ! Loop over blocks - in general, cannot use OpenMP for this step;
-      ! however, threading may be implemented inside the IPD_setup_step
+      ! Loop over blocks; cannot use OpenMP for this step; however,
+      ! threading may be implemented inside the IPD_setup_step
       do nb = 1,nBlocks
         nt = 1
         call ccpp_run(cdata_block(nb,nt)%suite%ipds(step), cdata_block(nb,nt), ierr)

--- a/physics/GFS_debug.f90
+++ b/physics/GFS_debug.f90
@@ -109,9 +109,7 @@
                      call print_var(mpirank,omprank,Tbd%blkno, 'Tbd%htlw0',            Tbd%htlw0)
                      call print_var(mpirank,omprank,Tbd%blkno, 'Tbd%htswc',            Tbd%htswc)
                      call print_var(mpirank,omprank,Tbd%blkno, 'Tbd%htsw0',            Tbd%htsw0)
-                     call print_var(mpirank,omprank,Tbd%blkno, 'Tbd%sec',              Tbd%sec)
-                     call print_var(mpirank,omprank,Tbd%blkno, 'Tbd%blksz(Tbd%blkno)', Tbd%blksz(Tbd%blkno))
-                     !call Interstitial%mprint(mpirank,omprank,Tbd%blkno)
+                     call print_var(mpirank,omprank,Tbd%blkno, 'Model%sec',            Model%sec)
                  end if
 !$OMP BARRIER
              end do

--- a/physics/GFS_rad_time_vary.f90
+++ b/physics/GFS_rad_time_vary.f90
@@ -16,11 +16,8 @@
 !! |   Model           | FV3-GFS_Control_type                                          | Fortran DDT containing FV3-GFS model control parameters                       | DDT      |  0   | GFS_control_type              |           | inout  | F        |
 !! |   Statein         | FV3-GFS_Statein_type                                          | Fortran DDT containing FV3-GFS prognostic state data in from dycore           | DDT      |  0   | GFS_statein_type              |           | in     | F        |
 !! |   Tbd             | FV3-GFS_Tbd_type                                              | Fortran DDT containing FV3-GFS data not yet assigned to a defined container   | DDT      |  0   | GFS_tbd_type                  |           | inout  | F        |
-!! |   sec             | seconds_elapsed_since_model_initialization                    | seconds elapsed since model initialization                                    | s        |  0   | real                          | kind_phys | in     | F        |
-!! |   ictmflg         | flag_for_initial_time-date_control                            | flag for initial time/date control                                            | flag     |  0   | integer                       |           | in     | F        |
-!! |   isolar          | flag_for_solar_constant                                       | solar constant control flag                                                   | flag     |  0   | integer                       |           | in     | F        |
 !!
-      subroutine GFS_rad_time_vary_run (Model, Statein, Tbd, sec, ictmflg, isolar)
+      subroutine GFS_rad_time_vary_run (Model, Statein, Tbd)
 
       use physparam,                 only: ipsd0, ipsdlim, iaerflg
       use mersenne_twister,          only: random_setseed, random_index, random_stat
@@ -37,8 +34,6 @@
       type(GFS_control_type), intent(inout) :: Model
       type(GFS_statein_type), intent(in)    :: Statein
       type(GFS_tbd_type),     intent(inout) :: Tbd
-      real(kind=kind_phys),   intent(in)    :: sec
-      integer,                intent(in)    :: ictmflg, isolar
 
       !--- local variables
       type (random_stat) :: stat
@@ -51,13 +46,12 @@
 
           call GFS_radupdate_run (Model%idat, Model%jdat, Model%fhswr, Model%dtf, Model%lsswr, &
                         Model%me, Model%slag, Model%sdec, Model%cdec, Model%solcon,            &
-                        ictmflg, isolar )
+                        Model%ictm, Model%isol )
         endif
-!$OMP barrier
 
         !--- set up random seed index in a reproducible way for entire cubed-sphere face (lat-lon grid)
         if ((Model%isubc_lw==2) .or. (Model%isubc_sw==2)) then
-          ipseed = mod(nint(con_100*sqrt(sec)), ipsdlim) + 1 + ipsd0
+          ipseed = mod(nint(con_100*sqrt(Model%sec)), ipsdlim) + 1 + ipsd0
           call random_setseed (ipseed, stat)
           call random_index (ipsdlim, numrdm, stat)
     
@@ -70,7 +64,7 @@
           do j = 1,Model%ny
             do i = 1,Model%nx
               ix = ix + 1
-              if (ix .gt. Tbd%blksz(nb)) then
+              if (ix .gt. Model%blksz(nb)) then
                 ix = 1
                 nb = nb + 1
               endif
@@ -82,7 +76,7 @@
             enddo
           enddo
         endif  ! isubc_lw and isubc_sw
-    
+
         if (Model%num_p3d == 4) then
           if (Model%kdt == 1) then
             Tbd%phy_f3d(:,:,1) = Statein%tgrs


### PR DESCRIPTION
This PR is a cleanup and preparation for an alternative implementation of the IPD_setup_step (for performance reasons):

- optimization of input arguments to time vary steps
- moving of sec and blksz from IPD_Data(:)%Tbd to IPD_Control
- remove Atm_block from IPD_step 0 as requested by Rusty
