### PR TITLE
Match module names and scheme names

### DIFF
--- a/GFS_layer/GFS_radiation_driver.F90
+++ b/GFS_layer/GFS_radiation_driver.F90
@@ -179,11 +179,11 @@
 !                                                                      !
 !       'module module_radsw_cntr_para'     in 'radsw_xxxx_param.f'    !
 !       'module module_radsw_parameters'    in 'radsw_xxxx_param.f'    !
-!       'module module_radsw_main'          in 'radsw_xxxx_main.f'     !
+!       'module rrtmg_sw'                   in 'radsw_xxxx_main.f'     !
 !                                                                      !
 !       'module module_radlw_cntr_para'     in 'radlw_xxxx_param.f'    !
 !       'module module_radlw_parameters'    in 'radlw_xxxx_param.f'    !
-!       'module module_radlw_main'          in 'radlw_xxxx_main.f'     !
+!       'module rrtmg_lw'                   in 'radlw_xxxx_main.f'     !
 !                                                                      !
 !    where xxxx may vary according to different scheme selection       !
 !                                                                      !
@@ -327,7 +327,7 @@
 
       use module_radsw_parameters,   only: topfsw_type, sfcfsw_type,    &
      &                                     profsw_type,cmpfsw_type,NBDSW
-      use module_radsw_main,         only: rswinit,  radsw_run
+      use rrtmg_sw,                  only: rswinit, rrtmg_sw_run
 
       use GFS_RRTMG_pre,             only: GFS_RRTMG_pre_run
       use GFS_RRTMG_post,            only: GFS_RRTMG_post_run
@@ -337,7 +337,7 @@
       use GFS_radlw_post,            only: GFS_radlw_post_run
       use module_radlw_parameters,   only: topflw_type, sfcflw_type,    &
      &                                     proflw_type, NBDLW
-      use module_radlw_main,         only: rlwinit,  radlw_run
+      use rrtmg_lw,                  only: rlwinit, rrtmg_lw_run
       use GFS_typedefs,              only: GFS_statein_type,             &
                                            GFS_stateout_type,            &
                                            GFS_sfcprop_type,             &
@@ -623,9 +623,9 @@
 !! - cloud initialization routine:
 !! call module_radiation_clouds::cld_init()
 !! - LW radiation initialization routine:
-!! call module_radlw_main::rlwinit()
+!! call rrtmg_lw::rlwinit()
 !! - SW radiation initialization routine:
-!! call module_radsw_main::rswinit()
+!! call rrtmg_sw::rswinit()
 !     Initialization
 
       call sol_init ( me )          !  --- ...  astronomy initialization routine
@@ -1126,46 +1126,46 @@
 !          faerlw(:,:,:,2)-  lw aerosols single scattering albedo       !
 !          faerlw(:,:,:,3)-  lw aerosols asymmetry parameter            !
 !                                                                       !
-!     6. sw fluxes at toa:    (defined in 'module_radsw_main')          !
+!     6. sw fluxes at toa:    (defined in 'rrtmg_sw')                   !
 !        (topfsw_type -- derived data type for toa rad fluxes)          !
 !          topfsw(:)%upfxc  -  total sky upward flux at toa             !
 !          topfsw(:)%dnfxc  -  total sky downward flux at toa           !
 !          topfsw(:)%upfx0  -  clear sky upward flux at toa             !
 !                                                                       !
-!     7. lw fluxes at toa:    (defined in 'module_radlw_main')          !
+!     7. lw fluxes at toa:    (defined in 'rrtmg_lw')                   !
 !        (topflw_type -- derived data type for toa rad fluxes)          !
 !          topflw(:)%upfxc  -  total sky upward flux at toa             !
 !          topflw(:)%upfx0  -  clear sky upward flux at toa             !
 !                                                                       !
-!     8. sw fluxes at sfc:    (defined in 'module_radsw_main')          !
+!     8. sw fluxes at sfc:    (defined in 'rrtmg_sw')                   !
 !        (sfcfsw_type -- derived data type for sfc rad fluxes)          !
 !          sfcfsw(:)%upfxc  -  total sky upward flux at sfc             !
 !          sfcfsw(:)%dnfxc  -  total sky downward flux at sfc           !
 !          sfcfsw(:)%upfx0  -  clear sky upward flux at sfc             !
 !          sfcfsw(:)%dnfx0  -  clear sky downward flux at sfc           !
 !                                                                       !
-!     9. lw fluxes at sfc:    (defined in 'module_radlw_main')          !
+!     9. lw fluxes at sfc:    (defined in 'rrtmg_lw')                   !
 !        (sfcflw_type -- derived data type for sfc rad fluxes)          !
 !          sfcflw(:)%upfxc  -  total sky upward flux at sfc             !
 !          sfcflw(:)%dnfxc  -  total sky downward flux at sfc           !
 !          sfcflw(:)%dnfx0  -  clear sky downward flux at sfc           !
 !                                                                       !
 !! optional radiation outputs:                                          !
-!!   10. sw flux profiles:    (defined in 'module_radsw_main')          !
+!!   10. sw flux profiles:    (defined in 'rrtmg_sw')                   !
 !!       (profsw_type -- derived data type for rad vertical profiles)   !
 !!         fswprf(:,:)%upfxc - total sky upward flux                    !
 !!         fswprf(:,:)%dnfxc - total sky downward flux                  !
 !!         fswprf(:,:)%upfx0 - clear sky upward flux                    !
 !!         fswprf(:,:)%dnfx0 - clear sky downward flux                  !
 !!                                                                      !
-!!   11. lw flux profiles:    (defined in 'module_radlw_main')          !
+!!   11. lw flux profiles:    (defined in 'rrtmg_lw')                   !
 !!       (proflw_type -- derived data type for rad vertical profiles)   !
 !!         flwprf(:,:)%upfxc - total sky upward flux                    !
 !!         flwprf(:,:)%dnfxc - total sky downward flux                  !
 !!         flwprf(:,:)%upfx0 - clear sky upward flux                    !
 !!         flwprf(:,:)%dnfx0 - clear sky downward flux                  !
 !!                                                                      !
-!!   12. sw sfc components:   (defined in 'module_radsw_main')          !
+!!   12. sw sfc components:   (defined in 'rrtmg_sw')                   !
 !!       (cmpfsw_type -- derived data type for component sfc fluxes)    !
 !!         scmpsw(:)%uvbfc  -  total sky downward uv-b flux at sfc      !
 !!         scmpsw(:)%uvbf0  -  clear sky downward uv-b flux at sfc      !
@@ -1237,7 +1237,7 @@
       !                          Grid, Tbd, Cldprop, Radtend, Diag)
       ! *DH
 ! CCPP: L1598-1618
-      call radsw_run (plyr, plvl, tlyr, tlvl, qlyr, olyr,              & ! input
+      call rrtmg_sw_run (plyr, plvl, tlyr, tlvl, qlyr, olyr,           & ! input
           gasvmr(:, :, 1),                                             &
           gasvmr(:, :, 2), gasvmr(:, :, 3), gasvmr(:, :, 4),           &
           Tbd%icsdsw, faersw(:, :, :, 1), faersw(:, :, :, 2),          &
@@ -1269,7 +1269,7 @@
           im, tsfg, tsfa)
 
 !CCPP: L1703-1714
-      call radlw_run (plyr, plvl, tlyr, tlvl, qlyr, olyr,              & ! inputs
+      call rrtmg_lw_run (plyr, plvl, tlyr, tlvl, qlyr, olyr,           & ! inputs
           gasvmr(:, :, 1), gasvmr(:, :, 2), gasvmr(:, :, 3),           &
           gasvmr(:, :, 4), gasvmr(:, :, 5), gasvmr(:, :, 6),           &
           gasvmr(:, :, 7), gasvmr(:, :, 8), gasvmr(:, :, 9),           &

--- a/pgifix.py
+++ b/pgifix.py
@@ -42,36 +42,6 @@ def execute(cmd, debug = True, abort = True):
 def correct_cap_object_names(fixcmd, cap):
     (cappath, capname) = os.path.split(cap)
     pgiprefix = capname.rstrip('.o').lower() + '_'
-    # DH*
-    # Nasty hack around non-CCPP-compliant module names and subroutine names
-    if pgiprefix == 'radsw_cap_':
-        print "WARNING! Manually change pgiprefix from 'radsw_cap_' to 'module_radsw_main_cap_'!"
-        pgiprefix = 'module_radsw_main_cap_'
-    elif pgiprefix == 'radlw_cap_':
-        print "WARNING! Manually change pgiprefix from 'radsw_cap_' to 'module_radlw_main_cap_'!"
-        pgiprefix = 'module_radlw_main_cap_'
-    elif pgiprefix == 'sfc_ex_coef_cap_':
-        print "WARNING! Manually change pgiprefix from 'sfc_ex_coef_cap_' to 'surface_exchange_coefficients_cap_'!"
-        pgiprefix = 'surface_exchange_coefficients_cap_'
-    elif pgiprefix == 'sfc_diag_cap_':
-        print "WARNING! Manually change pgiprefix from 'sfc_diag_cap_' to 'surface_diagnose_cap_'!"
-        pgiprefix = 'surface_diagnose_cap_'
-    elif pgiprefix == 'sasasshal_cap_':
-        print "WARNING! Manually change pgiprefix from 'sasasshal_cap_' to 'sasas_shal_cap_'!"
-        pgiprefix = 'sasas_shal_cap_'
-    elif pgiprefix == 'sasasshal_post_cap_':
-        print "WARNING! Manually change pgiprefix from 'sasasshal_post_cap_' to 'sasas_shal_post_cap_'!"
-        pgiprefix = 'sasas_shal_post_cap_'
-    elif pgiprefix == 'gscond_cap_':
-        print "WARNING! Manually change pgiprefix from 'gscond_cap_' to 'gfs_zhaocarr_gscond_cap_'!"
-        pgiprefix = 'gfs_zhaocarr_gscond_cap_'
-    elif pgiprefix == 'sasasdeep_cap_':
-        print "WARNING! Manually change pgiprefix from 'sasasdeep_cap_' to 'sasas_deep_cap_'!"
-        pgiprefix = 'sasas_deep_cap_'
-    elif pgiprefix == 'precpd_cap_':
-        print "WARNING! Manually change pgiprefix from 'precpd_cap_' to 'gfs_zhaocarr_precpd_cap_'!"
-        pgiprefix = 'gfs_zhaocarr_precpd_cap_'
-    # *DH
     # Get list of all symbols in cap object
     nmcmd = 'nm {0}'.format(cap)
     (status, stdout, stderr) = execute(nmcmd)

--- a/physics/gscond.f
+++ b/physics/gscond.f
@@ -3,7 +3,7 @@
 !! condensation and evaporation for use in the Zhao and Carr (1997)
 !! \cite zhao_and_carr_1997 scheme.
 
-      module GFS_zhaocarr_gscond
+      module zhaocarr_gscond
       contains
 
 !> \defgroup Zhao-Carr Zhao-Carr Microphysics
@@ -46,10 +46,10 @@
 !> \ingroup condense
 !! \brief Brief description of the subroutine
 !!
-!! \section arg_table_gscond_init  Argument Table
+!! \section arg_table_zhaocarr_gscond_init  Argument Table
 !!
-       subroutine gscond_init
-       end subroutine gscond_init
+       subroutine zhaocarr_gscond_init
+       end subroutine zhaocarr_gscond_init
 
 
 !> \ingroup condense
@@ -63,7 +63,7 @@
 !! steps, and on the temperature. Evaporation of cloud is allowed at
 !! points where the relative humidity is lower than the critical value
 !! required for condensation.
-!! \section arg_table_gscond_run Argument Table
+!! \section arg_table_zhaocarr_gscond_run Argument Table
 !! | local var name | longname                                                   | description                                              | units   | rank |  type   |   kind    | intent | optional |
 !! |----------------|------------------------------------------------------------|----------------------------------------------------------|---------|------|---------|-----------|--------|----------|
 !! | im             | horizontal_loop_extent                                     | horizontal loop extent                                   | count   |    0 | integer |           | in     |   F      |
@@ -93,8 +93,8 @@
 !! - \f$E_{c}\f$: evaporation rate of cloud (\f$s^{-1}\f$)
 !> \section Zhao-Carr_cond_detailed Detailed Algorithm
 !> @{
-        subroutine gscond_run (im,ix,km,dt,dtf,prsl,ps,q,clw1,clw2      &
-     &,                  cwm, t                                         &
+        subroutine zhaocarr_gscond_run (im,ix,km,dt,dtf,prsl,ps,q,clw1  &
+     &,                  clw2, cwm, t                                   &
      &,                  tp, qp, psp, tp1, qp1, psp1, u, lprnt, ipr)
 
 
@@ -538,19 +538,19 @@
       endif
 !-----------------------------------------------------------------------
       return
-      end subroutine gscond_run
+      end subroutine zhaocarr_gscond_run
 !> @}
 
 !> \ingroup condense
 !! \brief Brief description of the subroutine
 !!
-!! \section arg_table_gscond_finalize  Argument Table
+!! \section arg_table_zhaocarr_gscond_finalize  Argument Table
 !!
-       subroutine gscond_finalize
-       end subroutine gscond_finalize
+       subroutine zhaocarr_gscond_finalize
+       end subroutine zhaocarr_gscond_finalize
 
 
 !> @}
 !! @}
 
-      end module  GFS_zhaocarr_gscond
+      end module zhaocarr_gscond

--- a/physics/mfdeepcnv.f
+++ b/physics/mfdeepcnv.f
@@ -13,26 +13,26 @@
 
 !> \brief Brief description of the subroutine
 !!
-!! \section arg_table_sasasdeep_init  Argument Table
+!! \section arg_table_sasas_deep_init  Argument Table
 !! | local var name | longname                                                  | description                        | units   | rank | type    |    kind   | intent | optional |
 !! |----------------|-----------------------------------------------------------|------------------------------------|---------|------|---------|-----------|--------|----------|
 !!
-      subroutine sasasdeep_init
-      end subroutine sasasdeep_init
+      subroutine sasas_deep_init
+      end subroutine sasas_deep_init
 
 
 !> \brief Brief description of the subroutine
 !!
-!! \section arg_table_sasasdeep_finalize  Argument Table
+!! \section arg_table_sasas_deep_finalize  Argument Table
 !! | local var name | longname                                                  | description                        | units   | rank | type    |    kind   | intent | optional |
 !! |----------------|-----------------------------------------------------------|------------------------------------|---------|------|---------|-----------|--------|----------|
 !!
-      subroutine sasasdeep_finalize
-      end subroutine sasasdeep_finalize
+      subroutine sasas_deep_finalize
+      end subroutine sasas_deep_finalize
 
 !> \brief Brief description of the subroutine
 !!
-!! \section arg_table_sasasdeep_run Argument Table
+!! \section arg_table_sasas_deep_run Argument Table
 !! | local var name | longname                                                  | description                                         | units   | rank | type    |    kind   | intent | optional |
 !! |----------------|-----------------------------------------------------------|-----------------------------------------------------|---------|------|---------|-----------|--------|----------|
 !! | im             | horizontal_loop_extent                                    | horizontal loop extent                              | count   |    0 | integer |           | in     | F        |
@@ -68,7 +68,7 @@
 !!  \section detailed Detailed Algorithm
 !!  @{
 ! DH* TODO add intent information for all variables
-      subroutine sasasdeep_run(im,ix,km,delt,delp,prslp,psp,phil,ql1,   &
+      subroutine sasas_deep_run(im,ix,km,delt,delp,prslp,psp,phil,ql1,   &
      &     ql2,q1,t1,u1,v1,cldwrk,rn,kbot,ktop,kcnv,islimsk,garea,      &
      &     dot,ncloud,ud_mf,dd_mf,dt_mf,cnvw,cnvc)
 
@@ -2312,7 +2312,7 @@ c
       enddo
 !!
       return
-      end subroutine sasasdeep_run
+      end subroutine sasas_deep_run
       !> @}
       !> @}
 

--- a/physics/mfshalcnv.f
+++ b/physics/mfshalcnv.f
@@ -12,14 +12,14 @@
 
 !> \brief Brief description of the subroutine
 !!
-!! \section arg_table_sasasshal_init Argument Table
+!! \section arg_table_sasas_shal_init Argument Table
 !!
-      subroutine sasasshal_init
-      end subroutine sasasshal_init
+      subroutine sasas_shal_init
+      end subroutine sasas_shal_init
 
 !> \brief Brief description of the subroutine
 !!
-!! \section arg_table_sasasshal_run Argument Table
+!! \section arg_table_sasas_shal_run Argument Table
 !! | local var name | longname                                                  | description                                            | units   | rank | type    |    kind   | intent | optional |
 !! |----------------|-----------------------------------------------------------|--------------------------------------------------------|---------|------|---------|-----------|--------|----------|
 !! | im             | horizontal_loop_extent                                    | horizontal loop extent                                 | count   |    0 | integer |           | in     | F        |
@@ -54,7 +54,7 @@
 !!  \section detailed Detailed Algorithm
 !!  @{
 ! DH* TODO add intent information for all variables
-      subroutine sasasshal_run (im,ix,km,delt,delp,prslp,psp,phil,ql1,  &
+      subroutine sasas_shal_run (im,ix,km,delt,delp,prslp,psp,phil,ql1,  &
      &     ql2,q1,t1,u1,v1,rn,kbot,ktop,kcnv,islimsk,garea,             &
      &     dot,ncloud,hpbl,ud_mf,dt_mf,cnvw,cnvc)
 !    &     dot,ncloud,hpbl,ud_mf,dt_mf,cnvw,cnvc,me)
@@ -1494,15 +1494,15 @@ c
       enddo
 !!
       return
-      end subroutine sasasshal_run
+      end subroutine sasas_shal_run
 !> @}
 
 !> \brief Brief description of the subroutine
 !!
-!! \section arg_table_sasasshal_init Argument Table
+!! \section arg_table_sasas_shal_init Argument Table
 !!
-      subroutine sasasshal_finalize
-      end subroutine sasasshal_finalize
+      subroutine sasas_shal_finalize
+      end subroutine sasas_shal_finalize
 !> @}
 
       end module sasas_shal
@@ -1512,7 +1512,7 @@ c
 
 !> \brief Brief description of the subroutine
 !!
-!! \section arg_table_sasasshal_post_run Argument Table
+!! \section arg_table_sasas_shal_post_run Argument Table
 !! | local var name | longname                                                 | description                                                          | units   | rank | type                          |    kind   | intent | optional |
 !! |----------------|----------------------------------------------------------|----------------------------------------------------------------------|---------|------|-------------------------------|-----------|--------|----------|
 !! | frain          | dynamics_to_physics_timestep_ratio                       | ratio of dynamics timestep to physics timestep                       | none    |    0 | real                          | kind_phys | in     | F        |
@@ -1524,7 +1524,7 @@ c
 !! | Diag           | FV3-GFS_Diag_type                                        | Fortran DDT containing FV3-GFS fields targeted for diagnostic output | DDT     |    0 | GFS_diag_type                 |           | inout  | F        |
 !! | Tbd            | FV3-GFS_Tbd_type                                         | Fortran DDT containing FV3-GFS miscellaneous data                    | DDT     |    0 | GFS_tbd_type                  |           | inout  | F        |
 !!
-      subroutine sasasshal_post_run (frain, rain1, cnvc, cnvw, Model,   &
+      subroutine sasas_shal_post_run (frain, rain1, cnvc, cnvw, Model,   &
      &                               Grid, Diag, Tbd)
 
         use machine,               only: kind_phys
@@ -1561,20 +1561,20 @@ c
           Tbd%phy_f3d(:,:,num2) = cnvw(:,:)
         endif
 
-      end subroutine sasasshal_post_run
+      end subroutine sasas_shal_post_run
 
 !> \brief Brief description of the subroutine
 !!
-!! \section arg_table_sasasshal_post_init Argument Table
+!! \section arg_table_sasas_shal_post_init Argument Table
 !!
-      subroutine sasasshal_post_init ()
-      end subroutine sasasshal_post_init
+      subroutine sasas_shal_post_init ()
+      end subroutine sasas_shal_post_init
 
 !> \brief Brief description of the subroutine
 !!
-!! \section arg_table_sasasshal_post_finalize Argument Table
+!! \section arg_table_sasas_shal_post_finalize Argument Table
 !!
-      subroutine sasasshal_post_finalize ()
-      end subroutine sasasshal_post_finalize
+      subroutine sasas_shal_post_finalize ()
+      end subroutine sasas_shal_post_finalize
 
       end module sasas_shal_post

--- a/physics/precpd.f
+++ b/physics/precpd.f
@@ -2,7 +2,7 @@
 !! This file contains the subroutine that calculates precipitation
 !! processes from suspended cloud water/ice
 
-      module GFS_zhaocarr_precpd
+      module zhaocarr_precpd
       contains
 
 !> \ingroup Zhao-Carr
@@ -12,17 +12,17 @@
 !> \ingroup precip
 !! \brief Brief description of the subroutine
 !!
-!! \section arg_table_precpd_init  Argument Table
+!! \section arg_table_zhaocarr_precpd_init  Argument Table
 !!
-      subroutine precpd_init ()
-      end subroutine precpd_init
+      subroutine zhaocarr_precpd_init ()
+      end subroutine zhaocarr_precpd_init
 
 
 !> \ingroup precip
 !! \brief This subroutine computes the conversion from condensation to
 !! precipitation (snow or rain) or evaporation of rain.
 !!
-!! \section arg_table_precpd_run Argument Table
+!! \section arg_table_zhaocarr_precpd_run Argument Table
 !! | local var name | longname                                                      | description                                                       | units       | rank |  type   |   kind   | intent  | optional |
 !! |----------------|---------------------------------------------------------------|-------------------------------------------------------------------|-------------|------|---------|----------|---------|----------|
 !! |  im            | horizontal_loop_extent                                        | horizontal loop extent                                            | count       |  0   | integer |          |  in     |   F      |
@@ -88,8 +88,8 @@
 !! \section Zhao-Carr_precip_detailed Detailed Algorithm
 !! @{
 ! DH* TODO add intent() information for variables
-       subroutine precpd_run (im,ix,km,dt,del,prsl,q,cwm,t,rn,sr        &
-     &,                   rainp,u00k,psautco,prautco,evpco,wminco       &
+       subroutine zhaocarr_precpd_run (im,ix,km,dt,del,prsl,q,cwm,t,rn  &
+     &,                   sr,rainp,u00k,psautco,prautco,evpco,wminco    &
      &,                   wk1,lprnt,jpr)
 
 !
@@ -737,17 +737,17 @@
       enddo
 !
       return
-      end subroutine precpd_run
+      end subroutine zhaocarr_precpd_run
 !> @}
 
 !> \ingroup precip
 !! \brief Brief description of the subroutine
 !!
-!! \section arg_table_precpd_finalize  Argument Table
+!! \section arg_table_zhaocarr_precpd_finalize  Argument Table
 !!
-      subroutine precpd_finalize
-      end subroutine precpd_finalize
+      subroutine zhaocarr_precpd_finalize
+      end subroutine zhaocarr_precpd_finalize
 
 !> @}
 
-      end module GFS_zhaocarr_precpd
+      end module zhaocarr_precpd

--- a/physics/radlw_datatb.f
+++ b/physics/radlw_datatb.f
@@ -33,16 +33,16 @@
 !                                                                          !
 !    the 'radlw_rrtm3_main.f' contains:                                    !
 !                                                                          !
-!       'module_radlw_main'        -- main lw radiation transfer           !
+!       'rrtmg_lw'                 -- main lw radiation transfer           !
 !                                                                          !
-!    in the main module 'module_radlw_main' there are only two             !
+!    in the main module 'rrtmg_lw' there are only two                      !
 !    externally callable subroutines:                                      !
 !                                                                          !
 !       'lwrad'     -- main rrtm1 lw radiation routine                     !
 !       'rlwinit'   -- initialization routine                              !
 !                                                                          !
 !    all the lw radiation subprograms become contained subprograms         !
-!    in module 'module_radlw_main' and many of them are not directly       !
+!    in module 'rrtmg_lw' and many of them are not directly                !
 !    accessable from places outside the module.                            !
 !                                                                          !
 !    compilation sequence is:                                              !
@@ -61,7 +61,7 @@
 !!!!!                         end descriptions                         !!!!!
 !!!!!  ==============================================================  !!!!!
 
-!> \ingroup module_radlw_main
+!> \ingroup rrtmg_lw
 !> This module contains plank flux data.
 !========================================!
       module module_radlw_avplank        !
@@ -738,7 +738,7 @@
       end module module_radlw_avplank    !
 !========================================!
 
-!> \ingroup  module_radlw_main
+!> \ingroup  rrtmg_lw
 !> This module contains reference temperature and pressure.
 !!
 !!  - These pressures are chosen such that the ln of the first one
@@ -922,7 +922,7 @@
       end module module_radlw_ref        !
 !========================================!
 
-!> \ingroup module_radlw_main
+!> \ingroup rrtmg_lw
 !> This module contains cloud property coefficients.
 !========================================!
       module module_radlw_cldprlw        !
@@ -1584,7 +1584,7 @@
 !========================================!
 
 !> \defgroup module_radlw_kgbnn module_radlw_kgbnn
-!! \ingroup module_radlw_main
+!! \ingroup rrtmg_lw
 !! @{
 
 !*********************************************************************!

--- a/physics/radlw_main.f
+++ b/physics/radlw_main.f
@@ -29,9 +29,9 @@
 !                                                                          !
 !    the 'radlw_rrtm3_main.f' contains:                                    !
 !                                                                          !
-!       'module_radlw_main'        -- main lw radiation transfer           !
+!       'rrtmg_lw'        -- main lw radiation transfer                    !
 !                                                                          !
-!    in the main module 'module_radlw_main' there are only two             !
+!    in the main module 'rrtmg_lw' there are only two                      !
 !    externally callable subroutines:                                      !
 !                                                                          !
 !                                                                          !
@@ -52,7 +52,7 @@
 !           (none)                                                         !
 !                                                                          !
 !    all the lw radiation subprograms become contained subprograms         !
-!    in module 'module_radlw_main' and many of them are not directly       !
+!    in module 'rrtmg_lw' and many of them are not directly                !
 !    accessable from places outside the module.                            !
 !                                                                          !
 !    derived data type constructs used:                                    !
@@ -235,7 +235,7 @@
 !!!!!  ==============================================================  !!!!!
 
 
-!> \defgroup module_radlw_main module_radlw_main
+!> \defgroup rrtmg_lw rrtmg_lw
 !! \ingroup RRTMG
 !! This module includes NCEP's modifications of the rrtmg-lw radiation
 !! code from AER.
@@ -249,13 +249,13 @@
 !!  - module_radlw_cldprlw: cloud property coefficients
 !!  - module_radlw_kgbnn: absorption coeffients for 16 bands, where nn = 01-16
 !! - radlw_main.f, which contains:
-!!  - module_radlw_main, which is the main LW radiation transfer
+!!  - rrtmg_lw, which is the main LW radiation transfer
 !!    program and contains two externally callable subroutines:
 !!   - lwrad(): the main LW radiation routine
 !!   - rlwinit(): the initialization routine
 !!
 !! All the LW radiation subprograms become contained subprograms in
-!! module 'module_radlw_main' and many of them are not directly
+!! module 'rrtmg_lw' and many of them are not directly
 !! accessable from places outside the module.
 !!
 !!\author   Eli J. Mlawer, emlawer@aer.com
@@ -275,7 +275,7 @@
 !!  (http://www.rtweb.aer.com/)
 !! @{
 !========================================!
-      module module_radlw_main           !
+      module rrtmg_lw                    !
 !........................................!
 !
       use physparam,        only : ilwrate, ilwrgas, ilwcliq, ilwcice,  &
@@ -382,7 +382,7 @@
 
 !  ---  public accessable subprograms
 
-      public radlw_init, radlw_run, radlw_finalize, rlwinit
+      public rrtmg_lw_init, rrtmg_lw_run, rrtmg_lw_finalize, rlwinit
 
 
 ! ================
@@ -448,10 +448,10 @@
 !!\n                    upfxc - total sky upward flux
 !!\n                    dnfx0 - clear sky downward flux
 !!\n                    upfx0 - clear sky upward flux
-         subroutine radlw_init ()
-         end subroutine radlw_init
+         subroutine rrtmg_lw_init ()
+         end subroutine rrtmg_lw_init
 
-!! \section arg_table_radlw_run Argument Table
+!! \section arg_table_rrtmg_lw_run Argument Table
 !! | local var name  | longname                                                                                     | description                                                | units   | rank | type        |    kind   | intent | optional |
 !! |-----------------|----------------------------------------------------------------------------------------------|------------------------------------------------------------|---------|------|-------------|-----------|--------|----------|
 !! | plyr            | air_pressure_at_layer_for_radiation_in_hPa                                                   | air pressure layer                                         | hPa     |    2 | real        | kind_phys | in     | F        |
@@ -499,7 +499,7 @@
 !> \section gen_lwrad General Algorithm
 !> @{
 ! --------------------------------
-      subroutine radlw_run                                              &
+      subroutine rrtmg_lw_run                                           &
      &     ( plyr,plvl,tlyr,tlvl,qlyr,olyr,gasvmr_co2, gasvmr_n2o,      &   !  ---  inputs
      &       gasvmr_ch4, gasvmr_o2, gasvmr_co, gasvmr_cfc11,            &
      &       gasvmr_cfc12, gasvmr_cfc22, gasvmr_ccl4,                   &
@@ -796,7 +796,7 @@
       endif
 
 !     if ( lprnt ) then
-!       print *,'  In radlw, isubclw, ipsdlw0,ipseed =',                &
+!       print *,'  In rrtmg_lw, isubclw, ipsdlw0,ipseed =',             &
 !    &          isubclw, ipsdlw0, ipseed
 !     endif
 
@@ -1309,11 +1309,11 @@
       enddo  lab_do_iplon
 
 !...................................
-      end subroutine radlw_run
+      end subroutine rrtmg_lw_run
 !-----------------------------------
 !> @}
-      subroutine radlw_finalize ()
-      end subroutine radlw_finalize 
+      subroutine rrtmg_lw_finalize ()
+      end subroutine rrtmg_lw_finalize 
 
 
 
@@ -6722,7 +6722,7 @@
 
 !
 !........................................!
-      end module module_radlw_main       !
+      end module rrtmg_lw                !
 !========================================!
 
 !! @}

--- a/physics/radlw_param.f
+++ b/physics/radlw_param.f
@@ -1,7 +1,7 @@
 !>  \file radlw_param.f
 !!  This file contains LW band parameters setup.
 
-!> \ingroup  module_radlw_main
+!> \ingroup rrtmg_lw
 !! @{
 
 !!!!!  ==============================================================  !!!!!
@@ -31,9 +31,9 @@
 !                                                                          !
 !    the 'radlw_rrtm3_main.f' contains:                                    !
 !                                                                          !
-!       'module_radlw_main'        -- main lw radiation transfer           !
+!       'rrtmg_lw'        -- main lw radiation transfer                    !
 !                                                                          !
-!    in the main module 'module_radlw_main' there are only two             !
+!    in the main module 'rrtmg_lw' there are only two                      !
 !    externally callable subroutines:                                      !
 !                                                                          !
 !       'lwrad'     -- main rrtm3 lw radiation routine                     !

--- a/physics/radsw_datatb.f
+++ b/physics/radsw_datatb.f
@@ -34,16 +34,16 @@
 !                                                                          !
 !    the 'radsw_rrtm3_main.f' contains:                                    !
 !                                                                          !
-!       'module_radsw_main'        -- main sw radiation transfer           !
+!       'rrtmg_sw'                 -- main sw radiation transfer           !
 !                                                                          !
-!    in the main module 'module_radsw_main' there are only two             !
+!    in the main module 'rrtmg_sw' there are only two             !
 !    externally callable subroutines:                                      !
 !                                                                          !
 !       'swrad'      -- main rrtm3 sw radiation routine                    !
 !       'rswinit'    -- initialization routine                             !
 !                                                                          !
 !    all the sw radiation subprograms become contained subprograms         !
-!    in module 'module_radsw_main' and many of them are not directly       !
+!    in module 'rrtmg_sw' and many of them are not directly       !
 !    accessable from places outside the module.                            !
 !                                                                          !
 !    compilation sequence is:                                              !
@@ -63,7 +63,7 @@
 !!!!!  ==============================================================  !!!!!
 
 
-!> \ingroup module_radlw_main
+!> \ingroup rrtmg_lw
 !> This module contains the reference pressures (in logarithm form) at
 !! 59 vertical levels (TOA is omitted), and the mid-latitude summer
 !! (MLS) standard temperature profile for the 59 pressure layers that
@@ -136,7 +136,7 @@
       end module module_radsw_ref        !
 !========================================!
 
-!> \ingroup module_radlw_main
+!> \ingroup rrtmg_lw
 !> This module contains cloud radiative property coefficients.
 !!
 !! For liquid water clouds, cloud radiative property coefficients are
@@ -1924,7 +1924,7 @@
       end module module_radsw_cldprtb    !
 !========================================!
 
-!> \ingroup module_radlw_main
+!> \ingroup rrtmg_lw
 !> This module contains various indexes and coefficients for SW spectral
 !! bands, as well as the spectral distribution of solar flux. The values
 !! of spectral solar flux are derived based on a prescribed solar
@@ -2265,7 +2265,7 @@
 !========================================!
 
 !>\defgroup module_radsw_kgbnn module_radsw_kgbnn
-!>\ingroup  module_radsw_main
+!>\ingroup  rrtmg_sw
 !! @{
 
 !> This module sets up absorption coefficients for band 16: 2600-3250

--- a/physics/radsw_main.f
+++ b/physics/radsw_main.f
@@ -29,9 +29,9 @@
 !                                                                          !
 !   the 'radsw_rrtm3_main.f' contains:                                     !
 !                                                                          !
-!      'module_radsw_main'        -- main sw radiation transfer            !
+!      'rrtmg_sw'                 -- main sw radiation transfer            !
 !                                                                          !
-!   in the main module 'module_radsw_main' there are only two              !
+!   in the main module 'rrtmg_sw' there are only two                       !
 !   externally callable subroutines:                                       !
 !                                                                          !
 !      'swrad'      -- main sw radiation routine                           !
@@ -53,7 +53,7 @@
 !           (none)                                                         !
 !                                                                          !
 !   all the sw radiation subprograms become contained subprograms          !
-!   in module 'module_radsw_main' and many of them are not directly        !
+!   in module 'rrtmg_sw' and many of them are not directly                 !
 !   accessable from places outside the module.                             !
 !                                                                          !
 !    derived data type constructs used:                                    !
@@ -261,7 +261,7 @@
 
 
 !> \ingroup RRTMG
-!! \defgroup module_radsw_main module_radsw_main
+!! \defgroup rrtmg_sw rrtmg_sw
 !! This module includes NCEP's modifications of the rrtmg-sw radiation
 !! code from AER.
 !!
@@ -381,9 +381,9 @@
 !!  - mersenne_twister: program of random number generators using the
 !!    Mersenne-Twister algorithm
 !! - radsw_main.f, which contains:
-!!  - module_radsw_main: the main SW radiation computation programming
+!!  - rrtmg_sw: the main SW radiation computation programming
 !!    source codes, which contains two externally callable subroutines:
-!!   - swrad(): the main radiation routine
+!!   - rrtmg_sw_run(): the main radiation routine
 !!   - rswinit(): the initialization routine
 !!
 !!\author   Eli J. Mlawer, emlawer@aer.com
@@ -403,7 +403,7 @@
 !!  (http://www.rtweb.aer.com/)
 !! @{
 !========================================!
-      module module_radsw_main           !
+      module rrtmg_sw                    !
 !........................................!
 !
       use physparam,        only : iswrate, iswrgas, iswcliq, iswcice,  &
@@ -504,7 +504,7 @@
 
 !  ---  public accessable subprograms
 
-      public radsw_init, radsw_run, radsw_finalize, rswinit 
+      public rrtmg_sw_init, rrtmg_sw_run, rrtmg_sw_finalize, rswinit 
 
 
 ! =================
@@ -580,11 +580,11 @@
 !!\n                    visbm - downward surface uv+vis direct beam flux
 !!\n                    visdf - downward surface uv+vis diffused flux
 
-      subroutine radsw_init ()
-      end subroutine radsw_init
+      subroutine rrtmg_sw_init ()
+      end subroutine rrtmg_sw_init
 
 
-!! \section arg_table_radsw_run Argument Table
+!! \section arg_table_rrtmg_sw_run Argument Table
 !! | local var name  | longname                                                                                      | description                                                              | units   | rank | type        |    kind   | intent | optional |
 !! |-----------------|-----------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|---------|------|-------------|-----------|--------|----------|
 !! | plyr            | air_pressure_at_layer_for_radiation_in_hPa                                                    | air pressure layer                                                       | hPa     |    2 | real        | kind_phys | in     | F        |
@@ -637,7 +637,7 @@
 !> \section General_swrad General Algorithm
 !> @{
 !-----------------------------------
-      subroutine radsw_run                                                  &
+      subroutine rrtmg_sw_run                                           &
      &     ( plyr,plvl,tlyr,tlvl,qlyr,olyr,                             &
      &       gasvmr_co2,                                                &
      &       gasvmr_n2o, gasvmr_ch4,                                    &
@@ -1457,12 +1457,12 @@
 
       return
 !...................................
-      end subroutine radsw_run
+      end subroutine rrtmg_sw_run
 !-----------------------------------
 !> @}
 
-      subroutine radsw_finalize ()
-      end subroutine radsw_finalize
+      subroutine rrtmg_sw_finalize ()
+      end subroutine rrtmg_sw_finalize
 
 
 !> This subroutine initializes non-varying module variables, conversion
@@ -5476,6 +5476,6 @@
 
 !
 !........................................!
-      end module module_radsw_main       !
+      end module rrtmg_sw                !
 !========================================!
 !! @}

--- a/physics/radsw_param.f
+++ b/physics/radsw_param.f
@@ -1,7 +1,7 @@
 !>  \file radsw_param.f
 !!  This file contains SW band parameters setup.
 
-!>  \ingroup module_radsw_main
+!>  \ingroup rrtmg_sw
 !!  @{
 
 !!!!!  ==============================================================  !!!!!
@@ -31,16 +31,16 @@
 !                                                                          !
 !   the 'radsw_rrtm3_main.f' contains:                                     !
 !                                                                          !
-!      'module_radsw_main'        -- main sw radiation transfer            !
+!      'rrtmg_sw'                 -- main sw radiation transfer            !
 !                                                                          !
-!   in the main module 'module_radsw_main' there are only two              !
+!   in the main module 'rrtmg_sw' there are only two                       !
 !   externally callable subroutines:                                       !
 !                                                                          !
 !      'swrad'      -- main rrtm3 sw radiation routine                     !
 !      'rswinit'    -- initialization routine                              !
 !                                                                          !
 !   all the sw radiation subprograms become contained subprograms          !
-!   in module 'module_radsw_main' and many of them are not directly        !
+!   in module 'rrtmg_sw' and many of them are not directly                 !
 !   accessable from places outside the module.                             !
 !                                                                          !
 !   compilation sequence is:                                               !

--- a/physics/sfc_diag.f
+++ b/physics/sfc_diag.f
@@ -7,7 +7,7 @@
 !!  \section diagram Calling Hierarchy Diagram
 !!  \section intraphysics Intraphysics Communication
 
-      module surface_diagnose
+      module sfc_diag
       contains
   
       subroutine sfc_diag_init
@@ -110,5 +110,5 @@
       end subroutine sfc_diag_run
 !> @}
 
-      end module surface_diagnose
+      end module sfc_diag
 !> @}

--- a/physics/sfc_diff.f
+++ b/physics/sfc_diff.f
@@ -7,7 +7,7 @@
 !!  \section diagram Calling Hierarchy Diagram
 !!  \section intraphysics Intraphysics Communication
 
-      module surface_exchange_coefficients
+      module sfc_ex_coef
       contains
 
       subroutine sfc_ex_coef_init
@@ -367,5 +367,5 @@
       end subroutine sfc_ex_coef_run
 !> @}
 
-      end module surface_exchange_coefficients
+      end module sfc_ex_coef
 !> @}


### PR DESCRIPTION
This PR adjusts module names and scheme names for CCPP schemes to match each other, and removes the workaround in pgifix.py that allowed having different names.