### PR TITLE
Gmtb gfsphysics reduce op sfc_sice

### DIFF
--- a/makefile
+++ b/makefile
@@ -238,8 +238,14 @@ endif
 # this is the place to override default (implicit) compilation rules
 # and create specific (explicit) rules
 
+# this has no effect, because radiation_aerosols.o is in physics, not in gfsphys
 ./radiation_aerosols.o : ./gfsphys/radiation_aerosols.f
 	$(FC) $(CPPDEFS) $(FFLAGS) $(OTHER_FFLAGS) -xCORE-AVX-I -c $< -o $@
+
+# Reduce optimization for sfc_sice for bit-for-bit reproducibility
+FFLAGS_REDUCED_OPT=$(subst -O2,-O1,$(subst -xCORE-AVX2,-xCORE-AVX-I,$(FFLAGS)))
+./physics/sfc_sice.o : ./physics/sfc_sice.f
+	$(FC) $(CPPDEFS) $(FFLAGS_REDUCED_OPT) $(OTHER_FFLAGS) -c $< -o $@
 
 ./GFS_layer/GFS_diagnostics.o : ./GFS_layer/GFS_diagnostics.F90
 	$(FC) $(CPPDEFS) $(FFLAGS) $(OTHER_FFLAGS) -O0 -c $< -o $@


### PR DESCRIPTION
This PR modifies the compiler optimization flags for sfc_sice.f  when using the Intel compiler: instead of "-O2 -xCORE-AVX2", "-O1 -xCORE-AVX-I" are used.

The reason for this change is that with the standard optimization flags for PROD runs are used, the results of the model run change when certain arguments (e.g. fixed-length characters) are added to the argument list. The differences are small (1e-15) for each call to the scheme, but propagate quickly and modify the answers of the model run. The differences when adding arguments to the call to sfc_sice_run() are due to different optimization paths the Intel compiler can take, resulting in differences in the snetw and sneti calculation in lines 347-349, which are handed down to the internal subroutine ice3lay and subsequently modify the results of the intent(inout) variable gflux.

Note that this PR changes the results of the model run with the Intel compiler on Theia and Cheyenne. This needs to be noted for future integration with the trunk. New baseline runs are required after this PR is merged. The differences in runtime are negligible and several orders smaller than the variability from run to run on Theia.
