### PR TITLE
Fix floating point underflow in lwrad

### DIFF
--- a/physics/radlw_main.f
+++ b/physics/radlw_main.f
@@ -271,7 +271,7 @@
 !  ---  constant values
       real (kind=kind_phys), parameter :: eps     = 1.0e-6
       real (kind=kind_phys), parameter :: oneminus= 1.0-eps
-      real (kind=kind_phys), parameter :: cldmin  = 1.0e-80
+      real (kind=kind_phys), parameter :: cldmin  = tiny(cldmin)
       real (kind=kind_phys), parameter :: bpade   = 1.0/0.278  ! pade approx constant
       real (kind=kind_phys), parameter :: stpfac  = 296.0/1013.0
       real (kind=kind_phys), parameter :: wtdiff  = 0.5        ! weight for radiance to flux conversion


### PR DESCRIPTION
This PR changes the default value cldmin=1e-80 to tiny(cldmin) - the smallest value possible for the type/kind of cldmin to avoid floating point underflows (and corresponding warnings during compilation) for real*4.

Results are bit for bit identical on Theia (Intel, GNU, PGI with CCPP and IPD) and on my Macbook, tests on Cheyenne still to come.