### PR TITLE
Bugfix in radsw_param.f and radlw_param.f

### DIFF
--- a/physics/radlw_param.f
+++ b/physics/radlw_param.f
@@ -123,17 +123,17 @@
       integer, parameter :: NBDLW  = NBANDS
 
 ! \name Number of g-point in each band
-      integer  :: NG01, NG02, NG03, NG04, NG05, NG06, NG07, NG08,   
+      integer  :: NG01, NG02, NG03, NG04, NG05, NG06, NG07, NG08,       &
      &            NG09, NG10, NG11, NG12, NG13, NG14, NG15, NG16
-      parameter (NG01=10, NG02=12, NG03=16, NG04=14, NG05=16, NG06=08,
-     &           NG07=12, NG08=08, NG09=12, NG10=06, NG11=08, NG12=08,
+      parameter (NG01=10, NG02=12, NG03=16, NG04=14, NG05=16, NG06=08,  &
+     &           NG07=12, NG08=08, NG09=12, NG10=06, NG11=08, NG12=08,  &
      &           NG13=04, NG14=02, NG15=02, NG16=02)
 
 ! \name Begining index of each band
-      integer  :: NS01, NS02, NS03, NS04, NS05, NS06, NS07, NS08,      
+      integer  :: NS01, NS02, NS03, NS04, NS05, NS06, NS07, NS08,       &
      &            NS09, NS10, NS11, NS12, NS13, NS14, NS15, NS16
-      parameter (NS01=00, NS02=10, NS03=22, NS04=38, NS05=52, NS06=68, 
-     &           NS07=76, NS08=88, NS09=96, NS10=108, NS11=114,        
+      parameter (NS01=00, NS02=10, NS03=22, NS04=38, NS05=52, NS06=68,  &
+     &           NS07=76, NS08=88, NS09=96, NS10=108, NS11=114,         &
      &           NS12=122, NS13=130, NS14=134, NS15=136, NS16=138)
 
 ! band indices for each g-point

--- a/physics/radsw_param.f
+++ b/physics/radsw_param.f
@@ -144,23 +144,23 @@
       integer, parameter :: NBDSW  = NBANDS
 
 ! \name The actual number of g-point for bands 16-29
-      integer  :: NG16, NG17, NG18, NG19, NG20, NG21, NG22,
+      integer  :: NG16, NG17, NG18, NG19, NG20, NG21, NG22,             &
      &            NG23, NG24, NG25, NG26, NG27, NG28, NG29
-      parameter ( NG16=06, NG17=12, NG18=08, NG19=08, NG20=10,
-     &            NG21=10, NG22=02, NG23=10, NG24=08, NG25=06,
+      parameter ( NG16=06, NG17=12, NG18=08, NG19=08, NG20=10,          &
+     &            NG21=10, NG22=02, NG23=10, NG24=08, NG25=06,          &
      &            NG26=06, NG27=08, NG28=06, NG29=12)
 
       integer, dimension(NBLOW:NBHGH) :: NG
-      data  NG / NG16, NG17, NG18, NG19, NG20, NG21, NG22,
+      data  NG / NG16, NG17, NG18, NG19, NG20, NG21, NG22,              &
      &           NG23, NG24, NG25, NG26, NG27, NG28, NG29  /
 
 ! \name Accumulative starting index for bands 16-29
-      integer  :: NS16, NS17, NS18, NS19, NS20, NS21, NS22,
+      integer  :: NS16, NS17, NS18, NS19, NS20, NS21, NS22,             &
      &            NS23, NS24, NS25, NS26, NS27, NS28, NS29
-      parameter ( NS16=00,         NS17=NS16+NG16,  NS18=NS17+NG17,
-     &            NS19=NS18+NG18,  NS20=NS19+NG19,  NS21=NS20+NG20,
-     &            NS22=NS21+NG21,  NS23=NS22+NG22,  NS24=NS23+NG23,
-     &            NS25=NS24+NG24,  NS26=NS25+NG25,  NS27=NS26+NG26,
+      parameter ( NS16=00,         NS17=NS16+NG16,  NS18=NS17+NG17,     &
+     &            NS19=NS18+NG18,  NS20=NS19+NG19,  NS21=NS20+NG20,     &
+     &            NS22=NS21+NG21,  NS23=NS22+NG22,  NS24=NS23+NG23,     &
+     &            NS25=NS24+NG24,  NS26=NS25+NG25,  NS27=NS26+NG26,     &
      &            NS28=NS27+NG27,  NS29=NS28+NG28  )
 
 ! array contains values of NS16-NS29


### PR DESCRIPTION
This PR adds missing line continuation statements in physics/radlw_param.f and physics/radsw_param.f. The PGI compiler fails to compile these files without them.