### PR TITLE
Bugfix in GFS_PBL_generic.f90: incorrect array assignment

### DIFF
--- a/physics/GFS_PBL_generic.f90
+++ b/physics/GFS_PBL_generic.f90
@@ -136,7 +136,7 @@
               enddo
             enddo
             if (Model%ntoz > 0) then
-              Diag%dq3dt(:,:,5) = Diag%dq3dt(:,:,5) + dqdt(i,k,Model%ntoz) * Model%dtf
+              Diag%dq3dt(:,:,5) = Diag%dq3dt(:,:,5) + dqdt(:,:,Model%ntoz) * Model%dtf
             endif
           endif
 


### PR DESCRIPTION
In GFS_PBL_generic.f90, a supposed-to-be array assignment is incorrectly using indices from previous do loops.

Since GFS_PBL_generic.f90 is currently not used by NEMSfv3gfs, there is no impact on the results. For SCM, the results will be different of ntoz > 0.