### PR TITLE
update to deep convection interstitials

### DIFF
--- a/physics/GFS_DCNV_generic.f90
+++ b/physics/GFS_DCNV_generic.f90
@@ -11,53 +11,66 @@
       subroutine GFS_DCNV_generic_pre_finalize()
       end subroutine GFS_DCNV_generic_pre_finalize
 
-!> \section arg_table_GFS_DCNV_generic_pre_run Argument Table
-!! | local_name     | standard_name                                          | long_name                                                                 | units         | rank | type              |    kind   | intent | optional |
-!! |----------------|--------------------------------------------------------|---------------------------------------------------------------------------|---------------|------|-------------------|-----------|--------|----------|
-!! | Model          | FV3-GFS_Control_type                                   | Fortran DDT containing FV3-GFS model control parameters                   | DDT           |    0 | GFS_control_type  |           | in     | F        |
-!! | Stateout       | FV3-GFS_Stateout_type                                  | Fortran DDT containing FV3-GFS prognostic state to return to dycore       | DDT           |    0 | GFS_stateout_type |           | in     | F        |
-!! | Grid           | FV3-GFS_Grid_type                                      | Fortran DDT containing FV3-GFS grid and interpolation related data        | DDT           |    0 | GFS_grid_type     |           | in     | F        |
-!! | save_u         | x_wind_save                                            | x-wind before entering a physics scheme                                   | m s-1         |    2 | real              | kind_phys | inout  | F        |
-!! | save_v         | y_wind_save                                            | y-wind before entering a physics scheme                                   | m s-1         |    2 | real              | kind_phys | inout  | F        |
-!! | save_t         | air_temperature_save                                   | air temperature before entering a physics scheme                          | K             |    2 | real              | kind_phys | inout  | F        |
-!! | save_qv        | water_vapor_specific_humidity_save                     | water vapor specific humidity before entering a physics scheme            | kg kg-1       |    2 | real              | kind_phys | inout  | F        |
-!! | save_qcw       | cloud_condensed_water_mixing_ratio_save                | moist cloud condensed water mixing ratio before entering a physics scheme | kg kg-1       |    2 | real              | kind_phys | inout  | F        |
-!! | errmsg         | error_message                                          | error message for error handling in CCPP                                  | none          |    0 | character         | len=*     | out    | F        |
-!! | errflg         | error_flag                                             | error flag for error handling in CCPP                                     | flag          |    0 | integer           |           | out    | F        |
+!> \brief Interstitial scheme called prior to any deep convective scheme to save state variables for calculating tendencies after the deep convective scheme is executed
+!! \section arg_table_GFS_DCNV_generic_pre_run Argument Table
+!! | local_name      | standard_name                                          | long_name                                                                 | units   | rank | type      |    kind   | intent | optional |
+!! |-----------------|--------------------------------------------------------|---------------------------------------------------------------------------|---------|------|-----------|-----------|--------|----------|
+!! | im              | horizontal_loop_extent                                 | horizontal loop extent                                                    | count   |    0 | integer   |           | in     | F        |
+!! | levs            | vertical_dimension                                     | vertical layer dimension                                                  | count   |    0 | integer   |           | in     | F        |
+!! | ldiag3d         | flag_diagnostics_3D                                    | flag for 3d diagnostic fields                                             | flag    |    0 | logical   |           | in     | F        |
+!! | cnvgwd          | flag_convective_gravity_wave_drag                      | flag for conv gravity wave drag                                           | flag    |    0 | logical   |           | in     | F        |
+!! | lgocart         | flag_gocart                                            | flag for 3d diagnostic fields for gocart 1                                | flag    |    0 | logical   |           | in     | F        |
+!! | gu0             | x_wind_updated_by_physics                              | zonal wind updated by physics                                             | m s-1   |    2 | real      | kind_phys | in     | F        |
+!! | gv0             | y_wind_updated_by_physics                              | meridional wind updated by physics                                        | m s-1   |    2 | real      | kind_phys | in     | F        |
+!! | gt0             | air_temperature_updated_by_physics                     | temperature updated by physics                                            | K       |    2 | real      | kind_phys | in     | F        |
+!! | gq0_water_vapor | water_vapor_specific_humidity_updated_by_physics       | water vapor specific humidity updated by physics                          | kg kg-1 |    2 | real      | kind_phys | in     | F        |
+!! | save_u          | x_wind_save                                            | x-wind before entering a physics scheme                                   | m s-1   |    2 | real      | kind_phys | inout  | F        |
+!! | save_v          | y_wind_save                                            | y-wind before entering a physics scheme                                   | m s-1   |    2 | real      | kind_phys | inout  | F        |
+!! | save_t          | air_temperature_save                                   | air temperature before entering a physics scheme                          | K       |    2 | real      | kind_phys | inout  | F        |
+!! | save_qv         | water_vapor_specific_humidity_save                     | water vapor specific humidity before entering a physics scheme            | kg kg-1 |    2 | real      | kind_phys | inout  | F        |
+!! | errmsg          | error_message                                          | error message for error handling in CCPP                                  | none    |    0 | character | len=*     | out    | F        |
+!! | errflg          | error_flag                                             | error flag for error handling in CCPP                                     | flag    |    0 | integer   |           | out    | F        |
 !!
-    subroutine GFS_DCNV_generic_pre_run (Model, Stateout, Grid, save_u, save_v, save_t, save_qv, save_qcw, errmsg, errflg)
+    subroutine GFS_DCNV_generic_pre_run (im, levs, ldiag3d, cnvgwd, lgocart, gu0, gv0, gt0, gq0_water_vapor, &
+      save_u, save_v, save_t, save_qv, errmsg, errflg)
 
       use machine,               only: kind_phys
-      use GFS_typedefs,          only: GFS_control_type, GFS_stateout_type, GFS_grid_type
 
       implicit none
 
-      type(GFS_control_type),           intent(in) :: Model
-      type(GFS_stateout_type),          intent(in) :: Stateout
-      type(GFS_grid_type),              intent(in) :: Grid
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levs), intent(inout) :: save_u
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levs), intent(inout) :: save_v
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levs), intent(inout) :: save_t
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levs), intent(inout) :: save_qv
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levs), intent(inout) :: save_qcw
+      integer, intent(in) :: im, levs
+      logical, intent(in) :: ldiag3d, cnvgwd, lgocart
+      real(kind=kind_phys), dimension(im,levs), intent(in) :: gu0
+      real(kind=kind_phys), dimension(im,levs), intent(in) :: gv0
+      real(kind=kind_phys), dimension(im,levs), intent(in) :: gt0
+      real(kind=kind_phys), dimension(im,levs), intent(in) :: gq0_water_vapor
+      real(kind=kind_phys), dimension(im,levs), intent(inout) :: save_u
+      real(kind=kind_phys), dimension(im,levs), intent(inout) :: save_v
+      real(kind=kind_phys), dimension(im,levs), intent(inout) :: save_t
+      real(kind=kind_phys), dimension(im,levs), intent(inout) :: save_qv
       character(len=*), intent(out) :: errmsg
       integer, intent(out) :: errflg
+
+      integer :: i, k
 
       ! Initialize CCPP error handling variables
       errmsg = ''
       errflg = 0
 
-      if (Model%ldiag3d) then
-        save_t(:,:) = Stateout%gt0(:,:)
-        save_u(:,:) = Stateout%gu0(:,:)
-        save_v(:,:) = Stateout%gv0(:,:)
-      elseif (Model%cnvgwd) then
-        save_t(:,:) = Stateout%gt0(:,:)
+      if (ldiag3d) then
+        do k=1,levs
+          do i=1,im
+            save_t(i,k) = gt0(i,k)
+            save_u(i,k) = gu0(i,k)
+            save_v(i,k) = gv0(i,k)
+          enddo
+        enddo
+      elseif (cnvgwd) then
+        save_t(1:im,:) = gt0(1:im,:)
       endif   ! end if_ldiag3d/cnvgwd
 
-      if (Model%ldiag3d .or. Model%lgocart) then
-        save_qv(:,:) = Stateout%gq0(:,:,1)
-        save_qcw(:,:) = Stateout%gq0(:,:,3)
+      if (ldiag3d .or. lgocart) then
+        save_qv(1:im,:) = gq0_water_vapor(1:im,:)
       endif   ! end if_ldiag3d/lgocart
 
     end subroutine GFS_DCNV_generic_pre_run
@@ -75,88 +88,153 @@
     end subroutine GFS_DCNV_generic_post_finalize
 
 !> \section arg_table_GFS_DCNV_generic_post_run Argument Table
-!! | local_name     | standard_name                                             | long_name                                                                | units         | rank | type              |    kind   | intent | optional |
-!! |----------------|-----------------------------------------------------------|--------------------------------------------------------------------------|---------------|------|-------------------|-----------|--------|----------|
-!! | Grid           | FV3-GFS_Grid_type                                         | Fortran DDT containing FV3-GFS grid and interpolation related data       | DDT           |    0 | GFS_grid_type     |           | in     | F        |
-!! | Model          | FV3-GFS_Control_type                                      | Fortran DDT containing FV3-GFS model control parameters                  | DDT           |    0 | GFS_control_type  |           | in     | F        |
-!! | Stateout       | FV3-GFS_Stateout_type                                     | Fortran DDT containing FV3-GFS prognostic state to return to dycore      | DDT           |    0 | GFS_stateout_type |           | in     | F        |
-!! | frain          | dynamics_to_physics_timestep_ratio                        | ratio of dynamics timestep to physics timestep                           | none          |    0 | real              | kind_phys | in     | F        |
-!! | rain1          | lwe_thickness_of_deep_convective_precipitation_amount     | deep convective rainfall amount on physics timestep                      | m             |    1 | real              | kind_phys | in     | F        |
-!! | cld1d          | cloud_work_function                                       | cloud work function                                                      | m2 s-2        |    1 | real              | kind_phys | in     | F        |
-!! | save_u         | x_wind_save                                               | x-wind before entering a physics scheme                                  | m s-1         |    2 | real              | kind_phys | in     | F        |
-!! | save_v         | y_wind_save                                               | y-wind before entering a physics scheme                                  | m s-1         |    2 | real              | kind_phys | in     | F        |
-!! | save_t         | air_temperature_save                                      | air temperature before entering a physics scheme                         | K             |    2 | real              | kind_phys | in     | F        |
-!! | save_qv        | water_vapor_specific_humidity_save                        | water vapor specific humidity before entering a physics scheme           | kg kg-1       |    2 | real              | kind_phys | in     | F        |
-!! | ud_mf          | instantaneous_atmosphere_updraft_convective_mass_flux     | (updraft mass flux) * delt                                               | kg m-2        |    2 | real              | kind_phys | in     | F        |
-!! | dd_mf          | instantaneous_atmosphere_downdraft_convective_mass_flux   | (downdraft mass flux) * delt                                             | kg m-2        |    2 | real              | kind_phys | in     | F        |
-!! | dt_mf          | instantaneous_atmosphere_detrainment_convective_mass_flux | (detrainment mass flux) * delt                                           | kg m-2        |    2 | real              | kind_phys | in     | F        |
-!! | cnvw           | convective_cloud_water_mixing_ratio                       | moist convective cloud water mixing ratio                                | kg kg-1       |    2 | real              | kind_phys | in     | F        |
-!! | cnvc           | convective_cloud_cover                                    | convective cloud cover                                                   | frac          |    2 | real              | kind_phys | in     | F        |
-!! | Diag           | FV3-GFS_Diag_type                                         | Fortran DDT containing FV3-GFS fields targeted for diagnostic output     | DDT           |    0 | GFS_diag_type     |           | inout  | F        |
-!! | Tbd            | FV3-GFS_Tbd_type                                          | Fortran DDT containing FV3-GFS miscellaneous data                        | DDT           |    0 | GFS_tbd_type      |           | inout  | F        |
-!! | errmsg         | error_message                                             | error message for error handling in CCPP                                 | none          |    0 | character         | len=*     | out    | F        |
-!! | errflg         | error_flag                                                | error flag for error handling in CCPP                                    | flag          |    0 | integer           |           | out    | F        |
+!! | local_name      | standard_name                                                                               | long_name                                                            | units         | rank | type              |    kind   | intent | optional |
+!! |-----------------|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------|---------------|------|-------------------|-----------|--------|----------|
+!! | im              | horizontal_loop_extent                                                                      | horizontal loop extent                                               | count         |    0 | integer           |           | in     | F        |
+!! | levs            | vertical_dimension                                                                          | vertical layer dimension                                             | count         |    0 | integer           |           | in     | F        |
+!! | lssav           | flag_diagnostics                                                                            | logical flag for storing diagnostics                                 | flag          |    0 | logical           |           | in     | F        |
+!! | ldiag3d         | flag_diagnostics_3D                                                                         | flag for 3d diagnostic fields                                        | flag          |    0 | logical           |           | in     | F        |
+!! | lgocart         | flag_gocart                                                                                 | flag for 3d diagnostic fields for gocart 1                           | flag          |    0 | logical           |           | in     | F        |
+!! | frain           | dynamics_to_physics_timestep_ratio                                                          | ratio of dynamics timestep to physics timestep                       | none          |    0 | real              | kind_phys | in     | F        |
+!! | rain1           | lwe_thickness_of_deep_convective_precipitation_amount                                       | deep convective rainfall amount on physics timestep                  | m             |    1 | real              | kind_phys | in     | F        |
+!! | dtf             | time_step_for_dynamics                                                                      | dynamics timestep                                                    | s             |    0 | real              | kind_phys | in     | F        |
+!! | cld1d           | cloud_work_function                                                                         | cloud work function                                                  | m2 s-2        |    1 | real              | kind_phys | in     | F        |
+!! | save_u          | x_wind_save                                                                                 | x-wind before entering a physics scheme                              | m s-1         |    2 | real              | kind_phys | in     | F        |
+!! | save_v          | y_wind_save                                                                                 | y-wind before entering a physics scheme                              | m s-1         |    2 | real              | kind_phys | in     | F        |
+!! | save_t          | air_temperature_save                                                                        | air temperature before entering a physics scheme                     | K             |    2 | real              | kind_phys | in     | F        |
+!! | save_qv         | water_vapor_specific_humidity_save                                                          | water vapor specific humidity before entering a physics scheme       | kg kg-1       |    2 | real              | kind_phys | in     | F        |
+!! | gu0             | x_wind_updated_by_physics                                                                   | zonal wind updated by physics                                        | m s-1         |    2 | real              | kind_phys | in     | F        |
+!! | gv0             | y_wind_updated_by_physics                                                                   | meridional wind updated by physics                                   | m s-1         |    2 | real              | kind_phys | in     | F        |
+!! | gt0             | air_temperature_updated_by_physics                                                          | temperature updated by physics                                       | K             |    2 | real              | kind_phys | in     | F        |
+!! | gq0_water_vapor | water_vapor_specific_humidity_updated_by_physics                                            | water vapor specific humidity updated by physics                     | kg kg-1       |    2 | real              | kind_phys | in     | F        |
+!! | ud_mf           | instantaneous_atmosphere_updraft_convective_mass_flux                                       | (updraft mass flux) * delt                                           | kg m-2        |    2 | real              | kind_phys | in     | F        |
+!! | dd_mf           | instantaneous_atmosphere_downdraft_convective_mass_flux                                     | (downdraft mass flux) * delt                                         | kg m-2        |    2 | real              | kind_phys | in     | F        |
+!! | dt_mf           | instantaneous_atmosphere_detrainment_convective_mass_flux                                   | (detrainment mass flux) * delt                                       | kg m-2        |    2 | real              | kind_phys | in     | F        |
+!! | con_g           | gravitational_acceleration                                                                  | gravitational acceleration                                           | m s-2         |    0 | real              | kind_phys | in     | F        |
+!! | clw_ice         | cloud_ice_mixing_ratio                                                                      | moist cloud ice mixing ratio                                         | kg kg-1       |    2 | real              | kind_phys | in     | F        |
+!! | clw_liquid      | cloud_liquid_water_mixing_ratio                                                             | moist cloud water mixing ratio                                       | kg kg-1       |    2 | real              | kind_phys | in     | F        |
+!! | npdf3d          | number_of_3d_arrays_associated_with_pdf-based_clouds                                        | number of 3d arrays associated with pdf based clouds/mp              | count         |    0 | integer           |           | in     | F        |
+!! | num_p3d         | array_dimension_of_3d_arrays_for_microphysics                                               | number of 3D arrays needed for microphysics                          | count         |    0 | integer           |           | in     | F        |
+!! | ncnvcld3d       | number_of_convective_3d_cloud_fields                                                        | number of convective 3d clouds fields                                | count         |    0 | integer           |           | in     | F        |
+!! | rainc           | lwe_thickness_of_convective_precipitation_amount_on_dynamics_timestep                       | convective rain at this time step                                    | m             |    1 | real              | kind_phys | inout  | F        |
+!! | cldwrk          | cumulative_cloud_work_function                                                              | cumulative cloud work function (valid only with sas)                 | m2 s-1        |    1 | real              | kind_phys | inout  | F        |
+!! | cnvprcp         | cumulative_lwe_thickness_of_convective_precipitation_amount                                 | cumulative convective precipitation                                  | m             |    1 | real              | kind_phys | inout  | F        |
+!! | cnvprcpb        | cumulative_lwe_thickness_of_convective_precipitation_amount_in_bucket                       | cumulative convective precipitation in bucket                        | m             |    1 | real              | kind_phys | inout  | F        |
+!! | dt3dt           | cumulative_change_in_temperature_due_to_deep_convection                                     | cumulative change in temperature due to deep conv.                   | K             |    2 | real              | kind_phys | inout  | F        |
+!! | dq3dt           | cumulative_change_in_water_vapor_specific_humidity_due_to_deep_convection                   | cumulative change in water vapor specific humidity due to deep conv. | kg kg-1       |    2 | real              | kind_phys | inout  | F        |
+!! | du3dt           | cumulative_change_in_x_wind_due_to_deep_convection                                          | cumulative change in x wind due to deep convection                   | m s-1         |    2 | real              | kind_phys | inout  | F        |
+!! | dv3dt           | cumulative_change_in_y_wind_due_to_deep_convection                                          | cumulative change in y wind due to deep convection                   | m s-1         |    2 | real              | kind_phys | inout  | F        |
+!! | upd_mf          | cumulative_atmosphere_updraft_convective_mass_flux                                          | cumulative updraft mass flux                                         | Pa            |    2 | real              | kind_phys | inout  | F        |
+!! | dwn_mf          | cumulative_atmosphere_downdraft_convective_mass_flux                                        | cumulative downdraft mass flux                                       | Pa            |    2 | real              | kind_phys | inout  | F        |
+!! | det_mf          | cumulative_atmosphere_detrainment_convective_mass_flux                                      | cumulative detrainment mass flux                                     | Pa            |    2 | real              | kind_phys | inout  | F        |
+!! | dqdti           | instantaneous_water_vapor_specific_humidity_tendency_due_to_convection_on_dynamics_timestep | instantaneous total moisture tendency                                | kg kg-1 s-1   |    2 | real              | kind_phys | inout  | F        |
+!! | cnvqci          | instantaneous_deep_convective_cloud_condensate_mixing_ratio_on_dynamics_time_step           | instantaneous total convective condensate mixing ratio               | kg kg-1       |    2 | real              | kind_phys | inout  | F        |
+!! | upd_mfi         | instantaneous_atmosphere_updraft_convective_mass_flux_on_dynamics_timestep                  | (updraft mass flux) * delt                                           | kg m-2        |    2 | real              | kind_phys | inout  | F        |
+!! | dwn_mfi         | instantaneous_atmosphere_downdraft_convective_mass_flux_on_dynamics_timestep                | (downdraft mass flux) * delt                                         | kg m-2        |    2 | real              | kind_phys | inout  | F        |
+!! | det_mfi         | instantaneous_atmosphere_detrainment_convective_mass_flux_on_dynamics_timestep              | (detrainment mass flux) * delt                                       | kg m-2        |    2 | real              | kind_phys | inout  | F        |
+!! | cnvw            | convective_cloud_water_mixing_ratio                                                         | moist convective cloud water mixing ratio                            | kg kg-1       |    2 | real              | kind_phys | inout  | F        |
+!! | cnvc            | convective_cloud_cover                                                                      | convective cloud cover                                               | frac          |    2 | real              | kind_phys | inout  | F        |
+!! | cnvw_phy_f3d    | convective_cloud_water_mixing_ratio_in_phy_f3d                                              | convective cloud water mixing ratio in the phy_f3d array             | kg kg-1       |    2 | real              | kind_phys | inout  | F        |
+!! | cnvc_phy_f3d    | convective_cloud_cover_in_phy_f3d                                                           | convective cloud cover in the phy_f3d array                          | frac          |    2 | real              | kind_phys | inout  | F        |
+!! | errmsg          | error_message                                                                               | error message for error handling in CCPP                             | none          |    0 | character         | len=*     | out    | F        |
+!! | errflg          | error_flag                                                                                  | error flag for error handling in CCPP                                | flag          |    0 | integer           |           | out    | F        |
 !!
-    subroutine GFS_DCNV_generic_post_run (Grid, Model, Stateout, frain, rain1, cld1d, save_u, save_v, save_t, save_qv, &
-                                                               ud_mf, dd_mf, dt_mf, cnvw, cnvc, Diag, Tbd, errmsg, errflg)
+    subroutine GFS_DCNV_generic_post_run (im, levs, lssav, ldiag3d, lgocart, frain, rain1, dtf, cld1d, &
+      save_u, save_v, save_t, save_qv, gu0, gv0, gt0, gq0_water_vapor, ud_mf, dd_mf, dt_mf, con_g, &
+      clw_ice, clw_liquid, npdf3d, num_p3d, ncnvcld3d, &
+      rainc, cldwrk, cnvprcp, cnvprcpb, dt3dt, dq3dt, du3dt, dv3dt, upd_mf, dwn_mf, det_mf, dqdti, &
+      cnvqci, upd_mfi, dwn_mfi, det_mfi, cnvw, cnvc, cnvw_phy_f3d, cnvc_phy_f3d, errmsg, errflg)
 
       use machine,               only: kind_phys
-      use GFS_typedefs,          only: GFS_grid_type, GFS_control_type, GFS_stateout_type, GFS_diag_type, GFS_tbd_type
-      use physcons,              only: con_g
 
       implicit none
 
-      type(GFS_grid_type),            intent(in) :: Grid
-      type(GFS_control_type),         intent(in) :: Model
-      type(GFS_stateout_type),        intent(in) :: Stateout
-      type(GFS_diag_type),         intent(inout) :: Diag
-      type(GFS_tbd_type),          intent(inout) :: Tbd
+      integer, intent(in) :: im, levs
+      logical, intent(in) :: lssav, ldiag3d, lgocart
 
-      real(kind=kind_phys), intent(in) :: frain
-      real(kind=kind_phys), dimension(size(Grid%xlon,1)), intent(in) :: rain1, cld1d
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levs), intent(in) :: save_u, save_v, save_t, save_qv
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levs), intent(in) :: ud_mf, dd_mf, dt_mf
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levs), intent(in) :: cnvw, cnvc
+      real(kind=kind_phys), intent(in) :: frain, dtf
+      real(kind=kind_phys), dimension(im), intent(in) :: rain1, cld1d
+      real(kind=kind_phys), dimension(im,levs), intent(in) :: save_u, save_v, save_t, save_qv
+      real(kind=kind_phys), dimension(im,levs), intent(in) :: gu0, gv0, gt0, gq0_water_vapor
+      real(kind=kind_phys), dimension(im,levs), intent(in) :: ud_mf, dd_mf, dt_mf
+      real(kind=kind_phys), intent(in) :: con_g
+      real(kind=kind_phys), dimension(im,levs), intent(in) :: clw_ice, clw_liquid
+      integer, intent(in) :: npdf3d, num_p3d, ncnvcld3d
+
+      real(kind=kind_phys), dimension(im), intent(inout) :: rainc, cldwrk, cnvprcp, cnvprcpb
+      real(kind=kind_phys), dimension(im, levs), intent(inout) :: dt3dt, dq3dt, du3dt, dv3dt
+      real(kind=kind_phys), dimension(im, levs), intent(inout) :: upd_mf, dwn_mf, det_mf
+      real(kind=kind_phys), dimension(im, levs), intent(inout) :: dqdti, cnvqci, upd_mfi, dwn_mfi, det_mfi
+      real(kind=kind_phys), dimension(im,levs), intent(inout) :: cnvw, cnvc, cnvw_phy_f3d, cnvc_phy_f3d
 
       character(len=*), intent(out) :: errmsg
       integer, intent(out) :: errflg
 
-      integer :: i, num2, num3
+      integer :: i, k
 
       ! Initialize CCPP error handling variables
       errmsg = ''
       errflg = 0
 
-      do i = 1, size(Grid%xlon,1)
-        Diag%rainc(:) = frain * rain1(:)
+      do i=1,im
+        rainc(i) = frain * rain1(i)
       enddo
+!
+      if (lssav) then
+        do i=1,im
+          cldwrk (i)  = cldwrk (i)  + cld1d(i) * dtf
+          cnvprcp(i)  = cnvprcp(i)  + rainc(i)
+          cnvprcpb(i) = cnvprcpb(i) + rainc(i)
+        enddo
 
-      if (Model%lssav) then
-        Diag%cldwrk (:) = Diag%cldwrk (:) + cld1d(:) * Model%dtf
-        Diag%cnvprcp(:) = Diag%cnvprcp(:) + Diag%rainc(:)
+        if (ldiag3d) then
+          do k=1,levs
+            do i=1,im
+              dt3dt(i,k) = dt3dt(i,k) + (gt0(i,k)-save_t(i,k)) * frain
+              dq3dt(i,k) = dq3dt(i,k) + (gq0_water_vapor(i,k)-save_qv(i,k)) * frain
+              du3dt(i,k) = du3dt(i,k) + (gu0(i,k)-save_u(i,k)) * frain
+              dv3dt(i,k) = dv3dt(i,k) + (gv0(i,k)-save_v(i,k)) * frain
 
-        if (Model%ldiag3d) then
-          Diag%dt3dt(:,:,4) = Diag%dt3dt(:,:,4) + (Stateout%gt0(:,:)-save_t(:,:)) * frain
-          Diag%dq3dt(:,:,2) = Diag%dq3dt(:,:,2) + (Stateout%gq0(:,:,1)-save_qv(:,:)) * frain
-          Diag%du3dt(:,:,3) = Diag%du3dt(:,:,3) + (Stateout%gu0(:,:)-save_u(:,:)) * frain
-          Diag%dv3dt(:,:,3) = Diag%dv3dt(:,:,3) + (Stateout%gv0(:,:)-save_v(:,:)) * frain
-
-          Diag%upd_mf(:,:)  = Diag%upd_mf(:,:)  + ud_mf(:,:) * (con_g*frain)
-          Diag%dwn_mf(:,:)  = Diag%dwn_mf(:,:)  + dd_mf(:,:) * (con_g*frain)
-          Diag%det_mf(:,:)  = Diag%det_mf(:,:)  + dt_mf(:,:) * (con_g*frain)
+              upd_mf(i,k)  = upd_mf(i,k)  + ud_mf(i,k) * (con_g*frain)
+              dwn_mf(i,k)  = dwn_mf(i,k)  + dd_mf(i,k) * (con_g*frain)
+              det_mf(i,k)  = det_mf(i,k)  + dt_mf(i,k) * (con_g*frain)
+            enddo
+          enddo
         endif ! if (ldiag3d)
 
       endif   ! end if_lssav
-
-      if ((Model%npdf3d == 3) .and. (Model%num_p3d == 4)) then
-        num2 = Model%num_p3d + 2
-        num3 = num2 + 1
-        Tbd%phy_f3d(:,:,num2) = cnvw(:,:)
-        Tbd%phy_f3d(:,:,num3) = cnvc(:,:)
-      elseif ((Model%npdf3d == 0) .and. (Model%ncnvcld3d == 1)) then
-        num2 = Model%num_p3d + 1
-        Tbd%phy_f3d(:,:,num2) = cnvw(:,:)
+!
+!       update dqdt_v to include moisture tendency due to deep convection
+      if (lgocart) then
+        do k=1,levs
+          do i=1,im
+            dqdti  (i,k) = (gq0_water_vapor(i,k)  - save_qv(i,k)) * frain
+            upd_mfi(i,k) = upd_mfi(i,k) + ud_mf(i,k)   * frain
+            dwn_mfi(i,k) = dwn_mfi(i,k) + dd_mf(i,k)   * frain
+            det_mfi(i,k) = det_mfi(i,k) + dt_mf(i,k)   * frain
+            cnvqci (i,k) = cnvqci (i,k) + (clw_ice(i,k)+clw_liquid(i,k))*frain
+          enddo
+        enddo
+      endif ! if (lgocart)
+!
+      if ((npdf3d == 3) .and. (num_p3d == 4)) then
+        do k=1,levs
+          do i=1,im
+            cnvw_phy_f3d(i,k) = cnvw(i,k)
+            cnvc_phy_f3d(i,k) = cnvc(i,k)
+            cnvw(i,k)             = 0.0
+            cnvc(i,k)             = 0.0
+          enddo
+        enddo
+      elseif ((npdf3d == 0) .and. (ncnvcld3d == 1)) then
+        do k=1,levs
+          do i=1,im
+            cnvw_phy_f3d(i,k) = cnvw(i,k)
+            cnvw(i,k)             = 0.0
+          enddo
+        enddo
       endif
+
 
     end subroutine GFS_DCNV_generic_post_run
 

--- a/physics/GFS_DCNV_generic.f90
+++ b/physics/GFS_DCNV_generic.f90
@@ -202,9 +202,9 @@
           enddo
         endif ! if (ldiag3d)
 
-      endif   ! end if_lssav
-!
-!       update dqdt_v to include moisture tendency due to deep convection
+endif   ! end if_lssav
+
+      !update dqdt_v to include moisture tendency due to deep convection
       if (lgocart) then
         do k=1,levs
           do i=1,im

--- a/physics/samfdeepcnv.f
+++ b/physics/samfdeepcnv.f
@@ -142,8 +142,8 @@
 !! | ud_mf          | instantaneous_atmosphere_updraft_convective_mass_flux          | (updraft mass flux) * delt                                                                               | kg m-2  |    2 | real      | kind_phys | out    | F        |
 !! | dd_mf          | instantaneous_atmosphere_downdraft_convective_mass_flux        | (downdraft mass flux) * delt                                                                             | kg m-2  |    2 | real      | kind_phys | out    | F        |
 !! | dt_mf          | instantaneous_atmosphere_detrainment_convective_mass_flux      | (detrainment mass flux) * delt                                                                           | kg m-2  |    2 | real      | kind_phys | out    | F        |
-!! | cnvw           | convective_cloud_water_mixing_ratio                            | moist convective cloud water mixing ratio                                                                | kg kg-1 |    2 | real      | kind_phys | out    | F        |
-!! | cnvc           | convective_cloud_cover                                         | convective cloud cover                                                                                   | frac    |    2 | real      | kind_phys | out    | F        |
+!! | cnvw           | convective_cloud_water_mixing_ratio                            | moist convective cloud water mixing ratio                                                                | kg kg-1 |    2 | real      | kind_phys | inout  | F        |
+!! | cnvc           | convective_cloud_cover                                         | convective cloud cover                                                                                   | frac    |    2 | real      | kind_phys | inout  | F        |
 !! | clam           | entrainment_rate_coefficient_deep_convection                   | entrainment rate coefficient for deep conv.                                                              | none    |    0 | real      | kind_phys | in     | F        |
 !! | c0s            | rain_conversion_parameter_deep_convection                      | convective rain conversion parameter for deep conv.                                                      | m-1     |    0 | real      | kind_phys | in     | F        |
 !! | c1             | detrainment_conversion_parameter_deep_convection               | convective detrainment conversion parameter for deep conv.                                               | m-1     |    0 | real      | kind_phys | in     | F        |
@@ -196,11 +196,12 @@
 
       integer, intent(inout)  :: kcnv(im)
       real(kind=kind_phys), intent(inout) ::   qtr(ix,km,ntr+2),
-     &   q1(ix,km), t1(ix,km),   u1(ix,km), v1(ix,km)
+     &   q1(ix,km), t1(ix,km),   u1(ix,km), v1(ix,km),
+     &   cnvw(ix,km),  cnvc(ix,km)
 
       integer, intent(out) :: kbot(im), ktop(im)
       real(kind=kind_phys), intent(out) :: cldwrk(im),
-     &   rn(im),      cnvw(ix,km),  cnvc(ix,km),
+     &   rn(im),
      &   ud_mf(im,km),dd_mf(im,km), dt_mf(im,km)
 
       real(kind=kind_phys), intent(in) :: clam,    c0s,     c1,


### PR DESCRIPTION
I updated GFS_DCNV_generic_pre/post to no longer use GFS DDTs since their use limited other models in their data organization. This required passing in many new variables that had previously been part of DDTs. Some corresponding new standard names were added in GFS_typedefs in FV3 and in gmtb_scm_type_defs in SCM. In addition, there was a code stanza added to not break gocart functionality (even though this is not operational) since it would have needed to have been done at some point anyway! Code related to determining array indices for the 'phy_f3d' variable was removed since it was already included in a subroutine within GFS_typedefs during initialization. Instead, the correct portion of phy_f3d is passed in to the routine (using the previously calculated value of ncnvw).