### PR TITLE
NEMSfv3gfs standalone CCPP runs

### DIFF
--- a/physics/GFS_MP_generic.F90
+++ b/physics/GFS_MP_generic.F90
@@ -24,27 +24,23 @@
 !! | nncl           | number_of_tracers_for_cloud_condensate                 | number of tracers for cloud condensate                                    | count       |    0 | integer   |           | in     | F        |
 !! | ntrac          | number_of_tracers                                      | number of tracers                                                         | count       |    0 | integer   |           | in     | F        |
 !! | gt0            | air_temperature_updated_by_physics                     | temperature updated by physics                                            | K           |    2 | real      | kind_phys | in     | F        |
-!! | gq0_water_vapor| water_vapor_specific_humidity_updated_by_physics       | water vapor specific humidity updated by physics                          | kg kg-1     |    2 | real      | kind_phys | in     | F        |
 !! | gq0            | tracer_concentration_updated_by_physics                | tracer concentration updated by physics                                   | kg kg-1     |    3 | real      | kind_phys | in     | F        |
 !! | save_t         | air_temperature_save                                   | air temperature before entering a physics scheme                          | K           |    2 | real      | kind_phys | inout  | F        |
-!! | save_qv        | water_vapor_specific_humidity_save                     | water vapor specific humidity before entering a physics scheme            | kg kg-1     |    2 | real      | kind_phys | inout  | F        |
 !! | save_q         | tracer_concentration_save                              | tracer concentration before entering a physics scheme                     | kg kg-1     |    3 | real      | kind_phys | inout  | F        |
 !! | errmsg         | ccpp_error_message                                     | error message for error handling in CCPP                                  | none        |    0 | character | len=*     | out    | F        |
 !! | errflg         | ccpp_error_flag                                        | error flag for error handling in CCPP                                     | flag        |    0 | integer   |           | out    | F        |
 !!
-      subroutine GFS_MP_generic_pre_run(im, levs, ldiag3d, do_aw, ntcw, nncl, ntrac, gt0, gq0_water_vapor, gq0, &
-        save_t, save_qv, save_q, errmsg, errflg)
+      subroutine GFS_MP_generic_pre_run(im, levs, ldiag3d, do_aw, ntcw, nncl, ntrac, gt0, gq0, save_t, save_q, errmsg, errflg)
 !
       use machine,               only: kind_phys
 
       implicit none
-
       integer,                                          intent(in) :: im, levs, ntcw, nncl, ntrac
       logical,                                          intent(in) :: ldiag3d, do_aw
-      real(kind=kind_phys), dimension(im, levs),        intent(in) :: gt0, gq0_water_vapor
+      real(kind=kind_phys), dimension(im, levs),        intent(in) :: gt0
       real(kind=kind_phys), dimension(im, levs, ntrac), intent(in) :: gq0
 
-      real(kind=kind_phys), dimension(im, levs),        intent(inout) :: save_t, save_qv
+      real(kind=kind_phys), dimension(im, levs),        intent(inout) :: save_t
       real(kind=kind_phys), dimension(im, levs, ntrac), intent(inout) :: save_q
 
       character(len=*), intent(out) :: errmsg
@@ -59,8 +55,8 @@
       if (ldiag3d .or. do_aw) then
         do k=1,levs
           do i=1,im
-            save_t(i,k)   = gt0(i,k)
-            save_qv(i,k)  = gq0_water_vapor(i,k)
+            save_t(i,k) = gt0(i,k)
+            save_q(1:im,:,1) = gq0(1:im,:,1)
           enddo
         enddo
         do n=ntcw,ntcw+nncl-1
@@ -123,7 +119,6 @@
 !! | xlon             | longitude                                                               | longitude                                                               | radians     |    1 | real       | kind_phys | in     | F        |
 !! | gt0              | air_temperature_updated_by_physics                                      | temperature updated by physics                                          | K           |    2 | real       | kind_phys | in     | F        |
 !! | gq0              | tracer_concentration_updated_by_physics                                 | tracer concentration updated by physics                                 | kg kg-1     |    3 | real       | kind_phys | in     | F        |
-!! | gq0_water_vapor  | water_vapor_specific_humidity_updated_by_physics                        | water vapor specific humidity updated by physics                        | kg kg-1     |    2 | real       | kind_phys | in     | F        |
 !! | prsl             | air_pressure                                                            | layer mean pressure                                                     | Pa          |    2 | real       | kind_phys | in     | F        |
 !! | prsi             | air_pressure_at_interface                                               | pressure at layer interface                                             | Pa          |    2 | real       | kind_phys | in     | F        |
 !! | phii             | geopotential_at_interface                                               | geopotential at model layer interfaces                                  | m2 s-2      |    2 | real       | kind_phys | in     | F        |
@@ -168,11 +163,11 @@
 !!
 !> \section gfs_mp_gen GFS MP Generic Post General Algorithm
 !! @{
-      subroutine GFS_MP_generic_post_run(im, ix, levs, kdt, nrcm, ncld, nncl, ntcw, ntrac, imp_physics, imp_physics_gfdl,       &
-        cal_pre, lssav, ldiag3d, cplflx, cplchm, con_g, dtf, frain, rainc, rain1, rann, xlat, xlon, gt0, gq0, gq0_water_vapor,  &
-        prsl, prsi, phii, tsfc, ice, snow, graupel, save_t, save_qv, ice0, snow0, graupel0, del,                                &
-        rain, domr_diag, domzr_diag, domip_diag, doms_diag, tprcp, srflag, totprcp, totice, totsnw,                             &
-        totgrp, totprcpb, toticeb, totsnwb, totgrpb, dt3dt, dq3dt, rain_cpl, rainc_cpl, snow_cpl, pwat,                         &
+      subroutine GFS_MP_generic_post_run(im, ix, levs, kdt, nrcm, ncld, nncl, ntcw, ntrac, imp_physics, imp_physics_gfdl, &
+        cal_pre, lssav, ldiag3d, cplflx, cplchm, con_g, dtf, frain, rainc, rain1, rann, xlat, xlon, gt0, gq0,             &
+        prsl, prsi, phii, tsfc, ice, snow, graupel, save_t, save_qv, ice0, snow0, graupel0, del,                          &
+        rain, domr_diag, domzr_diag, domip_diag, doms_diag, tprcp, srflag, totprcp, totice, totsnw,                       &
+        totgrp, totprcpb, toticeb, totsnwb, totgrpb, dt3dt, dq3dt, rain_cpl, rainc_cpl, snow_cpl, pwat,                   &
         do_sppt, dtdtr, dtdtc, drain_cpl, dsnow_cpl, errmsg, errflg)
 !
       use machine,               only: kind_phys
@@ -187,7 +182,7 @@
       real(kind=kind_phys), dimension(im),            intent(inout) :: ice, snow, graupel
       real(kind=kind_phys), dimension(im),            intent(in)    :: ice0, snow0, graupel0
       real(kind=kind_phys), dimension(ix,nrcm),       intent(in)    :: rann
-      real(kind=kind_phys), dimension(im,levs),       intent(in)    :: gt0, gq0_water_vapor, prsl, save_t, save_qv, del
+      real(kind=kind_phys), dimension(im,levs),       intent(in)    :: gt0, prsl, save_t, save_qv, del
       real(kind=kind_phys), dimension(im,levs+1),     intent(in)    :: prsi, phii
       real(kind=kind_phys), dimension(im,levs,ntrac), intent(in)    :: gq0
 
@@ -243,7 +238,7 @@
 !
         call calpreciptype (kdt, nrcm, im, ix, levs, levs+1,           &
                             rann, xlat, xlon, gt0,    &
-                            gq0_water_vapor, prsl, prsi,        &
+                            gq0(:,:,1), prsl, prsi,        &
                             rain, phii, tsfc,           &  !input
                             domr, domzr, domip, doms)                           ! output
 !
@@ -296,7 +291,7 @@
           do k=1,levs
             do i=1,im
               dt3dt(i,k) = dt3dt(i,k) + (gt0(i,k)-save_t(i,k)) * frain
-              dq3dt(i,k) = dq3dt(i,k) + (gq0_water_vapor(i,k)-save_qv(i,k)) * frain
+              dq3dt(i,k) = dq3dt(i,k) + (gq0(i,k,1)-save_qv(i,k)) * frain
             enddo
           enddo
         endif
@@ -374,7 +369,7 @@
           enddo
         endif
         do i=1,im
-          pwat(i) = pwat(i) + del(i,k)*(gq0_water_vapor(i,k)+work1(i))
+          pwat(i) = pwat(i) + del(i,k)*(gq0(i,k,1)+work1(i))
         enddo
 !     if (lprnt .and. i == ipr) write(0,*)' gq0=',
 !    &gq0(i,k,1),' qgrs=',qgrs(i,k,1),' work2=',work2(i),' k=',k

--- a/physics/GFS_debug.F90
+++ b/physics/GFS_debug.F90
@@ -8,6 +8,7 @@
 
 #define PRINT_SUM
       interface print_var
+        module procedure print_logic_0d
         module procedure print_int_0d
         module procedure print_real_0d
         module procedure print_real_1d
@@ -144,6 +145,27 @@
                      call print_var(mpirank,omprank,Tbd%blkno, 'Tbd%htswc',            Tbd%htswc)
                      call print_var(mpirank,omprank,Tbd%blkno, 'Tbd%htsw0',            Tbd%htsw0)
                      call print_var(mpirank,omprank,Tbd%blkno, 'Model%sec',            Model%sec)
+                     call print_var(mpirank,omprank,Tbd%blkno, 'Diag%dswsfci',         Diag%dswsfci)
+                     call print_var(mpirank,omprank,Tbd%blkno, 'Diag%nswsfci',         Diag%nswsfci)
+                     call print_var(mpirank,omprank,Tbd%blkno, 'Diag%uswsfci',         Diag%uswsfci)
+                     call print_var(mpirank,omprank,Tbd%blkno, 'Diag%dlwsfci',         Diag%dlwsfci)
+                     call print_var(mpirank,omprank,Tbd%blkno, 'Diag%ulwsfci',         Diag%ulwsfci)
+                     call print_var(mpirank,omprank,Tbd%blkno, 'Diag%dusfci',          Diag%dusfci)
+                     call print_var(mpirank,omprank,Tbd%blkno, 'Diag%dvsfci',          Diag%dvsfci)
+                     call print_var(mpirank,omprank,Tbd%blkno, 'Diag%dtsfci',          Diag%dtsfci)
+                     call print_var(mpirank,omprank,Tbd%blkno, 'Diag%dqsfci',          Diag%dqsfci)
+                     call print_var(mpirank,omprank,Tbd%blkno, 'Diag%gfluxi',          Diag%gfluxi)
+                     call print_var(mpirank,omprank,Tbd%blkno, 'Diag%gflux',           Diag%gflux)
+                     call print_var(mpirank,omprank,Tbd%blkno, 'Sfcprop%slmsk',        Sfcprop%slmsk)
+                     call print_var(mpirank,omprank,Tbd%blkno, 'Diag%epi'    ,         Diag%epi)
+                     call print_var(mpirank,omprank,Tbd%blkno, 'Diag%gfluxi' ,         Diag%gfluxi)
+                     call print_var(mpirank,omprank,Tbd%blkno, 'Diag%t1'     ,         Diag%t1)
+                     call print_var(mpirank,omprank,Tbd%blkno, 'Diag%q1'     ,         Diag%q1)
+                     call print_var(mpirank,omprank,Tbd%blkno, 'Diag%u1'     ,         Diag%u1)
+                     call print_var(mpirank,omprank,Tbd%blkno, 'Diag%v1'     ,         Diag%v1)
+                     call print_var(mpirank,omprank,Tbd%blkno, 'Diag%dlwsfc',          Diag%dlwsfc)
+                     call print_var(mpirank,omprank,Tbd%blkno, 'Diag%ulwsfc',          Diag%ulwsfc)
+                     call print_var(mpirank,omprank,Tbd%blkno, 'Diag%psmean',          Diag%psmean)
                  end if
 #ifdef OPENMP
 !$OMP BARRIER
@@ -162,6 +184,18 @@
 #endif
 
       end subroutine GFS_diagtoscreen_run
+
+      subroutine print_logic_0d(mpirank,omprank,blkno,name,var)
+
+          implicit none
+
+          integer, intent(in) :: mpirank, omprank, blkno
+          character(len=*), intent(in) :: name
+          logical, intent(in) :: var
+
+          write(0,'(2a,3i4,1x,l)') 'XXX: ', trim(name), mpirank, omprank, blkno, var
+
+      end subroutine print_logic_0d
 
       subroutine print_int_0d(mpirank,omprank,blkno,name,var)
 

--- a/physics/GFS_suite_interstitial.F90
+++ b/physics/GFS_suite_interstitial.F90
@@ -200,14 +200,11 @@
 !! | adjsfculw      | surface_upwelling_longwave_flux                              | surface upwelling longwave flux at current time                       | W m-2         |    1 | real             | kind_phys | in     | F        |
 !! | xmu            | zenith_angle_temporal_adjustment_factor_for_shortwave_fluxes | zenith angle temporal adjustment factor for shortwave fluxes          | none          |    1 | real             | kind_phys | in     | F        |
 !! | Diag           | FV3-GFS_Diag_type                                            | Fortran DDT containing FV3-GFS fields targeted for diagnostic output  | DDT           |    0 | GFS_diag_type    |           | inout  | F        |
-!! | kcnv           | flag_deep_convection                                         | flag indicating whether convection occurs in column (0 or 1)          | flag          |    1 | integer          |           | out    | F        |
-!! | hflx           | kinematic_surface_upward_sensible_heat_flux                  | kinematic surface upward sensible heat flux                           | K m s-1       |    1 | real             | kind_phys | out    | F        |
-!! | evap           | kinematic_surface_upward_latent_heat_flux                    | kinematic surface upward latent heat flux                             | kg kg-1 m s-1 |    1 | real             | kind_phys | out    | F        |
 !! | errmsg         | ccpp_error_message                                           | error message for error handling in CCPP                              | none          |    0 | character        | len=*     | out    | F        |
 !! | errflg         | ccpp_error_flag                                              | error flag for error handling in CCPP                                 | flag          |    0 | integer          |           | out    | F        |
 !!
     subroutine GFS_suite_interstitial_2_run (Model, Grid, Statein, Radtend, xcosz, adjsfcdsw, adjsfcdlw, adjsfculw, xmu, &
-                                             Diag, kcnv, hflx, evap, errmsg, errflg)
+                                             Diag, errmsg, errflg)
 
       use machine,               only: kind_phys
       use GFS_typedefs,          only: GFS_control_type, GFS_grid_type, GFS_statein_type, GFS_radtend_type, GFS_diag_type
@@ -221,9 +218,7 @@
       type(GFS_radtend_type),           intent(in)    :: Radtend
       type(GFS_diag_type),              intent(inout) :: Diag
 
-      integer, dimension(size(Grid%xlon,1)), intent(out) :: kcnv
       real(kind=kind_phys), dimension(size(Grid%xlon,1)), intent(in) :: xcosz, adjsfcdsw, adjsfcdlw, adjsfculw, xmu
-      real(kind=kind_phys), dimension(size(Grid%xlon,1)), intent(out) :: hflx, evap
       character(len=*), intent(out) :: errmsg
       integer, intent(out) :: errflg
 
@@ -273,16 +268,6 @@
           endif
         endif
       endif    ! end if_lssav_block
-
-      kcnv(:)   = 0
-
-      hflx(:)       = 0.0
-      evap(:)       = 0.0
-
-      Diag%t1(:)      = Statein%tgrs(:,1)
-      Diag%q1(:)      = Statein%qgrs(:,1,1)
-      Diag%u1(:)      = Statein%ugrs(:,1)
-      Diag%v1(:)      = Statein%vgrs(:,1)
 
     end subroutine GFS_suite_interstitial_2_run
 

--- a/physics/GFS_surface_generic.F90
+++ b/physics/GFS_surface_generic.F90
@@ -209,7 +209,7 @@
         gabsbdlw(:) = semis(:) * adjsfcdlw(:)
 
         do i=1,im
-          tsurf(i)        = tsfc(i)
+          tsurf(i)   = tsfc(i)
           zlvl(i)    = phil(i,1) * onebg
         end do
 
@@ -265,8 +265,6 @@
 !! | sbsno          | snow_deposition_sublimation_upward_latent_heat_flux                                                                 | latent heat flux from snow depo/subl                                                | W m-2       |    1 | real       | kind_phys | in     | F        |
 !! | snowc          | surface_snow_area_fraction                                                                                          | surface snow area fraction                                                          | frac        |    1 | real       | kind_phys | in     | F        |
 !! | snohf          | snow_freezing_rain_upward_latent_heat_flux                                                                          | latent heat flux due to snow and frz rain                                           | W m-2       |    1 | real       | kind_phys | in     | F        |
-!! | con_eps        | ratio_of_dry_air_to_water_vapor_gas_constants                                                                       | rd/rv                                                                               | none        |    0 | real       | kind_phys | in     | F        |
-!! | con_epsm1      | ratio_of_dry_air_to_water_vapor_gas_constants_minus_one                                                             | (rd/rv) - 1                                                                         | none        |    0 | real       | kind_phys | in     | F        |
 !! | epi            | instantaneous_surface_potential_evaporation                                                                         | instantaneous sfc potential evaporation                                             | W m-2       |    1 | real       | kind_phys | inout  | F        |
 !! | gfluxi         | instantaneous_surface_ground_heat_flux                                                                              | instantaneous sfc ground heat flux                                                  | W m-2       |    1 | real       | kind_phys | inout  | F        |
 !! | t1             | air_temperature_at_lowest_model_layer_for_diag                                                                      | layer 1 temperature for diag                                                        | K           |    1 | real       | kind_phys | inout  | F        |
@@ -311,26 +309,22 @@
 !! | snowca         | cumulative_surface_snow_area_fraction_multiplied_by_timestep                                                        | cumulative surface snow area fraction multiplied by timestep                        | s           |    1 | real       | kind_phys | inout  | F        |
 !! | snohfa         | cumulative_snow_freezing_rain_upward_latent_heat_flux_multiplied_by_timestep                                        | cumulative latent heat flux due to snow and frz rain multiplied by timestep         | W m-2 s     |    1 | real       | kind_phys | inout  | F        |
 !! | ep             | cumulative_surface_upward_potential_latent_heat_flux_multiplied_by_timestep                                         | cumulative surface upward potential latent heat flux multiplied by timestep         | W m-2 s     |    1 | real       | kind_phys | inout  | F        |
-!! | tmpmin         | minimum_temperature_at_2m                                                                                           | min temperature at 2m height                                                        | K           |    1 | real       | kind_phys | inout  | F        |
-!! | tmpmax         | maximum_temperature_at_2m                                                                                           | max temperature at 2m height                                                        | K           |    1 | real       | kind_phys | inout  | F        |
-!! | spfhmin        | minimum_specific_humidity_at_2m                                                                                     | minimum specific humidity at 2m height                                              | kg kg-1     |    1 | real       | kind_phys | inout  | F        |
-!! | spfhmax        | maximum_specific_humidity_at_2m                                                                                     | maximum specific humidity at 2m height                                              | kg kg-1     |    1 | real       | kind_phys | inout  | F        |
-!! | wind10mmax     | maximum_wind_at_10m                                                                                                 | maximum wind speed at 10 m                                                          | m s-1       |    1 | real       | kind_phys | inout  | F        |
-!! | u10mmax        | maximum_x_wind_at_10m                                                                                               | maximum x wind at 10 m                                                              | m s-1       |    1 | real       | kind_phys | inout  | F        |
-!! | v10mmax        | maximum_y_wind_at_10m                                                                                               | maximum y wind at 10 m                                                              | m s-1       |    1 | real       | kind_phys | inout  | F        |
-!! | dpt2m          | dewpoint_temperature_at_2m                                                                                          | 2 meter dewpoint temperature                                                        | K           |    1 | real       | kind_phys | inout  | F        |
+!! | runoff         | total_runoff                                                                                                        | total water runoff                                                                  | kg m-2      |    1 | real       | kind_phys | inout  | F        |
+!! | srunoff        | surface_runoff                                                                                                      | surface water runoff (from lsm)                                                     | kg m-2      |    1 | real       | kind_phys | inout  | F        |
+!! | runof          | surface_runoff_flux                                                                                                 | surface runoff flux                                                                 | g m-2 s-1   |    1 | real       | kind_phys | in     | F        |
+!! | drain          | subsurface_runoff_flux                                                                                              | subsurface runoff flux                                                              | g m-2 s-1   |    1 | real       | kind_phys | in     | F        |
 !! | errmsg         | ccpp_error_message                                                                                                  | error message for error handling in CCPP                                            | none        |    0 | character  | len=*     | out    | F        |
 !! | errflg         | ccpp_error_flag                                                                                                     | error flag for error handling in CCPP                                               | flag        |    0 | integer    |           | out    | F        |
 !!
 #endif
       subroutine GFS_surface_generic_post_run (im, cplflx, lssav, islmsk, dtf, ep1d, gflx, tgrs_1, qgrs_1, ugrs_1, vgrs_1,          &
         adjsfcdlw, adjsfcdsw, adjnirbmd, adjnirdfd, adjvisbmd, adjvisdfd, adjsfculw, adjnirbmu, adjnirdfu, adjvisbmu, adjvisdfu,    &
-        t2m, q2m, u10m, v10m, tsfc, pgr, xcosz, evbs, evcw, trans, sbsno, snowc, snohf, con_eps, con_epsm1,                         &
+        t2m, q2m, u10m, v10m, tsfc, pgr, xcosz, evbs, evcw, trans, sbsno, snowc, snohf,                                             &
         epi, gfluxi, t1, q1, u1, v1, dlwsfci_cpl, dswsfci_cpl, dlwsfc_cpl, dswsfc_cpl, dnirbmi_cpl, dnirdfi_cpl, dvisbmi_cpl,       &
         dvisdfi_cpl, dnirbm_cpl, dnirdf_cpl, dvisbm_cpl, dvisdf_cpl, nlwsfci_cpl, nlwsfc_cpl, t2mi_cpl, q2mi_cpl, u10mi_cpl,        &
         v10mi_cpl, tsfci_cpl, psurfi_cpl, nnirbmi_cpl, nnirdfi_cpl, nvisbmi_cpl, nvisdfi_cpl, nswsfci_cpl, nswsfc_cpl, nnirbm_cpl,  &
-        nnirdf_cpl, nvisbm_cpl, nvisdf_cpl, gflux, evbsa, evcwa, transa, sbsnoa, snowca, snohfa, ep, tmpmin, tmpmax, spfhmin,       &
-        spfhmax, wind10mmax, u10mmax, v10mmax, dpt2m, errmsg, errflg)
+        nnirdf_cpl, nvisbm_cpl, nvisdf_cpl, gflux, evbsa, evcwa, transa, sbsnoa, snowca, snohfa, ep,                                &
+        runoff, srunoff, runof, drain, errmsg, errflg)
 
         use machine,               only: kind_phys
 
@@ -340,7 +334,7 @@
         logical,                              intent(in) :: cplflx, lssav
         integer, dimension(im),               intent(in) :: islmsk
 
-        real(kind=kind_phys),                 intent(in) :: dtf, con_eps, con_epsm1
+        real(kind=kind_phys),                 intent(in) :: dtf
 
         real(kind=kind_phys), dimension(im),  intent(in)  :: ep1d, gflx, tgrs_1, qgrs_1, ugrs_1, vgrs_1, adjsfcdlw, adjsfcdsw, &
           adjnirbmd, adjnirdfd, adjvisbmd, adjvisdfd, adjsfculw, adjnirbmu, adjnirdfu, adjvisbmu, adjvisdfu,                   &
@@ -350,10 +344,13 @@
           dswsfc_cpl, dnirbmi_cpl, dnirdfi_cpl, dvisbmi_cpl, dvisdfi_cpl, dnirbm_cpl, dnirdf_cpl, dvisbm_cpl, dvisdf_cpl, &
           nlwsfci_cpl, nlwsfc_cpl, t2mi_cpl, q2mi_cpl, u10mi_cpl, v10mi_cpl, tsfci_cpl, psurfi_cpl, nnirbmi_cpl, nnirdfi_cpl, &
           nvisbmi_cpl, nvisdfi_cpl, nswsfci_cpl, nswsfc_cpl, nnirbm_cpl, nnirdf_cpl, nvisbm_cpl, nvisdf_cpl, gflux, evbsa, &
-          evcwa, transa, sbsnoa, snowca, snohfa, ep, tmpmin, tmpmax, spfhmin, spfhmax, wind10mmax, u10mmax, v10mmax, dpt2m
+          evcwa, transa, sbsnoa, snowca, snohfa, ep
 
-        character(len=*),                     intent(out) :: errmsg
-        integer,                              intent(out) :: errflg
+        real(kind=kind_phys), dimension(im), intent(inout) :: runoff, srunoff
+        real(kind=kind_phys), dimension(im), intent(in)    :: drain, runof
+
+        character(len=*), intent(out) :: errmsg
+        integer,          intent(out) :: errflg
 
         real(kind=kind_phys), parameter :: albdf   = 0.06
 
@@ -441,28 +438,17 @@
             snowca(i)  = snowca(i) + snowc(i) * dtf
             snohfa(i)  = snohfa(i) + snohf(i) * dtf
             ep(i)      = ep(i)     + ep1d(i)  * dtf
-
-            tmpmax(i)  = max(tmpmax(i),t2m(i))
-            tmpmin(i)  = min(tmpmin(i),t2m(i))
-
-            spfhmax(i) = max(spfhmax(i),q2m(i))
-            spfhmin(i) = min(spfhmin(i),q2m(i))
           enddo
+        endif
 
-          do i=1, im
-  ! find max wind speed then decompose
-             tem = sqrt(u10m(i)*u10m(i) + v10m(i)*v10m(i))
-             if (tem > wind10mmax(i)) then
-                wind10mmax(i) = tem
-                u10mmax(i)    = u10m(i)
-                v10mmax(i)    = v10m(i)
-             endif
-
-  ! Compute dew point, first using vapor pressure
-             tem = max(pgr(i) * q2m(i) / ( con_eps - con_epsm1 *q2m(i)), 1.e-8)
-             dpt2m(i) = 243.5 / ( ( 17.67 / log(tem/611.2) ) - 1.) + 273.14
+!  --- ...  total runoff is composed of drainage into water table and
+!           runoff at the surface and is accumulated in unit of meters
+        if (lssav) then
+          tem = dtf * 0.001
+          do i=1,im
+            runoff(i)  = runoff(i)  + (drain(i)+runof(i)) * tem
+            srunoff(i) = srunoff(i) + runof(i) * tem
           enddo
-
         endif
 
       end subroutine GFS_surface_generic_post_run

--- a/physics/sfc_diag_post.F90
+++ b/physics/sfc_diag_post.F90
@@ -1,0 +1,87 @@
+!> \file GFS_surface_diag.F90
+!!  Contains code related to the surface diagnostic scheme.
+
+      module sfc_diag_post
+
+      contains
+
+      subroutine sfc_diag_post_init ()
+      end subroutine sfc_diag_post_init
+
+      subroutine sfc_diag_post_finalize()
+      end subroutine sfc_diag_post_finalize
+#if 0
+!> \section arg_table_sfc_diag_post_run Argument Table
+!! | local_name     | standard_name                                                                                                       | long_name                                                                           | units       | rank | type       |    kind   | intent | optional |
+!! |----------------|---------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|-------------|------|------------|-----------|--------|----------|
+!! | im             | horizontal_loop_extent                                                                                              | horizontal loop extent                                                              | count       |    0 | integer    |           | in     | F        |
+!! | lssav          | flag_diagnostics                                                                                                    | logical flag for storing diagnostics                                                | flag        |    0 | logical    |           | in     | F        |
+!! | dtf            | time_step_for_dynamics                                                                                              | dynamics timestep                                                                   | s           |    0 | real       | kind_phys | in     | F        |
+!! | con_eps        | ratio_of_dry_air_to_water_vapor_gas_constants                                                                       | rd/rv                                                                               | none        |    0 | real       | kind_phys | in     | F        |
+!! | con_epsm1      | ratio_of_dry_air_to_water_vapor_gas_constants_minus_one                                                             | (rd/rv) - 1                                                                         | none        |    0 | real       | kind_phys | in     | F        |
+!! | pgr            | surface_air_pressure                                                                                                | surface pressure                                                                    | Pa          |    1 | real       | kind_phys | in     | F        |
+!! | t2m            | temperature_at_2m                                                                                                   | 2 meter temperature                                                                 | K           |    1 | real       | kind_phys | in     | F        |
+!! | q2m            | specific_humidity_at_2m                                                                                             | 2 meter specific humidity                                                           | kg kg-1     |    1 | real       | kind_phys | in     | F        |
+!! | u10m           | x_wind_at_10m                                                                                                       | 10 meter u wind speed                                                               | m s-1       |    1 | real       | kind_phys | in     | F        |
+!! | v10m           | y_wind_at_10m                                                                                                       | 10 meter v wind speed                                                               | m s-1       |    1 | real       | kind_phys | in     | F        |
+!! | tmpmin         | minimum_temperature_at_2m                                                                                           | min temperature at 2m height                                                        | K           |    1 | real       | kind_phys | inout  | F        |
+!! | tmpmax         | maximum_temperature_at_2m                                                                                           | max temperature at 2m height                                                        | K           |    1 | real       | kind_phys | inout  | F        |
+!! | spfhmin        | minimum_specific_humidity_at_2m                                                                                     | minimum specific humidity at 2m height                                              | kg kg-1     |    1 | real       | kind_phys | inout  | F        |
+!! | spfhmax        | maximum_specific_humidity_at_2m                                                                                     | maximum specific humidity at 2m height                                              | kg kg-1     |    1 | real       | kind_phys | inout  | F        |
+!! | wind10mmax     | maximum_wind_at_10m                                                                                                 | maximum wind speed at 10 m                                                          | m s-1       |    1 | real       | kind_phys | inout  | F        |
+!! | u10mmax        | maximum_x_wind_at_10m                                                                                               | maximum x wind at 10 m                                                              | m s-1       |    1 | real       | kind_phys | inout  | F        |
+!! | v10mmax        | maximum_y_wind_at_10m                                                                                               | maximum y wind at 10 m                                                              | m s-1       |    1 | real       | kind_phys | inout  | F        |
+!! | dpt2m          | dewpoint_temperature_at_2m                                                                                          | 2 meter dewpoint temperature                                                        | K           |    1 | real       | kind_phys | inout  | F        |
+!! | errmsg         | ccpp_error_message                                                                                                  | error message for error handling in CCPP                                            | none        |    0 | character  | len=*     | out    | F        |
+!! | errflg         | ccpp_error_flag                                                                                                     | error flag for error handling in CCPP                                               | flag        |    0 | integer    |           | out    | F        |
+!!
+#endif
+      subroutine sfc_diag_post_run (im, lssav, dtf, con_eps, con_epsm1, pgr,    &
+                         t2m, q2m, u10m, v10m, tmpmin, tmpmax, spfhmin, spfhmax,&
+                         wind10mmax, u10mmax, v10mmax, dpt2m, errmsg, errflg)
+
+        use machine,               only: kind_phys
+
+        implicit none
+
+        integer,                              intent(in) :: im
+        logical,                              intent(in) :: lssav
+        real(kind=kind_phys),                 intent(in) :: dtf, con_eps, con_epsm1
+        real(kind=kind_phys), dimension(im),  intent(in) :: pgr, t2m, q2m, u10m, v10m
+        real(kind=kind_phys), dimension(im),  intent(inout) :: tmpmin, tmpmax, spfhmin, spfhmax
+        real(kind=kind_phys), dimension(im),  intent(inout) :: wind10mmax, u10mmax, v10mmax, dpt2m
+
+        character(len=*),                     intent(out) :: errmsg
+        integer,                              intent(out) :: errflg
+
+        integer :: i
+        real(kind=kind_phys) :: tem
+
+        ! Initialize CCPP error handling variables
+        errmsg = ''
+        errflg = 0
+
+        if (lssav) then
+          do i=1,im
+            tmpmax(i)  = max(tmpmax(i),t2m(i))
+            tmpmin(i)  = min(tmpmin(i),t2m(i))
+            spfhmax(i) = max(spfhmax(i),q2m(i))
+            spfhmin(i) = min(spfhmin(i),q2m(i))
+          enddo
+          ! Find max wind speed then decompose
+          do i=1, im
+             tem = sqrt(u10m(i)*u10m(i) + v10m(i)*v10m(i))
+             if (tem > wind10mmax(i)) then
+                wind10mmax(i) = tem
+                u10mmax(i)    = u10m(i)
+                v10mmax(i)    = v10m(i)
+             endif
+             ! Compute dew point, first using vapor pressure
+             tem = max(pgr(i) * q2m(i) / ( con_eps - con_epsm1 *q2m(i)), 1.e-8)
+             dpt2m(i) = 243.5 / ( ( 17.67 / log(tem/611.2) ) - 1.) + 273.14
+          enddo
+        endif
+
+      end subroutine sfc_diag_post_run
+
+      end module sfc_diag_post


### PR DESCRIPTION
See https://github.com/NCAR/ccpp-framework/pull/135 for a general description.

Changes to ccpp-physics:

- avoid using the same variable (or overlapping slices of it) twice in a scheme's argument list (e.g. gq0 and gq0_water_vapor)
- cleanup GFS_suite_interstitial_2 (parts of it already in GFS_surface_generics_pre)
- move code that is used twice in GFS_physics_driver, each time after sfc_diag, from GFS_surface_generics_post to sfc_diag_post
- add missing code for lssav = .true. to GFS_surface_generics_post