### PR TITLE
GFDL cloud microphysics: control output of namelist parameters

### DIFF
--- a/physics/gfdl_cloud_microphys.F90
+++ b/physics/gfdl_cloud_microphys.F90
@@ -378,7 +378,7 @@ contains
 #endif
 
        ! write version number and namelist to log file
-       if (me == master) then
+       if (me==master .and. logunit>=0) then
            write (logunit, *) " ================================================================== "
            write (logunit, *) "gfdl_cloud_microphys_mod"
            write (logunit, nml = gfdl_cloud_microphysics_nml)


### PR DESCRIPTION
This PR allows to suppress the writing of the namelist parameters from physics/gfdl_cloud_microphys.F90 by setting logunit to a negative value. This is a reasonable assumption, because I/O units need to be positive integers.

No test is needed for this PR.