### PR TITLE
Intel 15 backward compatibility CCPP static build

### DIFF
--- a/stochastic_physics/stochy_ccpp.F90
+++ b/stochastic_physics/stochy_ccpp.F90
@@ -229,9 +229,8 @@ contains
       integer              :: len_thread
       integer              :: i1_t
       integer              :: i2_t
-      integer, pointer     :: num_threads => ompthreads
 !
-      len_thread_m  = (len+num_threads-1) / num_threads
+      len_thread_m  = (len+ompthreads-1) / ompthreads
 !
       !$omp parallel do default(none)                                       &
       !$omp private(i1_t,i2_t,len_thread,it,i,ii,i1,i2)                     &
@@ -242,8 +241,8 @@ contains
       !$omp shared(imxin,jmxin)                                             &
       !$omp shared(outlon,outlat,wrk,iindx1,rinlon,jindx1,rinlat,ddx,ddy)   &
       !$omp shared(rlon,rlat,regin,gauout)                                  &
-      !$omp shared(num_threads,len_thread_m,len,iindx2,jindx2,rslmsk)
-      do it=1,num_threads ! start of threaded loop
+      !$omp shared(ompthreads,len_thread_m,len,iindx2,jindx2,rslmsk)
+      do it=1,ompthreads ! start of threaded loop
         i1_t       = (it-1)*len_thread_m+1
         i2_t       = min(i1_t+len_thread_m-1,len)
         len_thread = i2_t-i1_t+1


### PR DESCRIPTION
This PR makes one change that allows to compile and run the CCPP static build with Intel 15 on Theia:

stochastic_physics/stochy_ccpp.F90: replace pointer num_threads with …its target ompthreads for Intel 15 backward compatibility

Note that this PR does not change the default compiler version for the CCPP static build. If one wants to use Intel 15, it is necessary to replace the Intel18 modulefile with the Intel15 modulefile:

```
cd modulefiles/theia.intel/
cp fv3.intel-15.1.133 fv3.intel-18.0.1.163
cd ../../tests
./rt.sh ... # usual static options
# or: ./compile.sh ... # usual static options
```

Note: changes are restricted to ccpp-physics only, i.e. awaiting results of CCPP regression tests (using Intel18) only before merging.

Note 2: this PR is related to https://github.com/NCAR/NEMSfv3gfs/pull/51, which adds the new (temporary) modulefile modulefiles/theia.intel/fv3.intel-15.1.133 - this is not used by any of the automatic scripts and require the above manual steps.