### PR TITLE
Tiny fix to compile Thompson MP with SCM

### DIFF
--- a/physics/module_mp_thompson_hrrr.F90
+++ b/physics/module_mp_thompson_hrrr.F90
@@ -1497,7 +1497,9 @@ MODULE module_mp_thompson_hrrr
 #endif
                           kts, kte, dt, ii, jj)
       ! DH*
+#ifdef MPI
       use mpi
+#endif
       ! *DH
       implicit none
 


### PR DESCRIPTION
wrap 'use mpi' statement in ifdef in subroutine mp_thompson in order to compile without MPI in the GMTB SCM