### PR TITLE
CCPP acceptance: fv3_stochy / fv3_ccpp stochy bit-for-bit identical

### DIFF
--- a/stochastic_physics/get_stochy_pattern.F90
+++ b/stochastic_physics/get_stochy_pattern.F90
@@ -224,31 +224,31 @@ subroutine get_random_pattern_fv3_vect(rpattern,npatterns,&
                  gis_stochy%lats_nodes_a,gis_stochy%global_lats_a,gis_stochy%lonsperlat,&
                  gis_stochy%epsedn,gis_stochy%epsodn,gis_stochy%snnp1ev,gis_stochy%snnp1od,&
                  gis_stochy%plnev_a,gis_stochy%plnod_a,1)
-       do i=1,lonf
-          do j=1,gis_stochy%lats_node_a
-             lat=gis_stochy%global_lats_a(ipt_lats_node_a-1+j)
-             workgu(i,lat) = workgu(i,lat) + wrk2du(i,j,1)
-             workgv(i,lat) = workgv(i,lat) + wrk2dv(i,j,1)
+          do i=1,lonf
+             do j=1,gis_stochy%lats_node_a
+                lat=gis_stochy%global_lats_a(ipt_lats_node_a-1+j)
+                workgu(i,lat) = workgu(i,lat) + wrk2du(i,j,1)
+                workgv(i,lat) = workgv(i,lat) + wrk2dv(i,j,1)
+             enddo
           enddo
        enddo
-    enddo
-    call mp_reduce_sum(workgu,lonf,latg)
-    call mp_reduce_sum(workgv,lonf,latg)
+       call mp_reduce_sum(workgu,lonf,latg)
+       call mp_reduce_sum(workgv,lonf,latg)
 ! interpolate to cube grid
-    do blk=1,nblks
-       len=size(Grid(blk)%xlat,1)
-       pattern_1d = 0
-       associate( tlats=>Grid(blk)%xlat*rad2deg,&
-                  tlons=>Grid(blk)%xlon*rad2deg )
-          call stochy_la2ga(workgu,lonf,latg,gg_lons,gg_lats,wlon,rnlat,&
-                            pattern_1d(1:len),len,rslmsk,tlats,tlons)
-          skebu_save(blk,:,k)=pattern_1d(:)
-          call stochy_la2ga(workgv,lonf,latg,gg_lons,gg_lats,wlon,rnlat,&
-                            pattern_1d(1:len),len,rslmsk,tlats,tlons)
-          skebv_save(blk,:,k)=-1*pattern_1d(:)
-       end associate
+       do blk=1,nblks
+          len=size(Grid(blk)%xlat,1)
+          pattern_1d = 0
+          associate( tlats=>Grid(blk)%xlat*rad2deg,&
+                     tlons=>Grid(blk)%xlon*rad2deg )
+             call stochy_la2ga(workgu,lonf,latg,gg_lons,gg_lats,wlon,rnlat,&
+                               pattern_1d(1:len),len,rslmsk,tlats,tlons)
+             skebu_save(blk,:,k)=pattern_1d(:)
+             call stochy_la2ga(workgv,lonf,latg,gg_lons,gg_lats,wlon,rnlat,&
+                               pattern_1d(1:len),len,rslmsk,tlats,tlons)
+             skebv_save(blk,:,k)=-1*pattern_1d(:)
+          end associate
+       enddo
     enddo
-  enddo
  endif
  do k=1,skeblevs-1
     skebu_save(:,:,k)=skebu_save(:,:,k+1)

--- a/stochastic_physics/stochy_patterngenerator.F90
+++ b/stochastic_physics/stochy_patterngenerator.F90
@@ -249,6 +249,11 @@ module stochy_patterngenerator_mod
  end subroutine getnoise
  
  subroutine patterngenerator_advance(rpattern,k,skeb_first_call)
+
+#ifdef TRANSITION
+!DIR$ OPTIMIZE:1
+#endif
+
     ! advance 1st-order autoregressive process with
     ! specified autocorrelation (phi) and variance spectrum (spectrum)
     real(kind_dbl_prec) :: noise_e(len_trie_ls,2)


### PR DESCRIPTION
These PRs reduce the optimization of a particular routine deep inside the stochastic physics code to obtain bit-for-bit identical results of the (fv3_control based) regression tests fv3_stochy / fv3_ccpp_stochy (static build) in PROD mode.