### PR TITLE
CCPP acceptance: csawmgshoc* and *_debug bit-for-bit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,7 @@ elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
                                   ./physics/sflx.f
                                   ./physics/satmedmfvdif.F
                                   ./physics/cs_conv.F90
+                                  ./physics/gcm_shoc.F90
                                   PROPERTIES COMPILE_FLAGS "${CMAKE_Fortran_FLAGS_LOPT2}")
       # Add all of the above files to the list of schemes with special compiler flags
       list(APPEND SCHEMES_SFX ./physics/micro_mg2_0.F90
@@ -214,6 +215,7 @@ elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
                               ./physics/sflx.f
                               ./physics/satmedmfvdif.F
                               ./physics/cs_conv.F90
+                              ./physics/gcm_shoc.F90
                               ./physics/gfdl_fv_sat_adj.F90)
     endif (${CMAKE_BUILD_TYPE} MATCHES "Debug")
 
@@ -254,21 +256,22 @@ else (${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
 endif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
 
 # The auto-generated caps can contain calls to physics schemes in
-# which some of the arguments (pointers) are not associated. This is
-# on purpose to avoid allocating fields that are not used inside the
+# which some of the arguments (pointers, arrays) are not associated/allocated.
+# This is on purpose to avoid allocating fields that are not used inside the
 # scheme if, for example, certain conditions are not met. To avoid
 # Fortran runtime errors, it is necessary to remove checks for pointers
-# that are not associated from the caps ONLY. For the physics schemes,
-# these checks can and should remain enabled. Overwriting the check flags
-# explicitly works for Intel and GNU, but not for PGI.
+# that are not associated and for array bounds from the caps ONLY. For the
+# physics schemes, these checks can and should remain enabled. Overwriting
+# the pointer check flags explicitly works for Intel and GNU, but not for PGI.
 if (${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
-  set_property(SOURCE ${CAPS} PROPERTY COMPILE_FLAGS "-fcheck=no-pointer")
+  set_property(SOURCE ${CAPS} PROPERTY COMPILE_FLAGS "-fcheck=no-pointer,no-bounds")
 elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
-  set_property(SOURCE ${CAPS} PROPERTY COMPILE_FLAGS "-check nopointers")
+  set_property(SOURCE ${CAPS} PROPERTY COMPILE_FLAGS "-check nopointers,nobounds")
 elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI")
   if (CMAKE_Fortran_FLAGS MATCHES ".*chkptr.*")
     message (FATAL_ERROR "PGI compiler option chkptr cannot be used for CCPP physics")
   endif (CMAKE_Fortran_FLAGS MATCHES ".*chkptr.*")
+  set_property(SOURCE ${CAPS} PROPERTY COMPILE_FLAGS "-Mnobounds")
 endif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
 
 if (PROJECT STREQUAL "CCPP-FV3")

--- a/physics/GFS_suite_interstitial.F90
+++ b/physics/GFS_suite_interstitial.F90
@@ -615,7 +615,9 @@
       real(kind=kind_phys), dimension(im),              intent(in) :: xlat
       real(kind=kind_phys), dimension(im, levs, ntrac), intent(in) :: gq0
 
-      real(kind=kind_phys), dimension(im, levs),      intent(inout) :: rhc, save_qc, save_qi
+      real(kind=kind_phys), dimension(im, levs),      intent(inout) :: rhc, save_qc
+      ! save_qi is not allocated for Zhao-Carr MP
+      real(kind=kind_phys), dimension(:, :),          intent(inout) :: save_qi
       real(kind=kind_phys), dimension(im, levs, nn),  intent(inout) :: clw
 
       character(len=*), intent(out) :: errmsg
@@ -829,7 +831,9 @@
       logical,                                  intent(in) :: ltaerosol, lgocart
 
       real(kind=kind_phys),                     intent(in) :: con_pi, dtf
-      real(kind=kind_phys), dimension(im,levs), intent(in) :: save_qc, save_qi
+      real(kind=kind_phys), dimension(im,levs), intent(in) :: save_qc
+      ! save_qi is not allocated for Zhao-Carr MP
+      real(kind=kind_phys), dimension(:, :),    intent(in) :: save_qi
 
       real(kind=kind_phys), dimension(im,levs,ntrac), intent(inout) :: gq0
       real(kind=kind_phys), dimension(im,levs,nn),    intent(inout) :: clw

--- a/physics/cs_conv.F90
+++ b/physics/cs_conv.F90
@@ -59,7 +59,9 @@ module cs_conv_pre
 ! --- input/output
   real(r8), dimension(ntrac-ncld+2), intent(out) :: fswtr, fscav
   real(r8), dimension(im), intent(out) :: wcbmax
-  real(r8), dimension(im,levs), intent(out) :: save_q1,save_q2,save_q3
+  real(r8), dimension(im,levs), intent(out) :: save_q1,save_q2
+  ! save_q3 is not allocated for Zhao-Carr MP
+  real(r8), dimension(:,:), intent(out)     :: save_q3
 
   character(len=*), intent(out) :: errmsg
   integer,          intent(out) :: errflg

--- a/physics/module_bl_mynn.F90
+++ b/physics/module_bl_mynn.F90
@@ -113,7 +113,7 @@ MODULE module_bl_mynn
        &                  p_qnc= 0, &
        &                  p_qni= 0
 
-!END FV3 CONSTANTS                                                                                                                                                                                                                                                                                       
+!END FV3 CONSTANTS
 !====================================================================
 !WRF CONSTANTS
 !  USE module_model_constants, only: &


### PR DESCRIPTION
This PR and https://github.com/NCAR/FV3/pull/124 are required to get bit-for-bit identical results for the following tests: csawmgshoc, csawmgshoc127, fv3_control_debug, fv3_stretched_nest_debug.

For csawmgshoc, csawmgshoc127:
- reduce optimization for gcm_shoc.F90/gcm_shoc.f90 (replace -xCORE-AVX2 with -xCORE-AVX-I, remove -no-prec-div -no-prec-sqrt) for both the CCPP and IPD version

For fv3_control_debug, fv3_stretched_nest_debug:
- remove array bounds check from debug flags for auto-generated caps (similar to the existing removal of pointer association checks for auto-generated caps, and for the same reason)
- remove hard-coded dimensions and use assumed-size arrays, e.g. (:,:,) instead of (im,levs), for arrays that may not be allocated depending on the microphysics scheme

Also included:
- bugfix in IPD_CCPP_driver.F90, corrected format specifier in print statement
- remove trailing whitespaces in module_bl_mynn.F90, this caused the PGI compiler to abort (source line too long)
