### PR TITLE
Jet and Cheyenne build system updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
     string(REPLACE "-xCORE-AVX2" "-xCORE-AVX-I"
            CMAKE_Fortran_FLAGS_LOPT1
            "${CMAKE_Fortran_FLAGS_LOPT1}")
-    string(REPLACE "-axSSE4.2,AVX,CORE-AVX2" "-axSSE4.2,AVX,CORE-AVX-I"
+    string(REPLACE "-axSSE4.2,AVX,CORE-AVX2,CORE-AVX512" "-axSSE4.2,AVX,CORE-AVX-I"
            CMAKE_Fortran_FLAGS_LOPT1
            "${CMAKE_Fortran_FLAGS_LOPT1}")
     SET_SOURCE_FILES_PROPERTIES(./physics/radiation_aerosols.f


### PR DESCRIPTION
This PR and associated PRs update the build configuration for Jet following the major OS upgrade in the last week of March 2019, add additional compiler flags for the Intel Skylake processors on the kJet partition, and add a Intel-iMPI configuration for Cheyenne (by default, Cheyenne uses the SGI-MPT MPI implementation for all three compilers).

Changes for ccpp-physics: This PR extends the SIMD multi-architecture optimization flags (PROD flags) for the Intel compiler with the AVX-512 instruction sets for the kJet Skylake processors.

Associated PRs:

https://github.com/NCAR/NEMSfv3gfs/pull/132
https://github.com/NCAR/NEMS/pull/29
https://github.com/NCAR/ccpp-physics/pull/232
https://github.com/NCAR/FV3/pull/137

See https://github.com/NCAR/NEMSfv3gfs/pull/132 for information on testing requirements etc.