### PR TITLE
Thompson MP bug fix for saving temperature, and calculation of initial number concentrations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ if (${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
   SET_SOURCE_FILES_PROPERTIES(./physics/mersenne_twister.f PROPERTIES COMPILE_FLAGS "-fdefault-real-8 -fno-range-check")
   SET_SOURCE_FILES_PROPERTIES(./physics/module_nst_water_prop.f90 PROPERTIES COMPILE_FLAGS "-ffree-line-length-none -fdefault-real-8 -ffree-form")
   SET_SOURCE_FILES_PROPERTIES(./physics/aer_cloud.F ./physics/wv_saturation.F ./physics/cldwat2m_micro.F ./physics/surface_perturbation.F90 PROPERTIES COMPILE_FLAGS "-fdefault-real-8 -fdefault-double-8")
+  SET_SOURCE_FILES_PROPERTIES(./physics/module_mp_thompson_make_number_concentrations.F90 PROPERTIES COMPILE_FLAGS "-fdefault-real-8 -fdefault-double-8")
   if (PROJECT STREQUAL "CCPP-FV3")
     if (DYN32)
       message (FATAL_ERROR "The current build system does not allow building fast physics with 32-bit precision when the GNU compilers are used")
@@ -141,6 +142,7 @@ elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
                                 ./physics/module_MYNNSFC_wrapper.F90
                                 ./physics/module_MYNNrad_pre.F90
                                 ./physics/module_MYNNrad_post.F90
+                                ./physics/module_mp_thompson_make_number_concentrations.F90
                                 PROPERTIES COMPILE_FLAGS "-r8 -ftz")
 
     # Replace -xHost or -xCORE-AVX2 with -xCORE-AVX-I for certain files
@@ -230,6 +232,7 @@ elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI")
   SET_SOURCE_FILES_PROPERTIES(./physics/mersenne_twister.f PROPERTIES COMPILE_FLAGS "-r8 -Mnofptrap")
   SET_SOURCE_FILES_PROPERTIES(./physics/module_nst_water_prop.f90 PROPERTIES COMPILE_FLAGS "-r8 -Mfree")
   SET_SOURCE_FILES_PROPERTIES(./physics/aer_cloud.F ./physics/wv_saturation.F ./physics/cldwat2m_micro.F ./physics/surface_perturbation.F90 PROPERTIES COMPILE_FLAGS "-r8")
+  SET_SOURCE_FILES_PROPERTIES(./physics/module_mp_thompson_make_number_concentrations.F90 PROPERTIES COMPILE_FLAGS "-r8")
   if (PROJECT STREQUAL "CCPP-FV3")
     if (DYN32)
       SET_PROPERTY(SOURCE ./physics/gfdl_fv_sat_adj.F90 APPEND_STRING PROPERTY COMPILE_FLAGS " -r4 ")

--- a/physics/module_mp_thompson_hrrr.F90
+++ b/physics/module_mp_thompson_hrrr.F90
@@ -1,5 +1,3 @@
-!#define DEBUG_AEROSOLS
-
 !+---+-----------------------------------------------------------------+
 !.. This subroutine computes the moisture tendencies of water vapor,
 !.. cloud droplets, rain, cloud ice (pristine), snow, and graupel.
@@ -984,9 +982,6 @@ MODULE module_mp_thompson_hrrr
                               ims,ime, jms,jme, kms,kme,              &  ! memory dims
                               its,ite, jts,jte, kts,kte,              &  ! tile dims
                               errmsg, errflg)
-#ifdef DEBUG_AEROSOLS
-      use mpi
-#endif
 
       implicit none
 
@@ -1049,24 +1044,6 @@ MODULE module_mp_thompson_hrrr
       ! CCPP error handling
       character(len=*), optional, intent(  out) :: errmsg
       integer,          optional, intent(  out) :: errflg
-
-#ifdef DEBUG_AEROSOLS
-      integer :: mpirank, mpisize, impi, ierr
-      real    :: nc1d_in_debug, nwfa1d_in_debug, nifa1d_in_debug, nwfa1_in_debug
-      real    :: nc1d_out_debug, nwfa1d_out_debug, nifa1d_out_debug, nwfa1_out_debug
-
-      call MPI_COMM_RANK(MPI_COMM_WORLD,mpirank,ierr)
-      call MPI_COMM_SIZE(MPI_COMM_WORLD,mpisize,ierr)
-
-      nc1d_in_debug   = 0.0
-      nwfa1d_in_debug = 0.0
-      nifa1d_in_debug = 0.0
-      nwfa1_in_debug  = 0.0
-      nc1d_out_debug   = 0.0
-      nwfa1d_out_debug = 0.0
-      nifa1d_out_debug = 0.0
-      nwfa1_out_debug  = 0.0
-#endif
 
       ! CCPP
       if (present(errmsg)) errmsg = ''
@@ -1211,12 +1188,7 @@ MODULE module_mp_thompson_hrrr
             enddo
             nwfa1 = 11.1E6
          endif
-#ifdef DEBUG_AEROSOLS
-         nc1d_in_debug   = nc1d_in_debug   + sum(nc1d(:))
-         nwfa1d_in_debug = nwfa1d_in_debug + sum(nwfa1d(:))
-         nifa1d_in_debug = nifa1d_in_debug + sum(nifa1d(:))
-         nwfa1_in_debug  = nwfa1_in_debug  + nwfa1
-#endif
+
          call mp_thompson(qv1d, qc1d, qi1d, qr1d, qs1d, qg1d, ni1d,     &
                       nr1d, nc1d, nwfa1d, nifa1d, t1d, p1d, w1d, dz1d,  &
                       pptrain, pptsnow, pptgraul, pptice, &
@@ -1268,11 +1240,6 @@ MODULE module_mp_thompson_hrrr
                nifa(i,k,j) = nifa1d(k)
             enddo
          endif
-#ifdef DEBUG_AEROSOLS
-         nc1d_out_debug   = nc1d_out_debug   + sum(nc1d(:))
-         nwfa1d_out_debug = nwfa1d_out_debug + sum(nwfa1d(:))
-         nifa1d_out_debug = nifa1d_out_debug + sum(nifa1d(:))
-#endif
 
          do k = kts, kte
             qv(i,k,j) = qv1d(k)
@@ -1411,30 +1378,6 @@ MODULE module_mp_thompson_hrrr
 !         'ni: ', ni_max, '(', imax_ni, ',', jmax_ni, ',', kmax_ni, ')', &
 !         'nr: ', nr_max, '(', imax_nr, ',', jmax_nr, ',', kmax_nr, ')'
 ! END DEBUG - GT
-#ifdef DEBUG_AEROSOLS
-      nc1d_in_debug   = nc1d_in_debug   / real((j_end-j_start+1)*(i_end-i_start+1)*(kte-kts+1))
-      nwfa1d_in_debug = nwfa1d_in_debug / real((j_end-i_start+1)*(i_end-i_start+1)*(kte-kts+1))
-      nifa1d_in_debug = nifa1d_in_debug / real((j_end-j_start+1)*(i_end-i_start+1)*(kte-kts+1))
-      nwfa1_in_debug  = nwfa1_in_debug  / real((j_end-j_start+1)*(i_end-i_start+1))
-      nc1d_out_debug   = nc1d_out_debug   / real((j_end-j_start+1)*(i_end-i_start+1)*(kte-kts+1))
-      nwfa1d_out_debug = nwfa1d_out_debug / real((j_end-i_start+1)*(i_end-i_start+1)*(kte-kts+1))
-      nifa1d_out_debug = nifa1d_out_debug / real((j_end-j_start+1)*(i_end-i_start+1)*(kte-kts+1))
-      call MPI_BARRIER(MPI_COMM_WORLD,ierr)
-      do impi=0,mpisize-1
-         !if (impi==mpirank) then
-         if (impi==mpirank .and. impi==0) then
-            write(0,'(a,i3,a,l,e16.7)') "MPI rank ", mpirank, &
-                     & ": is_aero, mean(nwfa1) IN:", is_aerosol_aware, nwfa1_in_debug
-            write(0,'(a,i3,a,3e16.7)') "MPI rank ", mpirank, &
-                     & ": mean(nc1d_in), mean(nwfa1d_in), mean(nifa1d_in):", &
-                     & nc1d_in_debug, nwfa1d_in_debug, nifa1d_in_debug
-            write(0,'(a,i3,a,3e16.7)') "MPI rank ", mpirank, &
-                     & ": mean(nc1d_out), mean(nwfa1d_out), mean(nifa1d_out):", &
-                     & nc1d_out_debug, nwfa1d_out_debug, nifa1d_out_debug
-         end if
-         call MPI_BARRIER(MPI_COMM_WORLD,ierr)
-      end do
-#endif
 
       END SUBROUTINE mp_gt_driver
 
@@ -1607,12 +1550,6 @@ MODULE module_mp_thompson_hrrr
       LOGICAL, DIMENSION(kts:kte):: L_qc, L_qi, L_qr, L_qs, L_qg
       LOGICAL:: debug_flag
       INTEGER:: nu_c
-#ifdef DEBUG_AEROSOLS
-      INTEGER :: mpirank, ierr
-      LOGICAL :: abort = .false.
-
-      call MPI_COMM_RANK(MPI_COMM_WORLD,mpirank,ierr)
-#endif
 
 !+---+
 
@@ -3515,15 +3452,6 @@ MODULE module_mp_thompson_hrrr
 
          if (rr(kts).gt.R1*1000.) &
          pptrain = pptrain + sed_r(kts)*DT*onstep(1)
-#ifdef DEBUG_AEROSOLS
-         if (pptrain.ge.1E5) then
-            write(0,*) mpirank, " ::: DH DEBUG THOMPSON: pptrain, nstep, n, kts, DT, sed_r(kts), onstep(1), rr(kts)", &
-                     & pptrain, nstep, n, kts, DT, sed_r(kts), onstep(1), rr(kts)
-         end if
-         if (sed_r(kts)*DT*onstep(1).ge.1E3) then
-            abort = .true.
-         end if
-#endif
       enddo
       endif
 
@@ -3575,15 +3503,6 @@ MODULE module_mp_thompson_hrrr
 
          if (ri(kts).gt.R1*1000.) &
          pptice = pptice + sed_i(kts)*DT*onstep(2)
-#ifdef DEBUG_AEROSOLS
-         if (pptice.ge.1E5) then
-            write(0,*) mpirank, " ::: DH DEBUG THOMPSON: pptice, nstep, n, kts, DT, sed_i(kts), onstep(2), ri(kts)", &
-                     & pptice, nstep, n, kts, DT, sed_i(kts), onstep(2), ri(kts)
-         end if
-         if (sed_i(kts)*DT*onstep(2).ge.1E3) then
-            abort = .true.
-         end if
-#endif
       enddo
       endif
 
@@ -3611,15 +3530,6 @@ MODULE module_mp_thompson_hrrr
 
          if (rs(kts).gt.R1*1000.) &
          pptsnow = pptsnow + sed_s(kts)*DT*onstep(3)
-#ifdef DEBUG_AEROSOLS
-         if (pptsnow.ge.1E5) then
-            write(0,*) mpirank, " ::: DH DEBUG THOMPSON: pptsnow, nstep, n, kts, DT, sed_s(kts), onstep(3), rs(kts)", &
-                     & pptsnow, nstep, n, kts, DT, sed_s(kts), onstep(3), rs(kts)
-         end if
-         if (sed_s(kts)*DT*onstep(3).ge.1E3) then
-            abort = .true.
-         end if
-#endif
       enddo
       endif
 
@@ -3647,15 +3557,6 @@ MODULE module_mp_thompson_hrrr
 
          if (rg(kts).gt.R1*1000.) &
          pptgraul = pptgraul + sed_g(kts)*DT*onstep(4)
-#ifdef DEBUG_AEROSOLS
-         if (pptgraul.ge.1E5) then
-            write(0,*) mpirank, " ::: DH DEBUG THOMPSON: pptgraul, nstep, n, kts, DT, sed_g(kts), onstep(4), rg(kts)", &
-                     & pptgraul, nstep, n, kts, DT, sed_g(kts), onstep(4), rg(kts)
-         end if
-         if (sed_g(kts)*DT*onstep(4).ge.1E5) then
-            abort = .true.
-         end if
-#endif
       enddo
       endif
 
@@ -3760,15 +3661,6 @@ MODULE module_mp_thompson_hrrr
          qg1d(k) = qg1d(k) + qgten(k)*DT
          if (qg1d(k) .le. R1) qg1d(k) = 0.0
       enddo
-
-#ifdef DEBUG_AEROSOLS
-      if (abort) then
-         write(0,*) "DH DEBUG: abort for debugging (inside mp_thompson)"
-         call sleep(1)
-         call MPI_BARRIER(MPI_COMM_WORLD, ierr)
-         stop
-      end if
-#endif
 
       end subroutine mp_thompson
 !+---+-----------------------------------------------------------------+

--- a/physics/module_mp_thompson_make_number_concentrations.F90
+++ b/physics/module_mp_thompson_make_number_concentrations.F90
@@ -1,0 +1,186 @@
+module module_mp_thompson_make_number_concentrations
+
+      use physcons, only: PI => con_pi
+
+      implicit none
+
+      private
+
+      public make_IceNumber, make_DropletNumber, make_RainNumber
+
+!      Q_ice              is cloud ice mixing ratio, units of kg/m3
+!      Q_cloud            is cloud water mixing ratio, units of kg/m3
+!      Q_rain             is rain mixing ratio, units of kg/m3
+!      temp               is air temperature in Kelvin
+!      make_IceNumber     is cloud droplet number mixing ratio, units of number per m3
+!      make_DropletNumber is rain number mixing ratio, units of number per kg of m3
+!      make_RainNumber    is rain number mixing ratio, units of number per kg of m3
+!      qnwfa              is number of water-friendly aerosols in number per kg
+
+!+---+-----------------------------------------------------------------+ 
+!+---+-----------------------------------------------------------------+ 
+
+   contains
+
+      elemental real function make_IceNumber (Q_ice, temp)
+
+      !IMPLICIT NONE
+      REAL, PARAMETER:: Ice_density = 890.0
+      !REAL, PARAMETER:: PI = 3.1415926536
+      real, intent(in):: Q_ice, temp
+      integer idx_rei
+      real corr, reice, deice
+      double precision lambda
+
+!+---+-----------------------------------------------------------------+ 
+!..Table of lookup values of radiative effective radius of ice crystals
+!.. as a function of Temperature from -94C to 0C.  Taken from WRF RRTMG
+!.. radiation code where it is attributed to Jon Egill Kristjansson
+!.. and coauthors.
+!+---+-----------------------------------------------------------------+ 
+
+      !real retab(95)
+      !data retab /                                                      &
+      !   5.92779, 6.26422, 6.61973, 6.99539, 7.39234,                   &
+      !   7.81177, 8.25496, 8.72323, 9.21800, 9.74075, 10.2930,          &
+      !   10.8765, 11.4929, 12.1440, 12.8317, 13.5581, 14.2319,          &
+      !   15.0351, 15.8799, 16.7674, 17.6986, 18.6744, 19.6955,          &
+      !   20.7623, 21.8757, 23.0364, 24.2452, 25.5034, 26.8125,          &
+      !   27.7895, 28.6450, 29.4167, 30.1088, 30.7306, 31.2943,          &
+      !   31.8151, 32.3077, 32.7870, 33.2657, 33.7540, 34.2601,          &
+      !   34.7892, 35.3442, 35.9255, 36.5316, 37.1602, 37.8078,          &
+      !   38.4720, 39.1508, 39.8442, 40.5552, 41.2912, 42.0635,          &
+      !   42.8876, 43.7863, 44.7853, 45.9170, 47.2165, 48.7221,          &
+      !   50.4710, 52.4980, 54.8315, 57.4898, 60.4785, 63.7898,          &
+      !   65.5604, 71.2885, 75.4113, 79.7368, 84.2351, 88.8833,          &
+      !   93.6658, 98.5739, 103.603, 108.752, 114.025, 119.424,          &
+      !   124.954, 130.630, 136.457, 142.446, 148.608, 154.956,          &
+      !   161.503, 168.262, 175.248, 182.473, 189.952, 197.699,          &
+      !   205.728, 214.055, 222.694, 231.661, 240.971, 250.639/
+      real, dimension(95), parameter:: retab = (/                       &
+         5.92779, 6.26422, 6.61973, 6.99539, 7.39234,                   &
+         7.81177, 8.25496, 8.72323, 9.21800, 9.74075, 10.2930,          &
+         10.8765, 11.4929, 12.1440, 12.8317, 13.5581, 14.2319,          &
+         15.0351, 15.8799, 16.7674, 17.6986, 18.6744, 19.6955,          &
+         20.7623, 21.8757, 23.0364, 24.2452, 25.5034, 26.8125,          &
+         27.7895, 28.6450, 29.4167, 30.1088, 30.7306, 31.2943,          &
+         31.8151, 32.3077, 32.7870, 33.2657, 33.7540, 34.2601,          &
+         34.7892, 35.3442, 35.9255, 36.5316, 37.1602, 37.8078,          &
+         38.4720, 39.1508, 39.8442, 40.5552, 41.2912, 42.0635,          &
+         42.8876, 43.7863, 44.7853, 45.9170, 47.2165, 48.7221,          &
+         50.4710, 52.4980, 54.8315, 57.4898, 60.4785, 63.7898,          &
+         65.5604, 71.2885, 75.4113, 79.7368, 84.2351, 88.8833,          &
+         93.6658, 98.5739, 103.603, 108.752, 114.025, 119.424,          &
+         124.954, 130.630, 136.457, 142.446, 148.608, 154.956,          &
+         161.503, 168.262, 175.248, 182.473, 189.952, 197.699,          &
+         205.728, 214.055, 222.694, 231.661, 240.971, 250.639 /)
+
+!+---+-----------------------------------------------------------------+ 
+!..From the model 3D temperature field, subtract 179K for which
+!.. index value of retab as a start.  Value of corr is for
+!.. interpolating between neighboring values in the table.
+!+---+-----------------------------------------------------------------+ 
+
+      idx_rei = int(temp-179.)
+      idx_rei = min(max(idx_rei,1),94)
+      corr = temp - int(temp)
+      reice = retab(idx_rei)*(1.-corr) + retab(idx_rei+1)*corr
+      deice = 2.*reice * 1.E-6
+
+!+---+-----------------------------------------------------------------+ 
+!..Now we have the final radiative effective size of ice (as function
+!.. of temperature only).  This size represents 3rd moment divided by
+!.. second moment of the ice size distribution, so we can compute a
+!.. number concentration from the mean size and mass mixing ratio.
+!.. The mean (radiative effective) diameter is 3./Slope for an inverse
+!.. exponential size distribution.  So, starting with slope, work
+!.. backwords to get number concentration.
+!+---+-----------------------------------------------------------------+ 
+
+      lambda = 3.0 / deice
+      make_IceNumber = Q_ice * lambda*lambda*lambda / (PI*Ice_density)
+
+!+---+-----------------------------------------------------------------+ 
+!..Example1: Common ice size coming from Thompson scheme is about 30 microns.
+!.. An example ice mixing ratio could be 0.001 g/kg for a temperature of -50C.
+!.. Remember to convert both into MKS units.  This gives N_ice=357652 per kg.
+!..Example2: Lower in atmosphere at T=-10C matching ~162 microns in retab,
+!.. and assuming we have 0.1 g/kg mixing ratio, then N_ice=28122 per kg, 
+!.. which is 28 crystals per liter of air if the air density is 1.0.
+!+---+-----------------------------------------------------------------+ 
+
+      return
+      end function make_IceNumber
+
+!+---+-----------------------------------------------------------------+ 
+!+---+-----------------------------------------------------------------+ 
+
+      elemental real function make_DropletNumber (Q_cloud, qnwfa)
+
+      !IMPLICIT NONE
+
+      real, intent(in):: Q_cloud, qnwfa
+
+      !real, parameter:: PI = 3.1415926536
+      real, parameter:: am_r = PI*1000./6.
+      real, dimension(15), parameter:: g_ratio = (/24,60,120,210,336,   &
+     &                504,720,990,1320,1716,2184,2730,3360,4080,4896/)
+      double precision:: lambda, qnc
+      real:: q_nwfa, x1, xDc
+      integer:: nu_c
+
+!+---+
+
+      q_nwfa = MAX(99.E6, MIN(qnwfa,5.E10))
+      nu_c = MAX(2, MIN(NINT(2.5E10/q_nwfa), 15))
+
+      x1 = MAX(1., MIN(q_nwfa*1.E-9, 10.)) - 1.
+      xDc = (30. - x1*20./9.) * 1.E-6
+
+      lambda = (4.0D0 + nu_c) / xDc
+      qnc = Q_cloud / g_ratio(nu_c) * lambda*lambda*lambda / am_r
+      make_DropletNumber = SNGL(qnc)
+
+      return
+      end function make_DropletNumber
+
+!+---+-----------------------------------------------------------------+ 
+!+---+-----------------------------------------------------------------+ 
+
+      elemental real function make_RainNumber (Q_rain, temp)
+
+      IMPLICIT NONE
+
+      real, intent(in):: Q_rain, temp
+      double precision:: lambda, N0, qnr
+      !real, parameter:: PI = 3.1415926536
+      real, parameter:: am_r = PI*1000./6.
+
+      !+---+-----------------------------------------------------------------+ 
+      !.. Not thrilled with it, but set Y-intercept parameter to Marshal-Palmer value
+      !.. that basically assumes melting snow becomes typical rain. However, for
+      !.. -2C < T < 0C, make linear increase in exponent to attempt to keep
+      !.. supercooled collision-coalescence (warm-rain) similar to drizzle rather
+      !.. than bigger rain drops.  While this could also exist at T>0C, it is
+      !.. more difficult to assume it directly from having mass and not number.
+      !+---+-----------------------------------------------------------------+ 
+
+      N0 = 8.E6
+
+      if (temp .le. 271.15) then
+         N0 = 8.E8      
+      elseif (temp .gt. 271.15 .and. temp.lt.273.15) then
+         N0 = 8. * 10**(279.15-temp)
+      endif
+
+      lambda = SQRT(SQRT(N0*am_r*6.0/Q_rain))
+      qnr = Q_rain / 6.0 * lambda*lambda*lambda / am_r
+      make_RainNumber = SNGL(qnr)
+
+      return
+      end function make_RainNumber
+
+!+---+-----------------------------------------------------------------+ 
+!+---+-----------------------------------------------------------------+ 
+
+end module module_mp_thompson_make_number_concentrations

--- a/physics/mp_thompson_hrrr.F90
+++ b/physics/mp_thompson_hrrr.F90
@@ -1,7 +1,4 @@
 ! CCPP license goes here, as well as further documentation
-
-!#define DEBUG_AEROSOLS
-
 module mp_thompson_hrrr
 
       use machine, only : kind_phys
@@ -393,54 +390,6 @@ module mp_thompson_hrrr
          kme = nlev
          kte = nlev
 
-#ifdef DEBUG_AEROSOLS
-         if (mpirank==mpiroot) then
-             write(0,*) "AEROSOL DEBUG: called mp_thompson_hrrr_run, is_aerosol_aware=",  is_aerosol_aware, &
-                      & ", do_effective_radii=", do_effective_radii, ", do_radar_ref=", do_radar_ref, &
-                      & ", diagflag=", diagflag, ", do_radar_ref_mp=", do_radar_ref_mp
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run before: prsl min/mean/max =", &
-                              & minval(prsl), sum(prsl)/real(size(prsl)), maxval(prsl)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run before: tgrs min/mean/max =", &
-                              & minval(tgrs), sum(tgrs)/real(size(tgrs)), maxval(tgrs)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run before: rho min/mean/max =", &
-                              & minval(rho), sum(rho)/real(size(rho)), maxval(rho)
-             if (is_aerosol_aware) then
-                write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run before: nwfa2d min/mean/max =", &
-                                    & minval(nwfa2d), sum(nwfa2d)/real(size(nwfa2d)), maxval(nwfa2d)
-                write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run before: nifa2d min/mean/max =", &
-                                    & minval(nifa2d), sum(nifa2d)/real(size(nifa2d)), maxval(nifa2d)
-                write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run before: nwfa min/mean/max =", &
-                                    & minval(nwfa), sum(nwfa)/real(size(nwfa)), maxval(nwfa)
-                write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run before: nifa min/mean/max =", &
-                                    & minval(nifa), sum(nifa)/real(size(nifa)), maxval(nifa)
-                write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run before: nc min/mean/max =", &
-                                    & minval(nc), sum(nc)/real(size(nc)), maxval(nc)
-             end if
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run before: ni min/mean/max =", &
-                                 & minval(ni), sum(ni)/real(size(ni)), maxval(ni)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run before: nr min/mean/max =", &
-                                 & minval(nr), sum(nr)/real(size(nr)), maxval(nr)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run before: omega min/mean/max =", &
-                                 & minval(omega), sum(omega)/real(size(omega)), maxval(omega)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run before: w min/mean/max =", &
-                                 & minval(w), sum(w)/real(size(w)), maxval(w)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run before: re_cloud_mp min/mean/max =", &
-                                 & minval(re_cloud_mp), sum(re_cloud_mp)/real(size(re_cloud_mp)), maxval(re_cloud_mp)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run before: re_ice_mp min/mean/max =", &
-                                 & minval(re_ice_mp), sum(re_ice_mp)/real(size(re_ice_mp)), maxval(re_ice_mp)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run before: re_snow_mp min/mean/max =", &
-                                 & minval(re_snow_mp), sum(re_snow_mp)/real(size(re_snow_mp)), maxval(re_snow_mp)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run before: delta_rain_mp min/mean/max =", &
-                                 & minval(delta_rain_mp), sum(delta_rain_mp)/real(size(delta_rain_mp)), maxval(delta_rain_mp)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run before: delta_snow_mp min/mean/max =", &
-                                 & minval(delta_snow_mp), sum(delta_snow_mp)/real(size(delta_snow_mp)), maxval(delta_snow_mp)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run before: delta_ice_mp min/mean/max =", &
-                                 & minval(delta_ice_mp), sum(delta_ice_mp)/real(size(delta_ice_mp)), maxval(delta_ice_mp)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run before: delta_graupel_mp min/mean/max =", &
-                                 & minval(delta_graupel_mp), sum(delta_graupel_mp)/real(size(delta_graupel_mp)), maxval(delta_graupel_mp)
-         end if
-#endif
-
          ! Call Thompson MP with or without aerosols
          if (is_aerosol_aware) then
             call mp_gt_driver(qv=qv_mp, qc=qc_mp, qr=qr_mp, qi=qi_mp, qs=qs_mp, qg=qg_mp,    &
@@ -486,51 +435,6 @@ module mp_thompson_hrrr
          qi      = qi_mp/(1.0_kind_phys+qv_mp)
          qs      = qs_mp/(1.0_kind_phys+qv_mp)
          qg      = qg_mp/(1.0_kind_phys+qv_mp)
-
-#ifdef DEBUG_AEROSOLS
-         if (mpirank==mpiroot) then
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run after: prsl min/mean/max =", &
-                              & minval(prsl), sum(prsl)/real(size(prsl)), maxval(prsl)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run after: tgrs min/mean/max =", &
-                              & minval(tgrs), sum(tgrs)/real(size(tgrs)), maxval(tgrs)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run after: rho min/mean/max =", &
-                              & minval(rho), sum(rho)/real(size(rho)), maxval(rho)
-             if (is_aerosol_aware) then
-                write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run after: nwfa2d min/mean/max =", &
-                                    & minval(nwfa2d), sum(nwfa2d)/real(size(nwfa2d)), maxval(nwfa2d)
-                write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run after: nifa2d min/mean/max =", &
-                                    & minval(nifa2d), sum(nifa2d)/real(size(nifa2d)), maxval(nifa2d)
-                write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run after: nwfa min/mean/max =", &
-                                    & minval(nwfa), sum(nwfa)/real(size(nwfa)), maxval(nwfa)
-                write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run after: nifa min/mean/max =", &
-                                    & minval(nifa), sum(nifa)/real(size(nifa)), maxval(nifa)
-                write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run after: nc min/mean/max =", &
-                                    & minval(nc), sum(nc)/real(size(nc)), maxval(nc)
-             end if
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run after: ni min/mean/max =", &
-                                 & minval(ni), sum(ni)/real(size(ni)), maxval(ni)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run after: nr min/mean/max =", &
-                                 & minval(nr), sum(nr)/real(size(nr)), maxval(nr)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run after: omega min/mean/max =", &
-                                 & minval(omega), sum(omega)/real(size(omega)), maxval(omega)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run after: w min/mean/max =", &
-                                 & minval(w), sum(w)/real(size(w)), maxval(w)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run after: re_cloud_mp min/mean/max =", &
-                                 & minval(re_cloud_mp), sum(re_cloud_mp)/real(size(re_cloud_mp)), maxval(re_cloud_mp)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run after: re_ice_mp min/mean/max =", &
-                                 & minval(re_ice_mp), sum(re_ice_mp)/real(size(re_ice_mp)), maxval(re_ice_mp)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run after: re_snow_mp min/mean/max =", &
-                                 & minval(re_snow_mp), sum(re_snow_mp)/real(size(re_snow_mp)), maxval(re_snow_mp)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run after: delta_rain_mp min/mean/max =", &
-                                 & minval(delta_rain_mp), sum(delta_rain_mp)/real(size(delta_rain_mp)), maxval(delta_rain_mp)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run after: delta_snow_mp min/mean/max =", &
-                                 & minval(delta_snow_mp), sum(delta_snow_mp)/real(size(delta_snow_mp)), maxval(delta_snow_mp)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run after: delta_ice_mp min/mean/max =", &
-                                 & minval(delta_ice_mp), sum(delta_ice_mp)/real(size(delta_ice_mp)), maxval(delta_ice_mp)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp thompson run after: delta_graupel_mp min/mean/max =", &
-                                 & minval(delta_graupel_mp), sum(delta_graupel_mp)/real(size(delta_graupel_mp)), maxval(delta_graupel_mp)
-         end if
-#endif
 
          ! Convert rainfall deltas from mm to m (on physics timestep); add to inout variables
          ! "rain" in Thompson MP refers to precipitation (total of liquid rainfall+snow+graupel+ice)

--- a/physics/mp_thompson_hrrr_pre.F90
+++ b/physics/mp_thompson_hrrr_pre.F90
@@ -1,12 +1,14 @@
+!Activate this CPP flag to calculate initial number concentrations
+!#define MAKE_NUMBER_CONCENTRATIONS
+
 ! CCPP license goes here, as well as further documentation
-
-!#define DEBUG_AEROSOLS
-
 module mp_thompson_hrrr_pre
 
       use machine, only : kind_phys
 
       use module_mp_thompson_hrrr, only : naIN0, naIN1, naCCN0, naCCN1, eps
+
+      use module_mp_thompson_make_number_concentrations, only: make_IceNumber, make_DropletNumber, make_RainNumber
 
       implicit none
 
@@ -47,7 +49,6 @@ module mp_thompson_hrrr_pre
 !! | prsl            | air_pressure                                                          | mean layer pressure                                      | Pa         |    2 | real      | kind_phys | in     | F        |
 !! | phil            | geopotential                                                          | geopotential at model layer centers                      | m2 s-2     |    2 | real      | kind_phys | in     | F        |
 !! | area            | cell_area                                                             | area of the grid cell                                    | m2         |    1 | real      | kind_phys | in     | F        |
-!! | mpicomm         | mpi_comm                                                              | MPI communicator                                         | index      |    0 | integer   |           | in     | F        |
 !! | mpirank         | mpi_rank                                                              | current MPI-rank                                         | index      |    0 | integer   |           | in     | F        |
 !! | mpiroot         | mpi_root                                                              | master MPI-rank                                          | index      |    0 | integer   |           | in     | F        |
 !! | blkno           | ccpp_block_number                                                     | for explicit data blocking: block number of this block   | index      |    0 | integer   |           | in     | F        |
@@ -59,8 +60,7 @@ module mp_thompson_hrrr_pre
                                   spechum, qc, qr, qi, qs, qg, ni, nr,       &
                                   is_aerosol_aware, nc, nwfa, nifa, nwfa2d,  &
                                   nifa2d, tgrs, tgrs_save, prsl, phil, area, &
-                                  mpicomm, mpirank, mpiroot, blkno,          &
-                                  errmsg, errflg)
+                                  mpirank, mpiroot, blkno, errmsg, errflg)
 
          implicit none
 
@@ -94,7 +94,6 @@ module mp_thompson_hrrr_pre
          real(kind_phys),           intent(in   ) :: phil(1:ncol,1:nlev)
          real(kind_phys),           intent(in   ) :: area(1:ncol)
          ! MPI information
-         integer,                   intent(in   ) :: mpicomm
          integer,                   intent(in   ) :: mpirank
          integer,                   intent(in   ) :: mpiroot
          ! Blocking information
@@ -114,8 +113,25 @@ module mp_thompson_hrrr_pre
          errmsg = ''
          errflg = 0
 
+         ! Save current air temperature for tendency limiters in mp_thompson_hrrr_post
+         tgrs_save = tgrs
+
          ! Return if not first timestep
          if (kdt > 1) return
+
+         ! Consistency check
+         if (is_aerosol_aware     .and. &
+             (.not.present(nc)     .or. &
+              .not.present(nwfa2d) .or. &
+              .not.present(nifa2d) .or. &
+              .not.present(nwfa)   .or. &
+              .not.present(nifa)        )) then
+             write(errmsg,fmt='(*(a))') 'Logic error in mp_thompson_hrrr_pre_run:',                 &
+                                        ' aerosol-aware microphysics require all of the following', &
+                                        ' optional arguments: nc, nwfa2d, nifa2d, nwfa, nifa'
+             errflg = 1
+             return
+          end if
 
          ! Fix initial values of hydrometeors
          where(spechum<0) spechum = 0.0
@@ -126,50 +142,15 @@ module mp_thompson_hrrr_pre
          where(qg<0)      qg = 0.0
          where(ni<0)      ni = 0.0
          where(nr<0)      nr = 0.0
-         ! If qi is in boundary conditions but ni is not, reset qi to zero (and vice versa)
-         if (maxval(qi)>0.0 .and. maxval(ni)==0.0) qi = 0.0
-         if (maxval(ni)>0.0 .and. maxval(qi)==0.0) ni = 0.0
-         ! If qr is in boundary conditions but nr is not, reset qr to zero (and vice versa)
-         if (maxval(qr)>0.0 .and. maxval(nr)==0.0) qr = 0.0
-         if (maxval(nr)>0.0 .and. maxval(qr)==0.0) nr = 0.0
 
-         ! Return if aerosol-aware option is not used
-         if (.not. is_aerosol_aware) return
-
-         if (.not.present(nc)     .or. &
-             .not.present(nwfa2d) .or. &
-             .not.present(nifa2d) .or. &
-             .not.present(nwfa)   .or. &
-             .not.present(nifa)        ) then
-             write(errmsg,fmt='(*(a))') 'Logic error in mp_thompson_hrrr_pre_run:',                 &
-                                        ' aerosol-aware microphysics require all of the following', &
-                                        ' optional arguments: nc, nifa2d, nwfa2d, nwfa, nifa'
-             errflg = 1
-             return
-          end if
-
-          ! Fix initial values of aerosols
-          where(nc<0)     nc = 0.0
-          where(nwfa<0)   nwfa = 0.0
-          where(nifa<0)   nifa = 0.0
-          where(nwfa2d<0) nwfa2d = 0.0
-          where(nifa2d<0) nifa2d = 0.0
-
-#ifdef DEBUG_AEROSOLS
-         if (mpirank==mpiroot) then
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp_thompson_hrrr_pre_run before: nwfa2d min/mean/max =", &
-                                 & minval(nwfa2d), sum(nwfa2d)/real(size(nwfa2d)), maxval(nwfa2d)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp_thompson_hrrr_pre_run before: nifa2d min/mean/max =", &
-                                 & minval(nifa2d), sum(nifa2d)/real(size(nifa2d)), maxval(nifa2d)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp_thompson_hrrr_pre_run before: nwfa min/mean/max =",   &
-                                 & minval(nwfa), sum(nwfa)/real(size(nwfa)), maxval(nwfa)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp_thompson_hrrr_pre_run before: nifa min/mean/max =",   &
-                                 & minval(nifa), sum(nifa)/real(size(nifa)), maxval(nifa)
+         if (is_aerosol_aware) then
+            ! Fix initial values of aerosols
+            where(nc<0)     nc = 0.0
+            where(nwfa<0)   nwfa = 0.0
+            where(nifa<0)   nifa = 0.0
+            where(nwfa2d<0) nwfa2d = 0.0
+            where(nifa2d<0) nifa2d = 0.0
          end if
-#endif
-
-         ! Save current air temperature for tendency limiters in mp_thompson_hrrr_post
-         tgrs_save = tgrs
 
          ! Geopotential height in m2 s-2 to height in m
          hgt = phil/con_g
@@ -177,6 +158,39 @@ module mp_thompson_hrrr_pre
          ! Density of air in kg m-3 and inverse density of air
          rho = prsl/(con_rd*tgrs)
          orho = 1.0/rho
+
+         !  Prior to calling the functions: make_DropletNumber, make_IceNumber, make_RainNumber,
+         !  the incoming mixing ratios should be converted to units of mass/num per cubic meter
+         !  rather than per kg of air.  So, to pass back to the model state variables,
+         !  they also need to be switched back to mass/number per kg of air, because
+         !  what is returned by the functions is in units of number per cubic meter.
+
+#ifdef MAKE_NUMBER_CONCENTRATIONS
+         ! If qi is in boundary conditions but ni is not, calculate ni from qi, rho and tgrs
+         if (maxval(qi)>0.0 .and. maxval(ni)==0.0) then
+             ni = make_IceNumber(qi*rho, tgrs) * orho
+         end if
+#else
+         ! If qi is in boundary conditions but ni is not, reset qi to zero
+         if (maxval(qi)>0.0 .and. maxval(ni)==0.0) qi = 0.0
+#endif
+         ! If ni is in boundary conditions but qi is not, reset ni to zero
+         if (maxval(ni)>0.0 .and. maxval(qi)==0.0) ni = 0.0
+
+#ifdef MAKE_NUMBER_CONCENTRATIONS
+         ! If qr is in boundary conditions but nr is not, calculate nr from qr, rho and tgrs
+         if (maxval(qr)>0.0 .and. maxval(nr)==0.0) then
+             nr = make_RainNumber(qr*rho, tgrs) * orho
+         end if
+#else
+         ! If qr is in boundary conditions but nr is not, reset qr to zero
+         if (maxval(qr)>0.0 .and. maxval(nr)==0.0) qr = 0.0
+#endif
+         ! If nr is in boundary conditions but qr is not, reset nr to zero
+         if (maxval(nr)>0.0 .and. maxval(qr)==0.0) nr = 0.0
+
+         ! Return if aerosol-aware option is not used
+         if (.not. is_aerosol_aware) return
 
 !..Check for existing aerosol data, both CCN and IN aerosols.  If missing
 !.. fill in just a basic vertical profile, somewhat boundary-layer following.
@@ -221,7 +235,6 @@ module mp_thompson_hrrr_pre
                   nwfa2d(i) = nwfa(i,1) * 0.000196 * (airmass*2.E-10)
                enddo
 #else
-#if 1
                !+---+-----------------------------------------------------------------+
                !..Scale the lowest level aerosol data into an emissions rate.  This is
                !.. very far from ideal, but need higher emissions where larger amount
@@ -244,11 +257,6 @@ module mp_thompson_hrrr_pre
                   nwfa2d(i) = 10.0**(LOG10(nwfa(i,1)*1.E-6)-3.69897)
                   nwfa2d(i) = nwfa2d(i)*h_01 * 1.E6
                enddo
-#else
-               if (mpirank==mpiroot .and. blkno==1) write(*,*) ' Apparently there are no initial CCN aerosol surface emission rates, set to zero.'
-               ! calculate CCN surface flux here, right now just set to zero
-               nwfa2d = 0.
-#endif
 #endif
             else
                if (mpirank==mpiroot .and. blkno==1) write(*,*) ' Apparently initial CCN aerosol surface emission rates are present.'
@@ -284,18 +292,17 @@ module mp_thompson_hrrr_pre
             endif
          endif
 
-#ifdef DEBUG_AEROSOLS
-         if (mpirank==mpiroot) then
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp_thompson_hrrr_pre_run after: nwfa2d min/mean/max =", &
-                                 & minval(nwfa2d), sum(nwfa2d)/real(size(nwfa2d)), maxval(nwfa2d)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp_thompson_hrrr_pre_run after: nifa2d min/mean/max =", &
-                                 & minval(nifa2d), sum(nifa2d)/real(size(nifa2d)), maxval(nifa2d)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp_thompson_hrrr_pre_run after: nwfa min/mean/max =",   &
-                                 & minval(nwfa), sum(nwfa)/real(size(nwfa)), maxval(nwfa)
-             write(0,'(a,3e16.7)') "AEROSOL DEBUG mp_thompson_hrrr_pre_run after: nifa min/mean/max =",   &
-                                 & minval(nifa), sum(nifa)/real(size(nifa)), maxval(nifa)
+#ifdef MAKE_NUMBER_CONCENTRATIONS
+         ! If qc is in boundary conditions but nc is not, calculate nc from qc, rho and nwfa
+         if (maxval(qc)>0.0 .and. maxval(nc)==0.0) then
+            nc = make_DropletNumber(qc*rho, nwfa) * orho
          end if
+#else
+         ! If qc is in boundary conditions but nc is not, reset qc to zero
+         if (maxval(qc)>0.0 .and. maxval(nc)==0.0) qc = 0.0
 #endif
+         ! If nc is in boundary conditions but qc is not, reset nc to zero
+         if (maxval(nc)>0.0 .and. maxval(qc)==0.0) nc = 0.0
 
       end subroutine mp_thompson_hrrr_pre_run
 


### PR DESCRIPTION
This PR

(1) fixes a bug in mp_thompson_hrrr_pre_run that affects the tendency limiter that is applied later in mp_thompson_hrrr_post_run: The temperature before entering Thompson MP must be saved at every time step, not only at the first time step - otherwise the tendency is computed for the combination of the GF scheme, the gravity wave drag scheme, and the Thompson MP scheme

(2) adds code that computes initial number concentrations from mass concentrations, density, temperature and aerosols (from Greg Thompson) and re-arranges the logic in mp_thompson_hrrr_pre_run accordingly. Note that for the moment, this code is only used if the following CPP flag at the top of mp_thompson_hrrr_pre_run is activated (off by default):
```
#define MAKE_NUMBER_CONCENTRATIONS
```
This is to allow testing the impacts of bugfix (1) in isolation, and then adding (2).