### PR TITLE
GitHub CCPP update to VLab master 2019/04/29

### DIFF
--- a/physics/GFS_MP_generic.F90
+++ b/physics/GFS_MP_generic.F90
@@ -376,7 +376,7 @@
 !          endif
 ! compute fractional srflag
           total_precip = snow0(i)+ice0(i)+graupel0(i)+rain0(i)+rainc(i)
-          if (total_precip*tem > rainmin) then
+          if (total_precip > rainmin) then
             srflag(i) = (snow0(i)+ice0(i)+graupel0(i)+csnow)/total_precip
           endif
         enddo

--- a/physics/gfdl_cloud_microphys.F90
+++ b/physics/gfdl_cloud_microphys.F90
@@ -231,7 +231,7 @@ contains
       real(kind=kind_phys) :: onebg
       real(kind=kind_phys) :: tem
 #ifdef TRANSITION
-      real(kind=kind_phys), volatile :: volatile_var
+      real(kind=kind_phys), volatile :: volatile_var1, volatile_var2
 #endif
 
 
@@ -322,10 +322,11 @@ contains
       ! values of rain0, ice0, snow0, graupel0 (for bit-for-bit)
       do i=1,im
 #ifdef TRANSITION
-        volatile_var = rain0(i)+snow0(i)+ice0(i)+graupel0(i)
-        prcp0(i) = volatile_var * tem
-        if ( volatile_var * tem > rainmin ) then
-          sr(i) = (snow0(i) + ice0(i)  + graupel0(i)) / volatile_var
+        volatile_var1 = rain0(i)+snow0(i)+ice0(i)+graupel0(i)
+        volatile_var2 = snow0(i)+ice0(i)+graupel0(i)
+        prcp0(i) = volatile_var1 * tem
+        if ( volatile_var1 * tem > rainmin ) then
+          sr(i) = volatile_var2 / volatile_var1
 #else
         prcp0(i) = (rain0(i)+snow0(i)+ice0(i)+graupel0(i)) * tem
         if ( prcp0(i) > rainmin ) then

--- a/physics/iccninterp.F90
+++ b/physics/iccninterp.F90
@@ -223,8 +223,8 @@ contains
                ! i.e. i1 and i2 will have values determined by the
                ! previous code (line 178) - this leads to crashes in
                ! debug mode (out of bounds), for example for regression
-               ! test fv3_stretched_nest_debug_moninq. For the time
-               ! being, this is 'solved' by simply switching off ICCN
+               ! test fv3_stretched_nest_debug. For the time being,
+               ! this is 'solved' by simply switching off ICCN
                ! if MG2/3 are not used (these are the only microphysics
                ! schemes that use the ICCN data); however, this doesn't
                ! mean that the code is correct for MG2/3, it just doesn't


### PR DESCRIPTION
Update ccpp-physics to reflect changes in FV3 physics.

Changes:

physics/GFS_MP_generic.F90: update calculation of srflag according to changes in GFS_physics_driver.F90

physics/gfdl_cloud_microphs.F90: introduce second volatile variable for calculation of sr (Sfcprop%sr) to achieve b4b-identical results in PROD+TRANSITION mode

physics/iccninterp.F90: update regression test name in comment

See https://github.com/NCAR/NEMSfv3gfs/pull/146 for testing of this and associated PRs.