### PR TITLE
Changes in RUC LSM for fractional land/water/sea-ice mask.

### DIFF
--- a/physics/sfc_drv_ruc.F90
+++ b/physics/sfc_drv_ruc.F90
@@ -160,6 +160,7 @@ module lsm_ruc
 !! | con_rv          | gas_constant_water_vapor                                                     | ideal gas constant for water vapor                              | J kg-1 K-1    |    0 | real      | kind_phys | in     | F        |
 !! | con_hvap        | latent_heat_of_vaporization_of_water_at_0C                                   | latent heat of vaporization/sublimation (hvap)                  | J kg-1        |    0 | real      | kind_phys | in     | F        |
 !! | con_fvirt       | ratio_of_vapor_to_dry_air_gas_constants_minus_one                            | rv/rd - 1 (rv = ideal gas constant for water vapor)             | none          |    0 | real      | kind_phys | in     | F        |
+!! | land            | flag_nonzero_land_surface_fraction                                           | flag indicating presence of some land surface area fraction     | flag          |    1 | logical   |           | in     | F        |
 !! | rainnc          | lwe_thickness_of_explicit_rainfall_amount_from_previous_timestep             | explicit rainfall from previous timestep                        | m             |    1 | real      | kind_phys | in     | F        |
 !! | rainc           | lwe_thickness_of_convective_precipitation_amount_from_previous_timestep      | convective_precipitation_amount from previous timestep          | m             |    1 | real      | kind_phys | in     | F        |
 !! | ice             | lwe_thickness_of_ice_amount_from_previous_timestep                           | ice amount from previous timestep                               | m             |    1 | real      | kind_phys | in     | F        |
@@ -167,8 +168,8 @@ module lsm_ruc
 !! | graupel         | lwe_thickness_of_graupel_amount_from_previous_timestep                       | graupel amount from previous timestep                           | m             |    1 | real      | kind_phys | in     | F        |
 !! | srflag          | flag_for_precipitation_type                                                  | snow/rain flag for precipitation                                | flag          |    1 | real      | kind_phys | in     | F        |
 !! | sncovr1         | surface_snow_area_fraction_over_land                                         | surface snow area fraction                                      | frac          |    1 | real      | kind_phys | inout  | F        |
-!! | weasd           | water_equivalent_accumulated_snow_depth                                      | water equiv of acc snow depth over land and sea ice             | mm            |    1 | real      | kind_phys | inout  | F        |
-!! | snwdph          | surface_snow_thickness_water_equivalent                                      | water equivalent snow depth over land                           | mm            |    1 | real      | kind_phys | inout  | F        |
+!! | weasd           | water_equivalent_accumulated_snow_depth_over_land                            | water equiv of acc snow depth over land                         | mm            |    1 | real      | kind_phys | inout  | F        |
+!! | snwdph          | surface_snow_thickness_water_equivalent_over_land                            | water equivalent snow depth over land                           | mm            |    1 | real      | kind_phys | inout  | F        |
 !! | sr              | ratio_of_snowfall_to_rainfall                                                | snow ratio: ratio of snow to total precipitation                | frac          |    1 | real      | kind_phys | in     | F        |
 !! | rhosnf          | density_of_frozen_precipitation                                              | density of frozen precipitation                                 | kg m-3        |    1 | real      | kind_phys | out    | F        |
 !! | zf              | height_above_ground_at_lowest_model_layer                                    | layer 1 height above ground (not MSL)                           | m             |    1 | real      | kind_phys | in     | F        |
@@ -186,8 +187,8 @@ module lsm_ruc
 !! | wspd            | wind_speed_at_lowest_model_layer                                             | wind speed at lowest model level                                | m s-1         |    1 | real      | kind_phys | inout  | F        |
 !! | cm              | surface_drag_coefficient_for_momentum_in_air                                 | surface exchange coeff for momentum                             | none          |    1 | real      | kind_phys | in     | F        |
 !! | ch              | surface_drag_coefficient_for_heat_and_moisture_in_air                        | surface exchange coeff heat & moisture                          | none          |    1 | real      | kind_phys | in     | F        |
-!! | chh             | surface_drag_mass_flux_for_heat_and_moisture_in_air                          | surf h&m exch coef time surf wind & density                     | kg m-2 s-1    |    1 | real      | kind_phys | inout  | F        |
-!! | cmm             | surface_drag_wind_speed_for_momentum_in_air                                  | surf mom exch coef time mean surf wind                          | m s-1         |    1 | real      | kind_phys | inout  | F        |
+!! | chh             | surface_drag_mass_flux_for_heat_and_moisture_in_air_over_land                | thermal exchange coefficient over land                          | kg m-2 s-1    |    1 | real      | kind_phys | inout  | F        |
+!! | cmm             | surface_drag_wind_speed_for_momentum_in_air_over_land                        | momentum exchange coefficient over land                         | m s-1         |    1 | real      | kind_phys | inout  | F        |
 !! | wet1            | normalized_soil_wetness                                                      | normalized soil wetness                                         | frac          |    1 | real      | kind_phys | inout  | F        |
 !! | canopy          | canopy_water_amount                                                          | canopy water amount                                             | kg m-2        |    1 | real      | kind_phys | inout  | F        |
 !! | sigmaf          | vegetation_area_fraction                                                     | areal fractional cover of green vegetation                      | frac          |    1 | real      | kind_phys | in     | F        |
@@ -195,8 +196,8 @@ module lsm_ruc
 !! | alvwf           | mean_vis_albedo_with_weak_cosz_dependency                                    | mean vis albedo with weak cosz dependency                       | frac          |    1 | real      | kind_phys | in     | F        |
 !! | alnwf           | mean_nir_albedo_with_weak_cosz_dependency                                    | mean nir albedo with weak cosz dependency                       | frac          |    1 | real      | kind_phys | in     | F        |
 !! | snoalb          | upper_bound_on_max_albedo_over_deep_snow                                     | maximum snow albedo                                             | frac          |    1 | real      | kind_phys | in     | F        |
-!! | zorl            | surface_roughness_length                                                     | surface roughness length                                        | cm            |    1 | real      | kind_phys | inout  | F        |
-!! | qsurf           | surface_specific_humidity                                                    | surface air saturation specific humidity                        | kg kg-1       |    1 | real      | kind_phys | inout  | F        |
+!! | zorl            | surface_roughness_length_over_land_interstitial                              | surface roughness length over land  (temporary use as interstitial)| cm         |    1 | real      | kind_phys | inout  | F        |
+!! | qsurf           | surface_specific_humidity_over_land                                          | surface air saturation specific humidity over land              | kg kg-1       |    1 | real      | kind_phys | inout  | F        |
 !! | sfcqc           | cloud_condensed_water_mixing_ratio_at_surface                                | moist cloud water mixing ratio at surface                       | kg kg-1       |    1 | real      | kind_phys | inout  | F        |
 !! | sfcqv           | water_vapor_mixing_ratio_at_surface                                          | water vapor mixing ratio at surface                             | kg kg-1       |    1 | real      | kind_phys | inout  | F        |
 !! | sfcdew          | surface_condensation_mass                                                    | surface condensation mass                                       | kg m-2        |    1 | real      | kind_phys | inout  | F        |
@@ -217,14 +218,14 @@ module lsm_ruc
 !! | smfrkeep        | volume_fraction_of_frozen_soil_moisture_for_land_surface_model               | volume fraction of frozen soil moisture for lsm                 | frac          |    2 | real      | kind_phys | inout  | F        |
 !! | tslb            | soil_temperature_for_land_surface_model                                      | soil temperature for land surface model                         | K             |    2 | real      | kind_phys | inout  | F        |
 !! | stm             | soil_moisture_content                                                        | soil moisture content                                           | kg m-2        |    1 | real      | kind_phys | inout  | F        |
-!! | tskin           | surface_skin_temperature                                                     | surface skin temperature                                        | K             |    1 | real      | kind_phys | inout  | F        |
-!! | tsurf           | surface_skin_temperature_after_iteration                                     | surface skin temperature after iteration                        | K             |    1 | real      | kind_phys | inout  | F        |
+!! | tskin           | surface_skin_temperature_over_land_interstitial                              | surface skin temperature over land  (temporary use as interstitial)| K          |    1 | real      | kind_phys | inout  | F        |
+!! | tsurf           | surface_skin_temperature_after_iteration_over_land                           | surface skin temperature after iteration over land              | K             |    1 | real      | kind_phys | inout  | F        |
 !! | tice            | sea_ice_temperature                                                          | sea ice surface skin temperature                                | K             |    1 | real      | kind_phys | inout  | F        |
 !! | tsnow           | snow_temperature_bottom_first_layer                                          | snow temperature at the bottom of first snow layer              | K             |    1 | real      | kind_phys | inout  | F        |
 !! | snowfallac      | total_accumulated_snowfall                                                   | run-total snow accumulation on the ground                       | kg m-2        |    1 | real      | kind_phys | inout  | F        |
 !! | acsnow          | accumulated_water_equivalent_of_frozen_precip                                | snow water equivalent of run-total frozen precip                | kg m-2        |    1 | real      | kind_phys | inout  | F        |
-!! | evap            | kinematic_surface_upward_latent_heat_flux                                    | kinematic surface upward evaporation flux                       | kg kg-1 m s-1 |    1 | real      | kind_phys | out    | F        |
-!! | hflx            | kinematic_surface_upward_sensible_heat_flux                                  | kinematic surface upward sensible heat flux                     | K m s-1       |    1 | real      | kind_phys | out    | F        |
+!! | evap            | kinematic_surface_upward_latent_heat_flux_over_land                          | kinematic surface upward evaporation flux over land             | kg kg-1 m s-1 |    1 | real      | kind_phys | out    | F        |
+!! | hflx            | kinematic_surface_upward_sensible_heat_flux_over_land                        | kinematic surface upward sensible heat flux over land           | K m s-1       |    1 | real      | kind_phys | out    | F        |
 !! | evbs            | soil_upward_latent_heat_flux                                                 | soil upward latent heat flux                                    | W m-2         |    1 | real      | kind_phys | out    | F        |
 !! | evcw            | canopy_upward_latent_heat_flux                                               | canopy upward latent heat flux                                  | W m-2         |    1 | real      | kind_phys | out    | F        |
 !! | sbsno           | snow_deposition_sublimation_upward_latent_heat_flux                          | latent heat flux from snow depo/subl                            | W m-2         |    1 | real      | kind_phys | out    | F        |
@@ -233,7 +234,7 @@ module lsm_ruc
 !! | drain           | subsurface_runoff_flux                                                       | subsurface runoff flux                                          | g m-2 s-1     |    1 | real      | kind_phys | out    | F        |
 !! | runoff          | total_runoff                                                                 | total water runoff                                              | kg m-2        |    1 | real      | kind_phys | inout  | F        |
 !! | srunoff         | surface_runoff                                                               | surface water runoff (from lsm)                                 | kg m-2        |    1 | real      | kind_phys | inout  | F        |
-!! | gflux           | upward_heat_flux_in_soil                                                     | soil heat flux                                                  | W m-2         |    1 | real      | kind_phys | out    | F        |
+!! | gflux           | upward_heat_flux_in_soil_over_land                                           | soil heat flux over land                                        | W m-2         |    1 | real      | kind_phys | out    | F        |
 !! | shdmin          | minimum_vegetation_area_fraction                                             | min fractional coverage of green vegetation                     | frac          |    1 | real      | kind_phys | in     | F        |
 !! | shdmax          | maximum_vegetation_area_fraction                                             | max fractional coverage of green vegetation                     | frac          |    1 | real      | kind_phys | in     | F        |
 !! | flag_iter       | flag_for_iteration                                                           | flag for iteration                                              | flag          |    1 | logical   |           | in     | F        |
@@ -252,7 +253,7 @@ module lsm_ruc
      &       sfcemis, dlwflx, dswsfc, snet, delt, tg3, cm, ch,          &
      &       prsl1, zf, islmsk, ddvel, shdmin, shdmax, alvwf, alnwf,    &
      &       snoalb, sfalb, flag_iter, flag_guess, isot, ivegsrc, fice, &
-     &       smc, stc, slc, lsm_ruc, lsm,                               &
+     &       smc, stc, slc, lsm_ruc, lsm, land,                         &
      &       smcwlt2, smcref2, wspd, do_mynnsfclay,                     &
 ! --- constants
      &       con_cp, con_rv, con_rd, con_g, con_pi, con_hvap, con_fvirt,&
@@ -299,7 +300,7 @@ module lsm_ruc
                                             con_pi, con_rd,             &
                                             con_hvap, con_fvirt
 
-      logical, dimension(im), intent(in) :: flag_iter, flag_guess
+      logical, dimension(im), intent(in) :: flag_iter, flag_guess, land
       logical,                intent(in) :: do_mynnsfclay
 
 !  ---  in/out:
@@ -431,14 +432,14 @@ module lsm_ruc
                                zs, sh2o, smfrkeep, tslb, smois, wet1,    & ! out
                                errmsg, errflg)
 
-        do i  = 1, im ! n - horizontal loop
+        !do i  = 1, im ! n - horizontal loop
           ! overwrite Noah soil fields with initialized RUC soil fields for output
-          do k = 1, lsoil
-            smc(i,k)   = smois(i,k)
-            slc(i,k)   = sh2o(i,k)
-            stc(i,k)   = tslb(i,k)
-          enddo
-        enddo ! i
+          !do k = 1, lsoil
+          !  smc(i,k)   = smois(i,k)
+          !  slc(i,k)   = sh2o(i,k)
+          !  stc(i,k)   = tslb(i,k)
+          !enddo
+        !enddo ! i
 
       endif ! flag_init=.true.,iter=1
 !-- end of initialization
@@ -489,7 +490,7 @@ module lsm_ruc
 
       do i  = 1, im ! i - horizontal loop
         ! reassign smcref2 and smcwlt2 to RUC values
-        if(islmsk(i) == 0 .or. islmsk(i) == 2) then
+        if(.not. land(i)) then
           !water and sea ice
           smcref2 (i) = 1.
           smcwlt2 (i) = 0.
@@ -502,7 +503,8 @@ module lsm_ruc
 
       do i  = 1, im ! i - horizontal loop
         !> - Set flag for land and ice points.
-        flag(i) = (islmsk(i) == 1 .or. islmsk(i) == 2)
+        !- 10may19 - ice points are turned off.
+        flag(i) = land(i)
       enddo
 
       do i  = 1, im ! i - horizontal loop
@@ -700,6 +702,13 @@ module lsm_ruc
         if(ivegsrc == 1) then   ! IGBP - MODIS
         !> - Prepare land/ice/water masks for RUC LSM
         !SLMSK0   - SEA(0),LAND(1),ICE(2) MASK
+         IF (LAND(I)) then 
+         ! when LAND fraction is .true.
+            vtype(i,j) = vegtype(i)
+            stype(i,j) = soiltyp(i)
+            xland(i,j) = 1.
+            xice(i,j)  = 0.
+         ELSE
           if(islmsk(i) == 0.) then
             vtype(i,j) = 17 ! 17 - water (oceans and lakes) in MODIS
             stype(i,j) = 14
@@ -720,6 +729,7 @@ module lsm_ruc
             xland(i,j) = 1.
             xice(i,j) = fice(i)  ! fraction of sea-ice
           endif
+         ENDIF ! land=.true.
         else
           print *,'MODIS landuse is not available'
         endif
@@ -1068,11 +1078,11 @@ module lsm_ruc
           smfrkeep(i,k) = smfrsoil(i,k,j)
         enddo
 
-        do k = 1, lsoil
-          smc(i,k)   = smsoil(i,k,j)
-          slc(i,k)   = slsoil(i,k,j)
-          stc(i,k)   = stsoil(i,k,j)
-        enddo
+        !do k = 1, lsoil
+        !  smc(i,k)   = smsoil(i,k,j)
+        !  slc(i,k)   = slsoil(i,k,j)
+        !  stc(i,k)   = stsoil(i,k,j)
+        !enddo
 
 !  --- ...  do not return the following output fields to parent model
 !    ec      - canopy water evaporation (m s-1)


### PR DESCRIPTION
For this initial implementation of fractional land mask, RUC LSM will be called
only for land points. Sea ice points will be covered with the call to sfc_sice.
Also, this commit removes sending top 4 levels of RUC soil variables to the 4-layer Noah variables.
This was done on the early stages of RUC LSM implementation to see RUC soil variables in the model output.