### PR TITLE
Further code cleanup for SCM and FV3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,8 +164,8 @@ elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
     # Force consistent results of math calculations for MG microphysics;
     # in Debug/Bitforbit mode; without this flag, the results of the
     # intrinsic gamma function are different for the non-CCPP and CCPP
-    # version (on Theia with Intel 18). Note this is only required with
-    # dynamic CCPP builds (hybrid, standalone), not with static CCPP builds.
+    # version (on Theia with Intel 18). Note this is only required for
+    # the dynamic CCPP build, not for the static CCPP build.
     if (TRANSITION)
       # Replace -xHost or -xCORE-AVX2 with -xCORE-AVX-I, -no-prec-div with -prec-div, and
       # -no-prec-sqrt with -prec-sqrt for certain files for bit-for-bit reproducibility

--- a/physics/cu_gf_deep.F90
+++ b/physics/cu_gf_deep.F90
@@ -3211,19 +3211,20 @@ endif
         do i=its,itf
          aa0(i)=0.
         enddo
-        do 100 k=kts+1,ktf
-        do 100 i=its,itf
-         if(ierr(i).ne.0)go to 100
-         if(k.lt.kbcon(i))go to 100
-         if(k.gt.ktop(i))go to 100
-         dz=z(i,k)-z(i,k-1)
-         da=zu(i,k)*dz*(9.81/(1004.*( &
-                (t_cup(i,k)))))*dby(i,k-1)/ &
-             (1.+gamma_cup(i,k))
-!         if(k.eq.ktop(i).and.da.le.0.)go to 100
-         aa0(i)=aa0(i)+max(0.,da)
-         if(aa0(i).lt.0.)aa0(i)=0.
-100     continue
+        do k=kts+1,ktf
+          do i=its,itf
+           if(ierr(i).ne.0) exit
+           if(k.lt.kbcon(i)) exit
+           if(k.gt.ktop(i)) exit
+           dz=z(i,k)-z(i,k-1)
+           da=zu(i,k)*dz*(9.81/(1004.*( &
+                  (t_cup(i,k)))))*dby(i,k-1)/ &
+               (1.+gamma_cup(i,k))
+  !         if(k.eq.ktop(i).and.da.le.0.)go to 100
+           aa0(i)=aa0(i)+max(0.,da)
+           if(aa0(i).lt.0.)aa0(i)=0.
+          enddo
+        enddo
 
    end subroutine cup_up_aa0
 
@@ -4356,16 +4357,18 @@ endif
         do i=its,itf
          aa0(i)=0.
         enddo
-        do 100 i=its,itf
-        do 100 k=kts,kbcon(i)
-        if(ierr(i).ne.0 )go to 100
-!        if(k.gt.kbcon(i))go to 100
+        do i=its,itf
+          do k=kts,kbcon(i)
+            if(ierr(i).ne.0 ) exit
+!           if(k.gt.kbcon(i)) exit
 
-          dz = (z_cup (i,k+1)-z_cup (i,k))*g
-          da = dz*(tn(i,k)*(1.+0.608*qo(i,k))-t(i,k)*(1.+0.608*q(i,k)))/dtime
+            dz = (z_cup (i,k+1)-z_cup (i,k))*g
+            da = dz*(tn(i,k)*(1.+0.608*qo(i,k))-t(i,k)*(1.+0.608*q(i,k)))/dtime
 
-         aa0(i)=aa0(i)+da
-100     continue
+            aa0(i)=aa0(i)+da
+          enddo
+        enddo
+             
 
  end subroutine cup_up_aa1bl
 !---------------------------------------------------------------------- 

--- a/physics/cu_gf_driver.F90
+++ b/physics/cu_gf_driver.F90
@@ -33,7 +33,11 @@ contains
          integer,                   intent(in)    :: mpiroot
          character(len=*),          intent(  out) :: errmsg
          integer,                   intent(  out) :: errflg
-
+         
+         ! initialize ccpp error handling variables
+         errmsg = ''
+         errflg = 0
+         
          ! DH* temporary
          if (mpirank==mpiroot) then
             write(0,*) ' -----------------------------------------------------------------------------------------------------------------------------'

--- a/physics/cu_ntiedtke.F90
+++ b/physics/cu_ntiedtke.F90
@@ -119,7 +119,11 @@ contains
          integer,                   intent(in)    :: mpiroot
          character(len=*),          intent(  out) :: errmsg
          integer,                   intent(  out) :: errflg
-
+         
+         ! initialize ccpp error handling variables
+         errmsg = ''
+         errflg = 0
+         
          ! DH* temporary
          if (mpirank==mpiroot) then
             write(0,*) ' -----------------------------------------------------------------------------------------------------------------------------'

--- a/physics/micro_mg3_0.F90
+++ b/physics/micro_mg3_0.F90
@@ -2979,7 +2979,7 @@ subroutine micro_mg_tend (                                       &
 !               (nnucct(i,k)+tmpfrz+nnudep(i,k)+nsacwi(i,k))*lcldm(i,k)+(nsubi(i,k)-nprci(i,k)- &
 !               nprai(i,k))*icldm(i,k)+nnuccri(i,k)*precip_frac(i,k)
 
-          nitend(i,k) = nitend(i,k) + nnuccd(i,k) +                                   &
+          nitend(i,k) = nitend(i,k) + nnuccd(i,k)                                     &
                +  (nnucct(i,k)+tmpfrz+nnudep(i,k)+nsacwi(i,k)+nmultg(i,k))*lcldm(i,k) &
                + (nsubi(i,k)-nprci(i,k)-nprai(i,k))*icldm(i,k)                        &
                + (nnuccri(i,k)+nmultrg(i,k))*precip_frac(i,k)

--- a/physics/micro_mg3_0.F90
+++ b/physics/micro_mg3_0.F90
@@ -2426,11 +2426,13 @@ subroutine micro_mg_tend (                                       &
         if (do_cldice) then
 
            ! freezing of rain to produce ice if mean rain size is smaller than Dcs
-           if (lamr(i,k) > qsmall .and. one/lamr(i,k) < Dcs) then
-              mnuccri(i,k) = mnuccr(i,k)
-              nnuccri(i,k) = nnuccr(i,k)
-              mnuccr(i,k)  = zero 
-              nnuccr(i,k)  = zero
+           if (lamr(i,k) > qsmall) then
+             if(one/lamr(i,k) < Dcs) then
+                mnuccri(i,k) = mnuccr(i,k)
+                nnuccri(i,k) = nnuccr(i,k)
+                mnuccr(i,k)  = zero 
+                nnuccr(i,k)  = zero
+             end if
            end if
         end if
 

--- a/physics/module_gfdl_cloud_microphys.F90
+++ b/physics/module_gfdl_cloud_microphys.F90
@@ -684,7 +684,16 @@ subroutine mpdrv (hydrostatic, uin, vin, w, delp, pt, qv, ql, qr, qi, qs,     &
     ! -----------------------------------------------------------------------
     ! use local variables
     ! -----------------------------------------------------------------------
-
+    
+    !GJF: assign values to intent(out) variables that are commented out
+    w_var = 0.0
+    vt_r = 0.0
+    vt_s = 0.0
+    vt_g = 0.0
+    vt_i = 0.0
+    qn2 = 0.0
+    !GJF
+    
     do i = is, ie
 
         do k = ktop, kbot

--- a/physics/module_mp_thompson.F90
+++ b/physics/module_mp_thompson.F90
@@ -50,7 +50,7 @@ MODULE module_mp_thompson
 
       USE module_mp_radar
 
-#ifndef SION
+#if !defined(SION) && defined(MPI)
       use mpi
 #endif
 

--- a/physics/module_sf_ruclsm.F90
+++ b/physics/module_sf_ruclsm.F90
@@ -5859,7 +5859,7 @@ print *, 'D9SN,SOILT,TSOB : ', D9SN,SOILT,TSOB
         COSMC(1)=0.
         RHSMC(1)=SOILMOIS(NZS)
 !
-        DO 330 K=1,NZS2
+        DO K=1,NZS2
           KN=NZS-K
           K1=2*KN-3
           X4=2.*DTDZS(K1)*DIFFU(KN-1)
@@ -5872,10 +5872,11 @@ print *, 'D9SN,SOILT,TSOB : ', D9SN,SOILT,TSOB
           print *,'q2,soilmois(kn),DIFFU(KN),x2,HYDRO(KN+1),DTDZS2(KN-1),kn,k' &
                   ,q2,soilmois(kn),DIFFU(KN),x2,HYDRO(KN+1),DTDZS2(KN-1),kn,k
     ENDIF
- 330      RHSMC(K+1)=(SOILMOIS(KN)+Q2*RHSMC(K)                            &
+          RHSMC(K+1)=(SOILMOIS(KN)+Q2*RHSMC(K)                            &
                    +TRANSP(KN)                                            &
                    /(ZSHALF(KN+1)-ZSHALF(KN))                             &
                    *DELT)/DENOM
+        ENDDO
 
 ! --- MOISTURE BALANCE BEGINS HERE
 

--- a/physics/mp_thompson_post.F90
+++ b/physics/mp_thompson_post.F90
@@ -185,7 +185,11 @@ contains
       ! CCPP error handling
       character(len=*),          intent(  out) :: errmsg
       integer,                   intent(  out) :: errflg
-
+      
+      ! initialize ccpp error handling variables
+      errmsg = ''
+      errflg = 0
+      
       ! Check initialization state
       if (.not. is_initialized) return
 

--- a/physics/satmedmfvdif.F
+++ b/physics/satmedmfvdif.F
@@ -139,7 +139,7 @@
      &                     dtsfc(im),     dqsfc(im),
      &                     hpbl(im) 
 !
-      logical, intent(out)  :: dspheat
+      logical, intent(in)  :: dspheat
       character(len=*), intent(out) :: errmsg
       integer,          intent(out) :: errflg
 

--- a/physics/sfcsub.F
+++ b/physics/sfcsub.F
@@ -2697,7 +2697,7 @@
       real (kind=kind_io8), allocatable :: data8(:)
       real (kind=kind_io4), allocatable :: data4(:)
 !
-      logical, allocatable :: lbms(:)
+      logical*1, allocatable :: lbms(:)
 !
       integer kpds(200),kgds(200)
       integer jpds(200),jgds(200), kpds0(200)
@@ -8150,7 +8150,7 @@ cjfe
       real (kind=kind_io8), allocatable :: rlngrb(:), rltgrb(:)
 !
       logical lmask, yr2kc, gaus, ijordr
-      logical, allocatable :: lbms(:)
+      logical*1, allocatable :: lbms(:)
 !
       integer, intent(in) :: kpds7
       integer kpds(1000),kgds(1000)


### PR DESCRIPTION
These changes clean up the following:
 - Fortran 2018 deleted feature warnings in GNU 9.1 for cu_gf_deep.F90 and module_sf_ruclsm.F90 (Fortran 77 shared do loop endings and do loop ending that is neither continue or end do)
 - Uninitialized intent(out) variable warnings in Intel 18: cu_gf_driver.F90, cu_ntiedtke.F90, module_gfdl_cloud_microphys.F90, mp_thompson_post.F90, satmedmfvdif.F
 - division by zero in an if test and an extraneous operator (+) in micro_mg3_0.F90
 - different logical argument types in sfcsub.F
 - remove comment about HYBRID CCPP mode (see https://github.com/NCAR/NEMSfv3gfs/pull/162 for a description)

These need to be put through regression tests in FV3, which will be done as part of @climbfuji work to remove the hybrid build.

These changes also form a subset of the branch ccpp_release_3_work that is required to work with the SCM.

