### PR TITLE
Unified Gravity Wave Physics (UGWP) - DO NOT MERGE

### DIFF
--- a/physics/GFS_GWD_generic.F90
+++ b/physics/GFS_GWD_generic.F90
@@ -1,0 +1,1584 @@
+!> \file GFS_GWD_generic_pre.F90
+!! This file is the  parameterization of orographic gravity wave
+!! drag and mountain blocking.
+
+!> This module contains the CCPP-compliant orographic gravity wave 
+!! drag pre interstitial codes.
+      module GFS_GWD_generic_pre
+
+      contains
+
+!> \section arg_table_GFS_GWD_generic_pre_init Argument Table
+!!
+      subroutine GFS_GWD_generic_pre_init()
+      end subroutine GFS_GWD_generic_pre_init
+
+!! \section arg_table_GFS_GWD_generic_pre_run Argument Table
+!! | local_name     | standard_name                                                           | long_name                                                                                | units   | rank | type      | kind      | intent | optional |
+!! |----------------|-------------------------------------------------------------------------|------------------------------------------------------------------------------------------|---------|------|-----------|-----------|--------|----------|
+!! | im             | horizontal_loop_extent                                                  | horizontal dimension                                                                     | count   |    0 | integer   |           | in     | F        |
+!! | levs           | vertical_dimension                                                      | vertical layer dimension                                                                 | count   |    0 | integer   |           | in     | F        |
+!! | nmtvr          | number_of_statistical_measures_of_subgrid_orography                     | number of statistical measures of subgrid orography                                      | count   |    0 | integer   |           | in     | F        |
+!! | mntvar         | statistical_measures_of_subgrid_orography                               | array of statistical measures of subgrid orography                                       | various |    2 | real      | kind_phys | in     | F        |
+!! | hprime         | standard_deviation_of_subgrid_orography                                 | standard deviation of subgrid orography                                                  | m       |    1 | real      | kind_phys | out    | F        |
+!! | oc             | convexity_of_subgrid_orography                                          | convexity of subgrid orography                                                           | none    |    1 | real      | kind_phys | out    | F        |
+!! | oa4            | asymmetry_of_subgrid_orography                                          | asymmetry of subgrid orography                                                           | none    |    2 | real      | kind_phys | out    | F        |
+!! | clx            | fraction_of_grid_box_with_subgrid_orography_higher_than_critical_height | horizontal fraction of grid box covered by subgrid orography higher than critical height | frac    |    2 | real      | kind_phys | out    | F        |
+!! | theta          | angle_from_east_of_maximum_subgrid_orographic_variations                | angle with_respect to east of maximum subgrid orographic variations                      | degrees |    1 | real      | kind_phys | out    | F        |
+!! | sigma          | slope_of_subgrid_orography                                              | slope of subgrid orography                                                               | none    |    1 | real      | kind_phys | out    | F        |
+!! | gamma          | anisotropy_of_subgrid_orography                                         | anisotropy of subgrid orography                                                          | none    |    1 | real      | kind_phys | out    | F        |
+!! | elvmax         | maximum_subgrid_orography                                               | maximum of subgrid orography                                                             | m       |    1 | real      | kind_phys | out    | F        |
+!! | lssav          | flag_diagnostics                                                        | logical flag for storing diagnostics                                                     | flag    |    0 | logical   |           | in     | F        |
+!! | ldiag3d        | flag_diagnostics_3D                                                     | flag for 3d diagnostic fields                                                            | flag    |    0 | logical   |           | in     | F        |
+!! | dtdt           | tendency_of_air_temperature_due_to_model_physics                        | updated tendency of the temperature                                                      | K s-1   |    2 | real      | kind_phys | in     | F        |
+!! | dt3dt          | cumulative_change_in_temperature_due_to_orographic_gravity_wave_drag    | cumulative change in temperature due to orographic gravity wave drag                     | K       |    2 | real      | kind_phys | inout  | F        |
+!! | dtf            | time_step_for_dynamics                                                  | dynamics timestep                                                                        | s       |    0 | real      | kind_phys | in     | F        |
+!! | do_congwd      | do_congwd_flag                                                          | flag for turning off convective gwd if use UGWP                                          | flag    |    0 | logical   |           | none   | F        |
+!! | cnvgwd         | flag_convective_gravity_wave_drag                                       | flag for conv gravity wave drag                                                          | flag    |    0 | logical   |           | none   | F        |
+!! | errmsg         | ccpp_error_message                                                      | error message for error handling in CCPP                                                 | none    |    0 | character | len=*     | out    | F        |
+!! | errflg         | ccpp_error_flag                                                         | error flag for error handling in CCPP                                                    | flag    |    0 | integer   |           | out    | F        |
+!!
+!!  \section general General Algorithm
+!!  \section detailed Detailed Algorithm
+!!  @{
+      subroutine GFS_GWD_generic_pre_run(                               &
+                im, levs, nmtvr, mntvar,                                &
+                hprime, oc, oa4, clx, theta,                            &
+                 sigma, gamma, elvmax, lssav, ldiag3d,                  &
+                 dtdt, dt3dt, dtf,                                      &
+                 do_congwd, cnvgwd, errmsg, errflg)
+
+      use machine,       only: kind_phys
+      implicit none
+
+      integer, intent(in) :: im, levs, nmtvr
+      real(kind=kind_phys), intent(in) :: mntvar(im,nmtvr)
+
+      real(kind=kind_phys), intent(out) ::                              &
+        hprime(im), oc(im), oa4(im,4), clx(im,4),                       &
+        theta(im), sigma(im), gamma(im), elvmax(im)                     
+
+      logical, intent(in) :: lssav, ldiag3d, do_congwd, cnvgwd
+      real(kind=kind_phys), intent(in) :: dtdt(im,levs)
+      real(kind=kind_phys), intent(inout) :: dt3dt(im,levs)
+      real(kind=kind_phys), intent(in) :: dtf
+
+      character(len=*), intent(out) :: errmsg
+      integer,          intent(out) :: errflg
+
+      integer :: i, k
+
+      ! Initialize CCPP error handling variables
+      errmsg = ''
+      errflg = 0
+
+      IF (cnvgwd .and. do_congwd) THEN
+
+
+      if (nmtvr == 14) then  ! current operational - as of 2014
+        hprime(:) = mntvar(:,1)
+        oc(:)     = mntvar(:,2)
+        oa4(:,1)  = mntvar(:,3)
+        oa4(:,2)  = mntvar(:,4)
+        oa4(:,3)  = mntvar(:,5)
+        oa4(:,4)  = mntvar(:,6)
+        clx(:,1)  = mntvar(:,7)
+        clx(:,2)  = mntvar(:,8)
+        clx(:,3)  = mntvar(:,9)
+        clx(:,4)  = mntvar(:,10)
+        theta(:)  = mntvar(:,11)
+        gamma(:)  = mntvar(:,12)
+        sigma(:)  = mntvar(:,13)
+        elvmax(:) = mntvar(:,14)
+      elseif (nmtvr == 10) then
+        hprime(:) = mntvar(:,1)
+        oc(:)     = mntvar(:,2)
+        oa4(:,1)  = mntvar(:,3)
+        oa4(:,2)  = mntvar(:,4)
+        oa4(:,3)  = mntvar(:,5)
+        oa4(:,4)  = mntvar(:,6)
+        clx(:,1)  = mntvar(:,7)
+        clx(:,2)  = mntvar(:,8)
+        clx(:,3)  = mntvar(:,9)
+        clx(:,4)  = mntvar(:,10)
+      elseif (nmtvr == 6) then
+        hprime(:) = mntvar(:,1)
+        oc(:)     = mntvar(:,2)
+        oa4(:,1)  = mntvar(:,3)
+        oa4(:,2)  = mntvar(:,4)
+        oa4(:,3)  = mntvar(:,5)
+        oa4(:,4)  = mntvar(:,6)
+        clx(:,1)  = 0.0
+        clx(:,2)  = 0.0
+        clx(:,3)  = 0.0
+        clx(:,4)  = 0.0
+      else
+        hprime = 0
+        oc = 0
+        oa4 = 0
+        clx = 0
+        theta = 0
+        gamma = 0
+        sigma = 0
+        elvmax = 0
+      endif   ! end if_nmtvr
+
+      if (lssav) then
+        if (ldiag3d) then
+          do k=1,levs
+            do i=1,im
+              dt3dt(i,k) = dt3dt(i,k) - dtdt(i,k)*dtf
+            enddo
+          enddo
+        endif
+      endif
+
+      ENDIF ! do_congwd & cnvgwd
+
+      end subroutine GFS_GWD_generic_pre_run
+!> @}
+
+! \ingroup GFS_ogwd
+! \brief Brief description of the subroutine
+!
+!> \section arg_table_GFS_GWD_generic_pre_finalize Argument Table
+!!
+      subroutine GFS_GWD_generic_pre_finalize()
+      end subroutine GFS_GWD_generic_pre_finalize
+
+      end module GFS_GWD_generic_pre
+
+!> This module contains the CCPP-compliant orographic gravity wave dray scheme.
+      module GFS_GWD_generic
+
+      contains
+
+!> \section arg_table_GFS_GWD_generic_init Argument Table
+!!
+      subroutine GFS_GWD_generic_init()
+      end subroutine GFS_GWD_generic_init
+
+! \defgroup GFS_ogwd GFS Orographic Gravity Wave Drag
+!> \defgroup gfs_gwdps GFS gwdps Main
+!! \brief This subroutine includes orographic gravity wave drag and mountain
+!! blocking.
+!!
+!> The time tendencies of zonal and meridional wind are altered to
+!! include the effect of mountain induced gravity wave drag from
+!! subgrid scale orography including convective breaking, shear
+!! breaking and the presence of critical levels.
+!!
+!! \section arg_table_GFS_GWD_generic_run Argument Table
+!! | local_name     | standard_name                                                                 | long_name                                                                                                | units      | rank | type      | kind      | intent | optional |
+!! |----------------|-------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|------------|------|-----------|-----------|--------|----------|
+!! | im             | horizontal_loop_extent                                                        | horizontal loop extent                                                                                   | count      |    0 | integer   |           | in     | F        |
+!! | ix             | horizontal_dimension                                                          | horizontal dimension                                                                                     | count      |    0 | integer   |           | in     | F        |
+!! | km             | vertical_dimension                                                            | number of vertical layers                                                                                | count      |    0 | integer   |           | in     | F        |
+!! | A              | tendency_of_y_wind_due_to_model_physics                                       | meridional wind tendency due to model physics                                                            | m s-2      |    2 | real      | kind_phys | inout  | F        |
+!! | B              | tendency_of_x_wind_due_to_model_physics                                       | zonal wind tendency due to model physics                                                                 | m s-2      |    2 | real      | kind_phys | inout  | F        |
+!! | C              | tendency_of_air_temperature_due_to_model_physics                              | air temperature tendency due to model physics                                                            | K s-1      |    2 | real      | kind_phys | inout  | F        |
+!! | u1             | x_wind                                                                        | zonal wind                                                                                               | m s-1      |    2 | real      | kind_phys | in     | F        |
+!! | v1             | y_wind                                                                        | meridional wind                                                                                          | m s-1      |    2 | real      | kind_phys | in     | F        |
+!! | t1             | air_temperature                                                               | mid-layer temperature                                                                                    | K          |    2 | real      | kind_phys | in     | F        |
+!! | q1             | water_vapor_specific_humidity                                                 | mid-layer specific humidity of water vapor                                                               | kg kg-1    |    2 | real      | kind_phys | in     | F        |
+!! | kpbl           | vertical_index_at_top_of_atmosphere_boundary_layer                            | vertical index at top atmospheric boundary layer                                                         | index      |    1 | integer   |           | in     | F        |
+!! | prsi           | air_pressure_at_interface                                                     | interface pressure                                                                                       | Pa         |    2 | real      | kind_phys | in     | F        |
+!! | del            | air_pressure_difference_between_midlayers                                     | difference between mid-layer pressures                                                                   | Pa         |    2 | real      | kind_phys | in     | F        |
+!! | prsl           | air_pressure                                                                  | mid-layer pressure                                                                                       | Pa         |    2 | real      | kind_phys | in     | F        |
+!! | prslk          | dimensionless_exner_function_at_model_layers                                  | mid-layer Exner function                                                                                 | none       |    2 | real      | kind_phys | in     | F        |
+!! | phii           | geopotential_at_interface                                                     | interface geopotential                                                                                   | m2 s-2     |    2 | real      | kind_phys | in     | F        |
+!! | phil           | geopotential                                                                  | mid-layer geopotential                                                                                   | m2 s-2     |    2 | real      | kind_phys | in     | F        |
+!! | deltim         | time_step_for_physics                                                         | physics time step                                                                                        | s          |    0 | real      | kind_phys | in     | F        |
+!! | kdt            | index_of_time_step                                                            | current time step index                                                                                  | index      |    0 | integer   |           | in     | F        |
+!! | hprime         | standard_deviation_of_subgrid_orography                                       | standard deviation of subgrid orography                                                                  | m          |    1 | real      | kind_phys | in     | F        |
+!! | oc             | convexity_of_subgrid_orography                                                | convexity of subgrid orography                                                                           | none       |    1 | real      | kind_phys | in     | F        |
+!! | oa4            | asymmetry_of_subgrid_orography                                                | asymmetry of subgrid orography                                                                           | none       |    2 | real      | kind_phys | in     | F        |
+!! | clx4           | fraction_of_grid_box_with_subgrid_orography_higher_than_critical_height       | horizontal fraction of grid box covered by subgrid orography higher than critical height                 | frac       |    2 | real      | kind_phys | in     | F        |
+!! | theta          | angle_from_east_of_maximum_subgrid_orographic_variations                      | angle with respect to east of maximum subgrid orographic variations                                      | degrees    |    1 | real      | kind_phys | in     | F        |
+!! | sigma          | slope_of_subgrid_orography                                                    | slope of subgrid orography                                                                               | none       |    1 | real      | kind_phys | in     | F        |
+!! | gamma          | anisotropy_of_subgrid_orography                                               | anisotropy of subgrid orography                                                                          | none       |    1 | real      | kind_phys | in     | F        |
+!! | elvmax         | maximum_subgrid_orography                                                     | maximum of subgrid orography                                                                             | m          |    1 | real      | kind_phys | inout  | F        |
+!! | dusfc          | instantaneous_x_stress_due_to_gravity_wave_drag                               | zonal surface stress due to orographic gravity wave drag                                                 | Pa         |    1 | real      | kind_phys | out    | F        |
+!! | dvsfc          | instantaneous_y_stress_due_to_gravity_wave_drag                               | meridional surface stress due to orographic gravity wave drag                                            | Pa         |    1 | real      | kind_phys | out    | F        |
+!! | g              | gravitational_acceleration                                                    | gravitational acceleration                                                                               | m s-2      |    0 | real      | kind_phys | in     | F        |
+!! | cp             | specific_heat_of_dry_air_at_constant_pressure                                 | specific heat of dry air at constant pressure                                                            | J kg-1 K-1 |    0 | real      | kind_phys | in     | F        |
+!! | rd             | gas_constant_dry_air                                                          | ideal gas constant for dry air                                                                           | J kg-1 K-1 |    0 | real      | kind_phys | in     | F        |
+!! | rv             | gas_constant_water_vapor                                                      | ideal gas constant for water vapor                                                                       | J kg-1 K-1 |    0 | real      | kind_phys | in     | F        |
+!! | imx            | number_of_equatorial_longitude_points                                         | number of longitude points along the equator                                                             | count      |    0 | integer   |           | in     | F        |
+!! | nmtvr          | number_of_statistical_measures_of_subgrid_orography                           | number of statistical measures of subgrid orography                                                      | count      |    0 | integer   |           | in     | F        |
+!! | cdmbgwd        | multiplication_factors_for_mountain_blocking_and_orographic_gravity_wave_drag | multiplic. factors for (1) mountain blocking drag coeff. and (2) ref. level orographic gravity wave drag | none       |    1 | real      | kind_phys | in     | F        |
+!! | me             | mpi_rank                                                                      | rank of the current MPI task                                                                             | index      |    0 | integer   |           | in     | F        |
+!! | lprnt          | flag_print                                                                    | flag for debugging printouts                                                                             | flag       |    0 | logical   |           | in     | F        |
+!! | ipr            | horizontal_index_of_printed_column                                            | horizontal index of column used in debugging printouts                                                   | index      |    0 | integer   |           | in     | F        |
+!! | rdxzb          | level_of_dividing_streamline                                                  | level of the dividing streamline                                                                         | none       |    1 | real      | kind_phys | out    | F        |
+!! | do_congwd      | do_congwd_flag                                                                | flag for turning off convective gwd if use UGWP                                                          | flag       |    0 | logical   |           | none   | F        |
+!! | cnvgwd         | flag_convective_gravity_wave_drag                                             | flag for conv gravity wave drag                                                                          | flag       |    0 | logical   |           | none   | F        |
+!! | errmsg         | ccpp_error_message                                                            | error message for error handling in CCPP                                                                 | none       |    0 | character | len=*     | out    | F        |
+!! | errflg         | ccpp_error_flag                                                               | error flag for error handling in CCPP                                                                    | flag       |    0 | integer   |           | out    | F        |
+!!
+!> \section gen_gwdps GFS Orographic GWD Scheme General Algorithm
+!! -# Calculate subgrid mountain blocking
+!! -# Calculate orographic wave drag
+!!
+!! The NWP model gravity wave drag (GWD) scheme in the GFS has two
+!! main components: how the surface stress is computed, and then how
+!! that stress is distributed over a vertical column where it may
+!! interact with the models momentum.  Each of these depends on the
+!! large scale environmental atmospheric state and assumptions about
+!! the sub-grid scale processes.  In Alpert GWD (1987) based on linear,
+!! two-dimensional non-rotating, stably stratified flow over a mountain ridge,
+!! sub-grid scale gravity wave motions are assumed which propagate away
+!! from the mountain.  Described in Alpert (1987), the flux measured over
+!! a "low level" vertically averaged layer, in the atmosphere defines a base
+!! level flux.  "Low level" was taken to be the first 1/3 of the troposphere
+!! in the 1987 implementation.  This choice was meant to encompass a thick
+!! low layer for vertical averages of the environmental (large scale) flow
+!! quantities.  The vertical momentum flux or gravity wave stress in a
+!! grid box due to a single mountain is given as in Pierrehumbert, (1987) (PH):
+!!
+!! \f$ \tau =  \frac {\rho \: U^{3}\: G(F_{r})} {\Delta X \; N } \f$
+!!
+!! emetic \f$ \Delta X \f$ is a grid increment, N is the Brunt Viasala frequency
+!!
+!!
+!! \f$ N(\sigma) = \frac{-g \: \sigma \:
+!!  \frac{\partial\Theta}{\partial\sigma}}{\Theta \:R \:T} \f$
+!!
+!! The environmental variables are calculated from a mass weighted vertical
+!! average over a base layer.  G(Fr) is a monotonically increasing
+!! function of Froude number,
+!!
+!! \f$ F_{r} = \frac{N h^{'}}{U} \f$
+!!
+!! where U is the wind speed calculated as a mass weighted vertical average in
+!! the base layer, and  h', is the vertical displacement caused by the orography
+!! variance.  An effective mountain length for the gravity wave processes,
+!!
+!! \f$ l^{*} =  \frac{\Delta X}{m} \f$
+!!
+!! where m is the number of mountains in a grid box, can then
+!! be defined to obtain the form of the base level stress
+!!
+!!
+!! \f$ \tau =  \frac {\rho \: U^{3} \: G(F_{r})} {N \;l^{*}} \f$
+!!
+!! giving the stress induced from the surface in a model grid box.
+!!   PH gives the form for the function G(Fr) as
+!!
+!!
+!! \f$ G(F_{r}) = \bar{G}\frac{F^{2}_{r}}{F^{2}_{r}\: + \:a^{2}} \f$
+!!
+!! Where \f$ \bar{G}  \f$  is an order unity non-dimensional saturation
+!! flux set to 1  and 'a' is a function of the mountain aspect ratio also
+!!set to 1 in the 1987 implementation of the GFS GWD.  Typical values of
+!! U=10m/s, N=0.01 1/s, l*=100km, and a=1, gives a flux of 1 Pascal and
+!! if this flux is made to go to zero linearly with height then the
+!! decelerations would be about 10/m/s/day which is consistent with
+!! observations in PH.
+!!
+!!
+!! In Kim, Moorthi, Alpert's (1998, 2001) GWD currently in GFS operations,
+!! the GWD scheme has the same physical basis as in Alpert (1987) with the addition
+!! of enhancement factors for the amplitude, G, and mountain shape details
+!! in G(Fr) to account for effects from the mountain blocking.  A factor,
+!! E m’, is an enhancement factor on the stress in the Alpert '87 scheme.
+!!  The E ranges from no enhancement to an upper limit of 3, E=E(OA)[1-3],
+!!  and is a function of OA, the Orographic Asymmetry defined in KA (1995) as
+!!
+!! Orographic Asymmetry (OA) = \f$  \frac{ \bar{x} \; - \;
+!!  \sum\limits_{j=1}^{N_{b}} x_{j} \; n_{j} }{\sigma_{x}} \f$
+!!
+!! where Nb is the total number of bottom blocks in the mountain barrier,
+!! \f$ \sigma_{x} \f$ is the standard deviation of the horizontal distance defined by
+!!
+!! \f$ \sigma_{x} = \sqrt{ \frac{\sum\limits_{j=1}^{N_{b}}
+!! \; (x_{j} \; - \; \bar{x} )^2}{N_{x}} } \f$
+!!
+!!
+!! where Nx is the number of grid intervals for the large scale domain being
+!! considered. So the term, E(OA)m’/  \f$ \Delta X \f$ in Kim's scheme represents
+!! a multiplier on G shown in Alpert's eq (1), where m’ is the number of mountains
+!! in a sub-grid scale box. Kim increased the complexity of m’ making it a
+!! function of the fractional area of the sub-grid mountain and the asymmetry
+!! and convexity statistics which are found from running a gravity wave
+!!  model for a large number of cases:
+!!
+!! \f$ m^{'} = C_{m} \Delta X \left[  \frac{1 \; + \;
+!!  \sum\limits_{x} L_{h} }{\Delta X}  \right]^{OA+1}   \f$
+!!
+!! Where, according to Kim,  \f$ \sum \frac{L_{h}}{\Delta X} \f$  is
+!! the fractional area covered by the subgrid-scale orography higher than
+!! a critical height  \f$ h_{c} = Fr_{c} U_{0}/N_{0} \f$ , over the
+!! "low level" vertically averaged layer, for a grid box with the interval
+!! \f$ \Delta X \f$.  Each \f$ L_{n}\f$  is the width of a segment of
+!! orography intersection at the critical height:
+!!
+!! \f$  Fr_{0} = \frac{N_{0} \; h^{'}}{U_{0}}  \f$
+!!
+!! \f$ G^{'}(OC,Fr_{0}) = \frac{Fr_{0}^{2}}{Fr_{0}^{2} \; + \; a^{2}}  \f$
+!!
+!! \f$  a^{2} = \frac{C_{G}}{OC}  \f$
+!!
+!! \f$  E(OA, Fr_{0}) = (OA \; + \; 2)^{\delta} \f$ and \f$  \delta
+!! \; = \; \frac{C_{E} \; Fr_{0}}{Fr_{c}}  \f$  where \f$ Fr_{c} \f$
+!! is as in Alpert.
+!!
+!!
+!! This represents a closed scheme, somewhat empirical adjustments
+!! to the original scheme to calculate the surface stress.
+!!
+!! Momentum is deposited by the sub-grid scale gravity waves break due
+!! to the presence of convective mixing assumed to occur when the
+!! minimum Richardson number:
+!!
+!! Orographic Convexity (OC) = \f$  \frac{ \sum\limits_{j=1}^{N_{x}}
+!!  \; (h_{j} \; - \; \bar{h})^4 }{N_{x} \;\sigma_{h}^4} \f$  ,
+!!   and where  \f$ \sigma_{h} = \sqrt{ \frac{\sum\limits_{j=1}^{N_{x}}
+!!  \; (h_{j} \; - \; \bar{h} )^2}{N_{x}} } \f$
+!!
+!! This represents a closed scheme, somewhat empirical adjustments
+!! to the original scheme to calculate the surface stress.
+!!
+!! Momentum is deposited by the sub-grid scale gravity waves break due
+!!  to the presence of convective mixing assumed to occur when
+!!  the minimum Richardson number:
+!!
+!! \f$ Ri_{m} = \frac{Ri(1 \; - \; Fr)}{(1 \; + \; \sqrt{Ri}Fr)^2} \f$
+!!
+!! Is less than 1/4  Or if critical layers are encountered in a layer
+!! the the momentum flux will vanish.  The critical layer is defined
+!! when the base layer wind becomes perpendicular to the environmental
+!!  wind.  Otherwise, wave breaking occurs at a level where the amplification
+!!  of the wave causes the local Froude number or similarly a truncated
+!!  (first term of the) Scorer parameter, to be reduced below a critical
+!!  value by the saturation hypothesis (Lindzen,).  This is done through
+!!  eq 1 which can be written as
+!!
+!! \f$ \tau = \rho U N k h^{'2} \f$
+!!
+!! For small Froude number this is discretized in the vertical so at each
+!!  level the stress is reduced by ratio of the Froude or truncated Scorer
+!!  parameter, \f$ \frac{U^{2}}{N^{2}} = \frac{N \tau_{l-1}}{\rho U^{3} k} \f$ ,
+!!  where the stress is from the layer below beginning with that found near
+!!  the surface.   The respective change in momentum is applied in
+!! that layer building up from below.
+!!
+!! An amplitude factor is part of the calibration of this scheme which is
+!! a function of the model resolution and the vertical diffusion.  This
+!! is because the vertical diffusion and the GWD account encompass
+!! similar physical processes. Thus, one needs to run the model over
+!! and over for various amplitude factors for GWD and vertical diffusion.
+!!
+!! In addition, there is also mountain blocking from lift and frictional
+!!  forces.  Improved integration between how the GWD is calculated and
+!! the mountain blocking of wind flow around sub-grid scale orography
+!! is underway at NCEP.  The GFS already has convectively forced GWD
+!!  an independent process.  The next step is to test
+!!
+!> \section det_gwdps GFS Orographic GWD Scheme Detailed Algorithm
+!> @{
+      subroutine GFS_GWD_generic_run(                                   &
+                IM,IX,KM,A,B,C,U1,V1,T1,Q1,KPBL,                        &
+                PRSI,DEL,PRSL,PRSLK,PHII, PHIL,DELTIM,KDT,              &
+                HPRIME,OC,OA4,CLX4,THETA,SIGMA,GAMMA,ELVMAX,            &
+                DUSFC,DVSFC,G, CP, RD, RV, IMX,                         &
+                nmtvr, cdmbgwd, me, lprnt, ipr, rdxzb,                  &
+                do_congwd, cnvgwd, errmsg, errflg)
+!
+!   ********************************************************************
+! ----->  I M P L E M E N T A T I O N    V E R S I O N   <----------
+!
+!          --- Not in this code --  History of GWDP at NCEP----
+!              ----------------     -----------------------
+!  VERSION 3  MODIFIED FOR GRAVITY WAVES, LOCATION: .FR30(V3GWD)  *J*
+!---       3.1 INCLUDES VARIABLE SATURATION FLUX PROFILE CF ISIGST
+!---       3.G INCLUDES PS COMBINED W/ PH (GLAS AND GFDL)
+!-----         ALSO INCLUDED IS RI  SMOOTH OVER A THICK LOWER LAYER
+!-----         ALSO INCLUDED IS DECREASE IN DE-ACC AT TOP BY 1/2
+!-----     THE NMC GWD INCORPORATING BOTH GLAS(P&S) AND GFDL(MIGWD)
+!-----        MOUNTAIN INDUCED GRAVITY WAVE DRAG
+!-----    CODE FROM .FR30(V3MONNX) FOR MONIN3
+!-----        THIS VERSION (06 MAR 1987)
+!-----        THIS VERSION (26 APR 1987)    3.G
+!-----        THIS VERSION (01 MAY 1987)    3.9
+!-----    CHANGE TO FORTRAN 77 (FEB 1989)     --- HANN-MING HENRY JUANG
+!-----    20070601 ELVMAX bug fix (*j*)
+!
+!   VERSION 4
+!                ----- This code -----
+!
+!-----   MODIFIED TO IMPLEMENT THE ENHANCED LOW TROPOSPHERIC GRAVITY
+!-----   WAVE DRAG DEVELOPED BY KIM AND ARAKAWA(JAS, 1995).
+!        Orographic Std Dev (hprime), Convexity (OC), Asymmetry (OA4)
+!        and Lx (CLX4) are input topographic statistics needed.
+!
+!-----   PROGRAMMED AND DEBUGGED BY HONG, ALPERT AND KIM --- JAN 1996.
+!-----   debugged again - moorthi and iredell --- may 1998.
+!-----
+!       Further Cleanup, optimization and modification
+!                                       - S. Moorthi May 98, March 99.
+!-----   modified for usgs orography data (ncep office note 424)
+!        and with several bugs fixed  - moorthi and hong --- july 1999.
+!
+!-----   Modified & implemented into NRL NOGAPS
+!                                       - Young-Joon Kim, July 2000
+!-----
+!   VERSION lm MB  (6): oz fix 8/2003
+!                ----- This code -----
+!
+!------   Changed to include the Lott and Miller Mtn Blocking
+!         with some modifications by (*j*)  4/02
+!        From a Principal Coordinate calculation using the
+!        Hi Res 8 minute orography, the Angle of the
+!        mtn with that to the East (x) axis is THETA, the slope
+!        parameter SIGMA. The anisotropy is in GAMMA - all  are input
+!        topographic statistics needed.  These are calculated off-line
+!        as a function of model resolution in the fortran code ml01rg2.f,
+!        with script mlb2.sh.   (*j*)
+!-----   gwdps_mb.f version (following lmi) elvmax < hncrit (*j*)
+!        MB3a expt to enhance elvmax mtn hgt see sigfac & hncrit
+!        gwdps_GWDFIX_v6.f FIXGWD GF6.0 20070608 sigfac=4.
+!-----
+!----------------------------------------------------------------------C
+!    USE
+!        ROUTINE IS CALLED FROM GBPHYS  (AFTER CALL TO MONNIN)
+!
+!    PURPOSE
+!        USING THE GWD PARAMETERIZATIONS OF PS-GLAS AND PH-
+!        GFDL TECHNIQUE.  THE TIME TENDENCIES OF U V
+!        ARE ALTERED TO INCLUDE THE EFFECT OF MOUNTAIN INDUCED
+!        GRAVITY WAVE DRAG FROM SUB-GRID SCALE OROGRAPHY INCLUDING
+!        CONVECTIVE BREAKING, SHEAR BREAKING AND THE PRESENCE OF
+!        CRITICAL LEVELS
+!
+!  INPUT
+!        A(IX,KM)  NON-LIN TENDENCY FOR V WIND COMPONENT
+!        B(IX,KM)  NON-LIN TENDENCY FOR U WIND COMPONENT
+!        C(IX,KM)  NON-LIN TENDENCY FOR TEMPERATURE
+!        U1(IX,KM) ZONAL WIND M/SEC  AT T0-DT
+!        V1(IX,KM) MERIDIONAL WIND M/SEC AT T0-DT
+!        T1(IX,KM) TEMPERATURE DEG K AT T0-DT
+!        Q1(IX,KM) SPECIFIC HUMIDITY AT T0-DT
+!
+!        DELTIM  TIME STEP    SECS
+!        SI(N)   P/PSFC AT BASE OF LAYER N
+!        SL(N)   P/PSFC AT MIDDLE OF LAYER N
+!        DEL(N)  POSITIVE INCREMENT OF P/PSFC ACROSS LAYER N
+!        KPBL(IM) is the index of the top layer of the PBL
+!        ipr & lprnt for diagnostics
+!
+!  OUTPUT
+!        A, B    AS AUGMENTED BY TENDENCY DUE TO GWDPS
+!                OTHER INPUT VARIABLES UNMODIFIED.
+!  revision log:
+!    May 2013  J. Wang change cleff back to opn setting
+!    Jan 2014  J. Wang merge Henry and Fangin's dissipation heat in gfs to nems
+!
+!
+!   ********************************************************************
+      USE MACHINE , ONLY : kind_phys
+      implicit none
+!
+      ! Interface variables
+      integer, intent(in) :: im, ix, km, imx, kdt, ipr, me
+      integer, intent(in) :: KPBL(IM) ! Index for the PBL top layer!
+      ! DH* adding intent(in) information for the following variables
+      ! changes the results on Theia/Intel - skip for bit-for-bit results *DH
+!      real(kind=kind_phys), intent(in) ::                               &
+!     &                     deltim, G, CP, RD, RV, cdmbgwd(2)
+      real(kind=kind_phys) deltim, G, CP, RD, RV, cdmbgwd(2)
+      ! *DH
+      real(kind=kind_phys), intent(inout) ::                            &
+                           A(IX,KM), B(IX,KM), C(IX,KM)
+      real(kind=kind_phys), intent(in) ::                               &
+                           U1(IX,KM),   V1(IX,KM),     T1(IX,KM),       &
+                           Q1(IX,KM),   PRSI(IX,KM+1), DEL(IX,KM),      &
+                           PRSL(IX,KM), PRSLK(IX,KM),  PHIL(IX,KM),     &
+                           PHII(IX,KM+1)
+      real(kind=kind_phys), intent(in) ::                               &
+                           OC(IM), OA4(IX,4), CLX4(IX,4), HPRIME(IM)
+      real(kind=kind_phys), intent(inout) :: ELVMAX(IM)
+      real(kind=kind_phys), intent(in) ::                               &
+                           THETA(IM), SIGMA(IM), GAMMA(IM)
+      real(kind=kind_phys), intent(out) :: DUSFC(IM), DVSFC(IM),        &
+                           RDXZB(IX)
+      integer, intent(in) :: nmtvr
+      logical, intent(in) :: lprnt, do_congwd, cnvgwd
+      character(len=*), intent(out) :: errmsg
+      integer,          intent(out) :: errflg
+!
+      ! Local variables
+! for lm mtn blocking
+      real(kind=kind_phys) wk(IM)
+      real(kind=kind_phys) bnv2lm(IM,KM),PE(IM),EK(IM),ZBK(IM),UP(IM)
+      real(kind=kind_phys) DB(IM,KM),ANG(IM,KM),UDS(IM,KM)
+      real(kind=kind_phys) ZLEN, DBTMP, Rtrm, PHIANG, CDmb, DBIM, ZR
+      real(kind=kind_phys) ENG0, ENG1
+!
+!     Some constants
+!
+      real(kind=kind_phys) pi, dw2min, rimin, ric, bnv2min, efmin,      &
+                            efmax,hpmax,hpmin, rad_to_deg, deg_to_rad
+      PARAMETER (PI=3.1415926535897931)
+      PARAMETER (RAD_TO_DEG=180.0/PI, DEG_TO_RAD=PI/180.0)
+      PARAMETER (DW2MIN=1., RIMIN=-100., RIC=0.25, BNV2MIN=1.0E-5)
+!     PARAMETER (EFMIN=0.0, EFMAX=10.0, hpmax=200.0)
+      PARAMETER (EFMIN=0.0, EFMAX=10.0, hpmax=2400.0, hpmin=1.0)
+!
+      real(kind=kind_phys) FRC,    CE,     CEOFRC, frmax, CG, GMAX,     &
+                            VELEPS, FACTOP, RLOLEV, RDI
+!     &,                    CRITAC, VELEPS, FACTOP, RLOLEV, RDI
+      parameter (FRC=1.0, CE=0.8, CEOFRC=CE/FRC, frmax=100., CG=0.5)
+      parameter (GMAX=1.0, VELEPS=1.0, FACTOP=0.5)
+!      parameter (GMAX=1.0, CRITAC=5.0E-4, VELEPS=1.0, FACTOP=0.5)
+      parameter (RLOLEV=50000.0)
+!     parameter (RLOLEV=500.0)
+!     parameter (RLOLEV=0.5)
+!
+       real(kind=kind_phys) dpmin,hminmt,hncrit,minwnd,sigfac
+! --- for lm mtn blocking
+!     parameter (cdmb = 1.0)     !< non-dim sub grid mtn drag Amp (*j*)
+      parameter (hncrit=8000.)   !< Max value in meters for ELVMAX (*j*)
+!  hncrit set to 8000m and sigfac added to enhance elvmax mtn hgt
+      parameter (sigfac=4.0)     !< MB3a expt test for ELVMAX factor (*j*)
+      parameter (hminmt=50.)     !< min mtn height (*j*)
+      parameter (minwnd=0.1)     !< min wind component (*j*)
+
+!     parameter (dpmin=00.0)     !< Minimum thickness of the reference layer
+!!    parameter (dpmin=05.0)     !< Minimum thickness of the reference layer
+!     parameter (dpmin=20.0)     !< Minimum thickness of the reference layer
+                                 !< in centibars
+      parameter (dpmin=5000.0)   !< Minimum thickness of the reference layer
+                                 !< in Pa
+!
+      real(kind=kind_phys) FDIR
+      integer mdir
+      parameter(mdir=8, FDIR=mdir/(PI+PI))
+      integer nwdir(mdir)
+      data nwdir/6,7,5,8,2,3,1,4/
+      save nwdir
+!
+      LOGICAL ICRILV(IM)
+!
+!----   MOUNTAIN INDUCED GRAVITY WAVE DRAG
+!
+      real(kind=kind_phys) TAUB(IM),  XN(IM),     YN(IM),    UBAR(IM)  , &
+                           VBAR(IM),  ULOW(IM),   OA(IM),    CLX(IM)   , &
+                           ROLL(IM),  ULOI(IM)                         , &
+                           DTFAC(IM), XLINV(IM),  DELKS(IM), DELKS1(IM)
+!
+      real(kind=kind_phys) BNV2(IM,KM),  TAUP(IM,KM+1), ri_n(IM,KM)    , &
+                           TAUD(IM,KM),  RO(IM,KM),     VTK(IM,KM)     , &
+                           VTJ(IM,KM),   SCOR(IM),      VELCO(IM,KM-1) , &
+                           bnv2bar(im)
+!
+!     real(kind=kind_phys) VELKO(KM-1)
+      integer   kref(IM), kint(im), iwk(im), ipt(im)
+! for lm mtn blocking
+      integer   kreflm(IM), iwklm(im)
+      integer   idxzb(im), ktrial, klevm1
+!
+      real(kind=kind_phys) gor,    gocp,  fv,    gr2,  bnv,  fr        ,&
+                          brvf,   cleff, tem,   tem1,  tem2, temc, temv,&
+                          wdir,   ti,    rdz,   dw2,   shr2, bvf2     , &
+                          rdelks, efact, coefm, gfobnv, onebg         , &
+                          scork,  rscor, hd,    fro,   rim,  sira     , &
+                          dtaux,  dtauy, pkp1log, pklog               , &
+                          cosang, sinang, cos2a, sin2a
+!
+      integer kmm1, kmm2, lcap, lcapp1, kbps, kbpsp1,kbpsm1           , &
+      kmps, idir, nwd, i, j, k, klcap, kp1, kmpbl, npt, npr, kmll
+!    &, kmll,kmds,ihit,jhit
+!
+      ! Initialize CCPP error handling variables
+      errmsg = ''
+      errflg = 0
+
+
+      IF (cnvgwd .and. do_congwd) THEN
+
+
+!     parameter (cdmb = 1.0)     ! non-dim sub grid mtn drag Amp (*j*)
+! non-dim sub grid mtn drag Amp (*j*)
+!     cdmb = 1.0/float(IMX/192)
+!     cdmb = 192.0/float(IMX)
+      cdmb = 4.0 * 192.0/float(IMX)
+      if (cdmbgwd(1) >= 0.0) cdmb = cdmb * cdmbgwd(1)
+!
+      npr = 0
+      DO I = 1, IM
+         DUSFC(I) = 0.
+         DVSFC(I) = 0.
+      ENDDO
+!
+      DO K = 1, KM
+        DO I = 1, IM
+          DB(I,K)  = 0.
+          ANG(I,K) = 0.
+          UDS(I,K) = 0.
+        ENDDO
+      ENDDO
+!
+      RDI    = 1.0 / RD
+      onebg  = 1.0 / g
+      GOR    = G/RD
+      GR2    = G*GOR
+      GOCP   = G/CP
+      FV     = RV/RD - 1
+!
+!     NCNT   = 0
+      KMM1   = KM - 1
+      KMM2   = KM - 2
+      LCAP   = KM
+      LCAPP1 = LCAP + 1
+!
+!
+      IF ( NMTVR == 14) then 
+! ----  for lm and gwd calculation points
+        RDXZB(:)  = 0 
+        ipt = 0
+        npt = 0
+        DO I = 1,IM
+          IF (elvmax(i) > HMINMT .and. hprime(i) > hpmin)  then
+             npt      = npt + 1
+             ipt(npt) = i
+             if (ipr == i) npr = npt
+          ENDIF
+        ENDDO
+        IF (npt == 0) RETURN     ! No gwd/mb calculation done!
+!
+!       if (lprnt) print *,' npt=',npt,' npr=',npr,' ipr=',ipr,' im=',im
+!    &,' ipt(npt)=',ipt(npt)
+!
+! --- iwklm is the level above the height of the of the mountain.
+! --- idxzb is the level of the dividing streamline.
+! INITIALIZE DIVIDING STREAMLINE (DS) CONTROL VECTOR
+!
+        do i=1,npt
+          iwklm(i)  = 2
+          IDXZB(i)  = 0 
+          kreflm(i) = 0
+        enddo
+!       if (lprnt) 
+!    &  print *,' in gwdps_lm.f npt,IM,IX,IY,km,me=',npt,IM,IX,IY,km,me
+!
+!
+!> --- Subgrid Mountain Blocking Section
+!
+!..............................
+!..............................
+!
+!  (*j*)  11/03:  test upper limit on KMLL=km - 1
+!      then do not need hncrit -- test with large hncrit first.
+!       KMLL  = km / 2 ! maximum mtnlm height : # of vertical levels / 2
+
+        KMLL = kmm1
+
+! --- No mtn should be as high as KMLL (so we do not have to start at
+! --- the top of the model but could do calc for all levels).
+!
+          DO I = 1, npt
+            j = ipt(i)
+            ELVMAX(J) = min (ELVMAX(J) + sigfac * hprime(j), hncrit)
+          ENDDO
+!
+        DO K = 1,KMLL
+          DO I = 1, npt
+            j = ipt(i)
+! --- interpolate to max mtn height for index, iwklm(I) wk[gz]
+! --- ELVMAX is limited to hncrit because to hi res topo30 orog.
+            pkp1log =  phil(j,k+1) * onebg
+            pklog   =  phil(j,k)   * onebg
+!!!-------     ELVMAX(J) = min (ELVMAX(J) + sigfac * hprime(j), hncrit)
+
+            if (ELVMAX(j) <=  pkp1log .and. ELVMAX(j) >=  pklog) THEN
+
+!     print *,' in gwdps_lm.f 1  =',k,ELVMAX(j),pklog,pkp1log,me
+! ---        wk for diags but can be saved and reused.  
+               wk(i)    = G * ELVMAX(j) / (phil(j,k+1) - phil(j,k))
+               iwklm(I) =  MAX(iwklm(I), k+1) 
+!     print *,' in gwdps_lm.f 2 npt=',npt,i,j,wk(i),iwklm(i),me
+            endif
+!
+! ---        find at prsl levels large scale environment variables
+! ---        these cover all possible mtn max heights
+            VTJ(I,K)  = T1(J,K)  * (1.0+FV*Q1(J,K))
+            VTK(I,K)  = VTJ(I,K) / PRSLK(J,K)
+            RO(I,K)   = RDI * PRSL(J,K) / VTJ(I,K) ! DENSITY Kg/M**3
+          ENDDO
+        ENDDO
+!
+! testing for highest model level of mountain top
+!
+!         ihit = 2
+!         jhit = 0
+!        do i = 1, npt
+!        j=ipt(i)
+!          if ( iwklm(i) .gt. ihit ) then
+!            ihit = iwklm(i)
+!            jhit = j
+!          endif
+!        enddo
+!     print *, ' mb: kdt,max(iwklm),jhit,phil,me=',
+!    &          kdt,ihit,jhit,phil(jhit,ihit),me
+         
+        klevm1 = KMLL - 1
+        DO K = 1, klevm1
+          kp1 = k + 1
+          DO I = 1, npt
+           j   = ipt(i)
+           RDZ = g / (phil(j,kp1) - phil(j,k))
+! ---                               Brunt-Vaisala Frequency
+!> - Compute Brunt-Vaisala Frequency \f$N\f$.
+            BNV2LM(I,K) = (G+G) * RDZ * (VTK(I,Kp1) - VTK(I,K))         &
+                                     / (VTK(I,Kp1) + VTK(I,K))
+            bnv2lm(i,k) = max( bnv2lm(i,k), bnv2min )
+          ENDDO
+        ENDDO
+!    print *,' in gwdps_lm.f 3 npt=',npt,j,RDZ,me
+!
+        DO I = 1, npt
+          J   = ipt(i)
+          DELKS(I)  = 1.0 / (PRSI(J,1) - PRSI(J,iwklm(i)))
+          DELKS1(I) = 1.0 / (PRSL(J,1) - PRSL(J,iwklm(i)))
+          UBAR (I)  = 0.0
+          VBAR (I)  = 0.0
+          ROLL (I)  = 0.0
+          PE   (I)  = 0.0
+          EK   (I)  = 0.0
+          BNV2bar(I) = (PRSL(J,1)-PRSL(J,2)) * DELKS1(I) * BNV2LM(I,1)
+        ENDDO
+
+! --- find the dividing stream line height
+! --- starting from the level above the max mtn downward
+! --- iwklm(i) is the k-index of mtn elvmax elevation
+!> - Find the dividing streamline height starting from the level above
+!! the maximum mountain height and processing downward.
+        DO Ktrial = KMLL, 1, -1
+          DO I = 1, npt
+             IF ( Ktrial < iwklm(I) .and. kreflm(I) == 0 ) then
+                kreflm(I) = Ktrial
+             ENDIF
+          ENDDO
+        ENDDO
+!     print *,' in gwdps_lm.f 4 npt=',npt,kreflm(npt),me
+!
+! --- in the layer kreflm(I) to 1 find PE (which needs N, ELVMAX)
+! ---  make averages, guess dividing stream (DS) line layer.
+! ---  This is not used in the first cut except for testing and
+! --- is the vert ave of quantities from the surface to mtn top.
+!   
+        DO I = 1, npt
+          DO K = 1, Kreflm(I)
+            J          = ipt(i)
+            RDELKS     = DEL(J,K) * DELKS(I)
+            UBAR(I)    = UBAR(I)  + RDELKS * U1(J,K) ! trial Mean U below
+            VBAR(I)    = VBAR(I)  + RDELKS * V1(J,K) ! trial Mean V below
+            ROLL(I)    = ROLL(I)  + RDELKS * RO(I,K) ! trial Mean RO below
+            RDELKS     = (PRSL(J,K)-PRSL(J,K+1)) * DELKS1(I)
+            BNV2bar(I) = BNV2bar(I) + BNV2lm(I,K) * RDELKS
+! --- these vert ave are for diags, testing and GWD to follow (*j*).
+          ENDDO
+        ENDDO
+!     print *,' in gwdps_lm.f 5  =',i,kreflm(npt),BNV2bar(npt),me
+!
+! --- integrate to get PE in the trial layer.
+! --- Need the first layer where PE>EK - as soon as
+! --- IDXZB is not 0 we have a hit and Zb is found.
+!
+        DO I = 1, npt
+          J = ipt(i)
+          DO K = iwklm(I), 1, -1
+            PHIANG   =  atan2(V1(J,K),U1(J,K))*RAD_TO_DEG
+            ANG(I,K) = ( THETA(J) - PHIANG )
+            if ( ANG(I,K) >  90. ) ANG(I,K) = ANG(I,K) - 180.
+            if ( ANG(I,K) < -90. ) ANG(I,K) = ANG(I,K) + 180.
+            ANG(I,K) = ANG(I,K) * DEG_TO_RAD
+!
+!> - Compute wind speed UDS
+!!\f[
+!!    UDS=\max(\sqrt{U1^2+V1^2},minwnd)
+!!\f]
+!! where \f$ minwnd=0.1 \f$, \f$U1\f$ and \f$V1\f$ are zonal and
+!! meridional wind components of model layer wind.
+
+            UDS(I,K) =                                                  &
+               MAX(SQRT(U1(J,K)*U1(J,K) + V1(J,K)*V1(J,K)), minwnd)
+! --- Test to see if we found Zb previously
+            IF (IDXZB(I) == 0 ) then
+              PE(I) = PE(I) + BNV2lm(I,K) * (G*ELVMAX(J) - phil(J,K))   &
+                                          * (PHII(J,K+1) - PHII(J,K))   &
+                                          * (onebg*onebg)
+! ---  KE
+! --- Wind projected on the line perpendicular to mtn range, U(Zb(K)).
+! --- kenetic energy is at the layer Zb
+! --- THETA ranges from -+90deg |_ to the mtn "largest topo variations"
+              UP(I)  =  UDS(I,K) * cos(ANG(I,K))
+              EK(I)  = 0.5 *  UP(I) * UP(I)
+
+! --- Dividing Stream lime  is found when PE =exceeds EK.
+              IF (PE(I) >= EK(I)) THEN
+                 IDXZB(I) = K
+                 RDXZB(J) = real(K,kind=kind_phys)
+              ENDIF
+! --- Then mtn blocked flow is between Zb=k(IDXZB(I)) and surface
+!
+!> - The dividing streamline height (idxzb), of a subgrid scale
+!! obstable, is found by comparing the potential (PE) and kinetic
+!! energies (EK) of the upstream large scale wind and subgrid scale air
+!! parcel movements. the dividing streamline is found when
+!! \f$PE\geq EK\f$. Mountain-blocked flow is defined to exist between
+!! the surface and the dividing streamline height (\f$h_d\f$), which
+!! can be found by solving an integral equation for \f$h_d\f$:
+!!\f[
+!! \frac{U^{2}(h_{d})}{2}=\int_{h_{d}}^{H} N^{2}(z)(H-z)dz
+!!\f]
+!! where \f$H\f$ is the maximum subgrid scale elevation within the grid
+!! box of actual orography, \f$h\f$, obtained from the GTOPO30 dataset
+!! from the U.S. Geological Survey.
+            ENDIF
+          ENDDO
+        ENDDO
+!
+!     print *,' in gwdps_lm.f 6  =',phiang,THETA(ipt(npt)),me
+!     print *,' in gwdps_lm.f 7  =',IDXZB(npt),PE(npt)
+!
+!     if (lprnt .and. npr .gt. 0) then
+!       print *,' BNV2bar,BNV2lm=',bnv2bar(npr),BNV2lm(npr,1:klevm1)
+!       print *,' npr,IDXZB,UDS=',npr,IDXZB(npr),UDS(npr,:)
+!       print *,' PE,UP,EK=',PE(npr),UP(npr),EK(npr)
+!     endif
+!
+        DO I = 1, npt
+          J    = ipt(i)
+! --- Calc if N constant in layers (Zb guess) - a diagnostic only.
+          ZBK(I) = ELVMAX(J)                                            &
+                - SQRT(UBAR(I)*UBAR(I) + VBAR(I)*VBAR(I))/BNV2bar(I)
+        ENDDO
+!
+!     if (lprnt .and. npr .gt. 0) then
+!       print *,' iwklm,ZBK=',iwklm(npr),ZBK(npr),IDXZB(npr)
+!       print *,' Zb=',PHIL(ipr),IDXZB(npr))/G
+!     print *,' in gwdps_lm.f 8 npt =',npt,ZBK(npt),UP(npt),me
+!     endif
+!
+! --- The drag for mtn blocked flow
+!
+        DO I = 1, npt
+          J = ipt(i)
+          ZLEN = 0.
+!      print *,' in gwdps_lm.f 9  =',i,j,IDXZB(i),me
+          IF (IDXZB(I) > 0) then
+            DO K = IDXZB(I), 1, -1
+              IF (PHIL(J,IDXZB(I)) >  PHIL(J,K)) then
+
+!> - Calculate \f$ZLEN\f$, which sums up a number of contributions of
+!! elliptic obstables.
+!!\f[
+!!    ZLEN=\sqrt{[\frac{h_{d}-z}{z+h'}]}
+!!\f]
+!! where \f$z\f$ is the height, \f$h'\f$ is the orographic standard
+!! deviation (HPRIME).
+                ZLEN = SQRT( (PHIL(J,IDXZB(I)) - PHIL(J,K))             &
+                           / (PHIL(J,K )       + G*hprime(J)) )
+! --- lm eq 14:
+!> - Calculate the drag coefficient to vary with the aspect ratio of
+!! the obstable as seen by the incident flow (see eq.14 in Lott and
+!! Miller (1997) \cite lott_and_miller_1997)
+!!\f[
+!! R=\frac{\cos^{2}\psi+\gamma\sin^{2}\psi}{\gamma\cos^{2}\psi+\sin^{2}\psi}
+!!\f]
+!! where \f$\psi\f$, which is derived from THETA, is the angle between
+!! the incident flow direction and the normal ridge direcion.
+!! \f$\gamma\f$ is the orographic anisotropy (GAMMA).
+
+                cosang = cos(ang(i,k))
+                sinang = sin(ang(i,k))
+                cos2a  = cosang * cosang
+                sin2a  = sinang * sinang
+                tem    = cos2a + GAMMA(J)*sin2a
+                                                       ! Here Rtrm is 1.0/R
+                                                       ! --------------------
+                if (abs(tem) > 1.e-06) then
+                  Rtrm   = (gamma(J)*cos2a + sin2a) / tem
+                elseif (tem > 0.0) then
+                  Rtrm   = (gamma(J)*cos2a + sin2a) * 1.0e6
+                else
+                  Rtrm   = - (gamma(J)*cos2a + sin2a) * 1.0e6
+                endif
+                ZR =  MAX( 2.0 - Rtrm, 0. )
+
+! --- (negitive of DB -- see sign at tendency)
+!> - In each model layer below the dividing streamlines, a drag from
+!! the blocked flow is exerted by the obstacle on the large scale flow.
+!! The drag per unit area and per unit height is written (eq.15 in
+!! Lott and Miller (1997) \cite lott_and_miller_1997):
+!!\f[
+!! D_{b}(z)=-C_{d}\max(2-\frac{1}{R},0)\rho\frac{\sigma}{2h'}ZLEN\max(\cos\psi,\gamma\sin\psi)\frac{UDS}{2}
+!!\f]
+!! where \f$C_{d}\f$ is a specified constant, \f$\sigma\f$ is the
+!! orographic slope.
+
+                DBTMP = 0.25 *  CDmb * ZR * sigma(J) *                  &
+                       MAX(cosANG, gamma(J)*sinANG) * ZLEN / hprime(J)
+                DB(I,K) =  DBTMP * UDS(I,K)
+!
+!               if(lprnt .and. i .eq. npr) then
+!                 print *,' in gwdps_lmi.f 10 npt=',npt,i,j,idxzb(i)
+!    &,           DBTMP,R' ang=',ang(i,k),' gamma=',gamma(j),' K=',K
+!                 print *,' in gwdps_lmi.f 11   K=',k,ZLEN,cos(ANG(I,K))
+!                 print *,' in gwdps_lmi.f 12  DB=',DB(i,k),sin(ANG(I,K))
+!               endif
+              endif
+            ENDDO
+!         if(lprnt) print *,' @K=1,ZLEN,DBTMP=',K,ZLEN,DBTMP
+          endif
+        ENDDO
+! 
+!.............................
+!.............................
+! end  mtn blocking section
+!
+      ELSEIF ( NMTVR /= 14) then
+! ----  for mb not present and  gwd (nmtvr .ne .14)
+        ipt = 0
+        npt = 0
+        DO I = 1,IM
+          IF ( hprime(i) > hpmin )  then
+             npt      = npt + 1
+             ipt(npt) = i
+             if (ipr == i) npr = npt
+          ENDIF
+        ENDDO
+        IF (npt == 0) RETURN     ! No gwd/mb calculation done!
+!
+!       if (lprnt) print *,' NPR=',npr,' npt=',npt,' IPR=',IPR
+!      &,' ipt(npt)=',ipt(npt)
+!
+        do i=1,npt
+          IDXZB(i) = 0
+          RDXZB(i) = 0.
+        enddo
+      ENDIF
+!
+!.............................
+!.............................
+!
+!>-# Orographic Gravity Wave Drag Section
+      KMPBL  = km / 2 ! maximum pbl height : # of vertical levels / 2
+!
+!  Scale cleff between IM=384*2 and 192*2 for T126/T170 and T62
+!
+      if (imx > 0) then
+!       cleff = 1.0E-5 * SQRT(FLOAT(IMX)/384.0) !  this is inverse of CLEFF!
+!       cleff = 1.0E-5 * SQRT(FLOAT(IMX)/192.0) !  this is inverse of CLEFF!
+!       cleff = 0.5E-5 * SQRT(FLOAT(IMX)/192.0) !  this is inverse of CLEFF!
+!       cleff = 1.0E-5 * SQRT(FLOAT(IMX)/192)/float(IMX/192)
+!       cleff = 1.0E-5 / SQRT(FLOAT(IMX)/192.0) !  this is inverse of CLEFF!
+        cleff = 0.5E-5 / SQRT(FLOAT(IMX)/192.0) !  this is inverse of CLEFF!
+! hmhj for ndsl
+! jw        cleff = 0.1E-5 / SQRT(FLOAT(IMX)/192.0) !  this is inverse of CLEFF!
+!       cleff = 2.0E-5 * SQRT(FLOAT(IMX)/192.0) !  this is inverse of CLEFF!
+!       cleff = 2.5E-5 * SQRT(FLOAT(IMX)/192.0) !  this is inverse of CLEFF!
+      endif
+      if (cdmbgwd(2) >= 0.0) cleff = cleff * cdmbgwd(2)
+!
+      DO K = 1,KM
+        DO I =1,npt
+          J         = ipt(i)
+          VTJ(I,K)  = T1(J,K)  * (1.0+FV*Q1(J,K))
+          VTK(I,K)  = VTJ(I,K) / PRSLK(J,K)
+          RO(I,K)   = RDI * PRSL(J,K) / VTJ(I,K) ! DENSITY TONS/M**3
+          TAUP(I,K) = 0.0
+        ENDDO
+      ENDDO
+      DO K = 1,KMM1
+        kp1 = k + 1
+        DO I =1,npt
+          J         = ipt(i)
+          TI        = 2.0 / (T1(J,K)+T1(J,Kp1))
+          TEM       = TI  / (PRSL(J,K)-PRSL(J,Kp1))
+          RDZ       = g   / (phil(j,kp1) - phil(j,k))
+          TEM1      = U1(J,K) - U1(J,Kp1)
+          TEM2      = V1(J,K) - V1(J,Kp1)
+          DW2       = TEM1*TEM1 + TEM2*TEM2
+          SHR2      = MAX(DW2,DW2MIN) * RDZ * RDZ
+          BVF2      = G*(GOCP+RDZ*(VTJ(I,Kp1)-VTJ(I,K))) * TI
+          ri_n(I,K) = MAX(BVF2/SHR2,RIMIN)   ! Richardson number
+!                                              Brunt-Vaisala Frequency
+!         TEM       = GR2 * (PRSL(J,K)+PRSL(J,K+1)) * TEM
+!         BNV2(I,K) = TEM * (VTK(I,K+1)-VTK(I,K))/(VTK(I,K+1)+VTK(I,K))
+          BNV2(I,K) = (G+G) * RDZ * (VTK(I,Kp1)-VTK(I,K))               &
+                                  / (VTK(I,Kp1)+VTK(I,K))
+          bnv2(i,k) = max( bnv2(i,k), bnv2min )
+        ENDDO
+      ENDDO
+!      print *,' in gwdps_lm.f GWD:14  =',npt,kmm1,bnv2(npt,kmm1)
+!
+!     Apply 3 point smoothing on BNV2
+!
+!     do k=1,km
+!       do i=1,im
+!         vtk(i,k) = bnv2(i,k)
+!       enddo
+!     enddo
+!     do k=2,kmm1
+!       do i=1,im
+!         bnv2(i,k) = 0.25*(vtk(i,k-1)+vtk(i,k+1)) + 0.5*vtk(i,k)
+!       enddo
+!     enddo
+!
+!     Finding the first interface index above 50 hPa level
+!
+      do i=1,npt
+        iwk(i) = 2
+      enddo
+      DO K=3,KMPBL
+        DO I=1,npt
+          j   = ipt(i)
+          tem = (prsi(j,1) - prsi(j,k))
+          if (tem < dpmin) iwk(i) = k
+        enddo
+      enddo
+!
+!> - Calculate the reference level index: kref=max(2,KPBL+1). where
+!! KPBL is the index for the PBL top layer.
+      KBPS = 1
+      KMPS = KM
+      DO I=1,npt
+        J         = ipt(i)
+        kref(I)   = MAX(IWK(I), KPBL(J)+1 ) ! reference level
+        DELKS(I)  = 1.0 / (PRSI(J,1) - PRSI(J,kref(I)))
+        DELKS1(I) = 1.0 / (PRSL(J,1) - PRSL(J,kref(I)))
+        UBAR (I)  = 0.0
+        VBAR (I)  = 0.0
+        ROLL (I)  = 0.0
+        KBPS      = MAX(KBPS, kref(I))
+        KMPS      = MIN(KMPS, kref(I))
+!
+        BNV2bar(I) = (PRSL(J,1)-PRSL(J,2)) * DELKS1(I) * BNV2(I,1)
+      ENDDO
+!      print *,' in gwdps_lm.f GWD:15  =',KBPS,KMPS
+      KBPSP1 = KBPS + 1
+      KBPSM1 = KBPS - 1
+      DO K = 1,KBPS
+        DO I = 1,npt
+          IF (K < kref(I)) THEN
+            J          = ipt(i)
+            RDELKS     = DEL(J,K) * DELKS(I)
+            UBAR(I)    = UBAR(I)  + RDELKS * U1(J,K)   ! Mean U below kref
+            VBAR(I)    = VBAR(I)  + RDELKS * V1(J,K)   ! Mean V below kref
+!
+            ROLL(I)    = ROLL(I)  + RDELKS * RO(I,K)   ! Mean RO below kref
+            RDELKS     = (PRSL(J,K)-PRSL(J,K+1)) * DELKS1(I)
+            BNV2bar(I) = BNV2bar(I) + BNV2(I,K) * RDELKS
+          ENDIF
+        ENDDO
+      ENDDO
+!      print *,' in gwdps_lm.f GWD:15B =',bnv2bar(npt)
+!
+!     FIGURE OUT LOW-LEVEL HORIZONTAL WIND DIRECTION AND FIND 'OA'
+!
+!             NWD  1   2   3   4   5   6   7   8
+!              WD  W   S  SW  NW   E   N  NE  SE
+!
+!> - Calculate low-level horizontal wind direction, the derived
+!! orographic asymmetry parameter (OA), and the derived Lx (CLX).
+      DO I = 1,npt
+        J      = ipt(i)
+        wdir   = atan2(UBAR(I),VBAR(I)) + pi
+        idir   = mod(nint(fdir*wdir),mdir) + 1
+        nwd    = nwdir(idir)
+        OA(I)  = (1-2*INT( (NWD-1)/4 )) * OA4(J,MOD(NWD-1,4)+1)
+        CLX(I) = CLX4(J,MOD(NWD-1,4)+1)
+      ENDDO
+!
+!-----XN,YN            "LOW-LEVEL" WIND PROJECTIONS IN ZONAL
+!                                    & MERIDIONAL DIRECTIONS
+!-----ULOW             "LOW-LEVEL" WIND MAGNITUDE -        (= U)
+!-----BNV2             BNV2 = N**2
+!-----TAUB             BASE MOMENTUM FLUX
+!-----= -(RO * U**3/(N*XL)*GF(FR) FOR N**2 > 0
+!-----= 0.                        FOR N**2 < 0
+!-----FR               FROUDE    =   N*HPRIME / U
+!-----G                GMAX*FR**2/(FR**2+CG/OC)
+!
+!-----INITIALIZE SOME ARRAYS
+!
+      DO I = 1,npt
+        XN(I)     = 0.0
+        YN(I)     = 0.0
+        TAUB (I)  = 0.0
+        ULOW (I)  = 0.0
+        DTFAC(I)  = 1.0
+        ICRILV(I) = .FALSE. ! INITIALIZE CRITICAL LEVEL CONTROL VECTOR
+        
+!
+!----COMPUTE THE "LOW LEVEL" WIND MAGNITUDE (M/S)
+!
+        ULOW(I) = MAX(SQRT(UBAR(I)*UBAR(I) + VBAR(I)*VBAR(I)), 1.0)
+        ULOI(I) = 1.0 / ULOW(I)
+      ENDDO
+!
+      DO  K = 1,KMM1
+        kp1 = k + 1
+        DO  I = 1,npt
+          J            = ipt(i)
+          VELCO(I,K)   = 0.5 * ((U1(J,K)+U1(J,Kp1))*UBAR(I)             &
+                          +  (V1(J,K)+V1(J,Kp1))*VBAR(I))
+          VELCO(I,K)   = VELCO(I,K) * ULOI(I)
+!         IF ((VELCO(I,K).LT.VELEPS) .AND. (VELCO(I,K).GT.0.)) THEN
+!           VELCO(I,K) = VELEPS
+!         ENDIF
+        ENDDO
+      ENDDO
+!      
+!
+!   find the interface level of the projected wind where
+!   low levels & upper levels meet above pbl
+!
+!     do i=1,npt
+!       kint(i) = km
+!     enddo
+!     do k = 1,kmm1
+!       do i = 1,npt
+!         IF (K .GT. kref(I)) THEN
+!           if(velco(i,k) .lt. veleps .and. kint(i) .eq. km) then
+!             kint(i) = k+1
+!           endif
+!         endif
+!       enddo
+!     enddo
+!  WARNING  KINT = KREF !!!!!!!!!
+      do i=1,npt
+        kint(i) = kref(i)
+      enddo
+!
+!     if(lprnt) print *,' ubar=',ubar
+!    &,' vbar=',vbar,' ulow=',ulow,' veleps=',veleps
+!
+      DO I = 1,npt
+        J      = ipt(i)
+        BNV    = SQRT( BNV2bar(I) )
+        FR     = BNV     * ULOI(I) * min(HPRIME(J),hpmax)
+        FR     = MIN(FR, FRMAX)
+        XN(I)  = UBAR(I) * ULOI(I)
+        YN(I)  = VBAR(I) * ULOI(I)
+!
+!     Compute the base level stress and store it in TAUB
+!     CALCULATE ENHANCEMENT FACTOR, NUMBER OF MOUNTAINS & ASPECT
+!     RATIO CONST. USE SIMPLIFIED RELATIONSHIP BETWEEN STANDARD
+!     DEVIATION & CRITICAL HGT
+!
+!> - Calculate enhancement factor (E),number of mountans (m') and
+!! aspect ratio constant.
+!!\n As in eq.(4.9),(4.10),(4.11) in Kim and Arakawa (1995)
+!! \cite kim_and_arakawa_1995, we define m' and E in such a way that they
+!! depend on the geometry and location of the subgrid-scale orography
+!! through OA and the nonlinearity of flow above the orography through
+!! Fr. OC, which is the orographic convexity, and statistically
+!! determine how protruded (sharp) the subgrid-scale orography is, is
+!! included in the saturation flux G' in such a way that G' is
+!! proportional to OC. The forms of E,m' and G' are:
+!!\f[
+!!  E(OA,F_{r_{0}})=(OA+2)^{\delta}
+!!\f]
+!!\f[
+!!  \delta=C_{E}F_{r_{0}}/F_{r_{c}}
+!!\f]
+!!\f[
+!!  m'(OA,CLX)=C_{m}\triangle x(1+CLX)^{OA+1}
+!!\f]
+!!\f[
+!!  G'(OC,F_{r_{0}})=\frac{F_{r_{0}}^2}{F_{r_{0}}^2+a^{2}}
+!!\f]
+!!\f[
+!! a^{2}=C_{G}OC^{-1}
+!!\f]
+!! where \f$F_{r_{c}}(=1)\f$ is the critical Froude number,
+!! \f$F_{r_{0}}\f$ is the Froude number. \f$C_{E}\f$,\f$C_{m}\f$,
+!! \f$C_{G}\f$ are constants.
+
+!> - Calculate the reference-level drag \f$\tau_{0}\f$ (eq.(4.8) in
+!! Kim and Arakawa (1995) \cite kim_and_arakawa_1995):
+!!\f[
+!! \tau_0=E\frac{m'}{\triangle x}\frac{\rho_{0}U_0^3}{N_{0}}G'
+!!\f]
+!! where \f$E\f$,\f$m'\f$, and \f$G'\f$ are the enhancement factor,
+!! "the number of mountains", and the flux function defined above,
+!! respectively.
+
+        EFACT    = (OA(I) + 2.) ** (CEOFRC*FR)
+        EFACT    = MIN( MAX(EFACT,EFMIN), EFMAX )
+!
+        COEFM    = (1. + CLX(I)) ** (OA(I)+1.)
+!
+        XLINV(I) = COEFM * CLEFF
+!
+        TEM      = FR    * FR * OC(J)
+        GFOBNV   = GMAX  * TEM / ((TEM + CG)*BNV)  ! G/N0
+!
+        TAUB(I)  = XLINV(I) * ROLL(I) * ULOW(I) * ULOW(I)               &
+                 * ULOW(I)  * GFOBNV  * EFACT         ! BASE FLUX Tau0
+!
+!         tem      = min(HPRIME(I),hpmax)
+!         TAUB(I)  = XLINV(I) * ROLL(I) * ULOW(I) * BNV * tem * tem
+!
+        K        = MAX(1, kref(I)-1)
+        TEM      = MAX(VELCO(I,K)*VELCO(I,K), 0.1)
+        SCOR(I)  = BNV2(I,K) / TEM  ! Scorer parameter below ref level
+      ENDDO
+!     if(lprnt) print *,' taub=',taub
+!                                                                       
+!----SET UP BOTTOM VALUES OF STRESS
+!
+      DO K = 1, KBPS
+        DO I = 1,npt
+          IF (K <= kref(I)) TAUP(I,K) = TAUB(I)
+        ENDDO
+      ENDDO
+!
+!   Now compute vertical structure of the stress.
+!
+      DO K = KMPS, KMM1                   ! Vertical Level K Loop!
+        KP1 = K + 1
+        DO I = 1, npt
+!
+!-----UNSTABLE LAYER IF RI < RIC
+!-----UNSTABLE LAYER IF UPPER AIR VEL COMP ALONG SURF VEL <=0 (CRIT LAY)
+!---- AT (U-C)=0. CRIT LAYER EXISTS AND BIT VECTOR SHOULD BE SET (.LE.)
+!
+          IF (K >= kref(I)) THEN
+            ICRILV(I) = ICRILV(I) .OR. ( ri_n(I,K) <  RIC)              &
+                                  .OR. (VELCO(I,K) <= 0.0)
+          ENDIF
+        ENDDO
+!
+!> - Compute the drag above the reference level (\f$k\geq kref\f$):
+!!  - Calculate the ratio of the Scorer parameter (\f$R_{scor}\f$).
+!! \n From a series of experiments, Kim and Arakawa (1995)
+!! \cite kim_and_arakawa_1995 found that the magnitude of drag divergence
+!! tends to be underestimated by the revised scheme in low-level
+!! downstream regions with wave breaking. Therefore, at low levels when
+!! OA > 0 (i.e., in the "downstream" region) the saturation hypothesis
+!! is replaced by the following formula based on the ratio of the
+!! the Scorer parameter:
+!!\f[
+!! R_{scor}=\min \left[\frac{\tau_i}{\tau_{i+1}},1\right]
+!!\f]
+        DO I = 1,npt
+          IF (K >= kref(I))   THEN
+            IF (.NOT.ICRILV(I) .AND. TAUP(I,K) > 0.0 ) THEN
+              TEMV = 1.0 / max(VELCO(I,K), 0.01)
+!             IF (OA(I) .GT. 0. .AND.  PRSI(ipt(i),KP1).GT.RLOLEV) THEN
+              IF (OA(I) > 0. .AND. kp1 < kint(i)) THEN
+                SCORK   = BNV2(I,K) * TEMV * TEMV
+                RSCOR   = MIN(1.0, SCORK / SCOR(I))
+                SCOR(I) = SCORK
+              ELSE
+                RSCOR   = 1.
+              ENDIF
+!
+!>  - The drag above the reference level is expressed as:
+!!\f[
+!! \tau=\frac{m'}{\triangle x}\rho NUh_d^2
+!!\f]
+!! where \f$h_{d}\f$ is the displacement wave amplitude. In the absence
+!! of wave breaking, the displacement amplitude for the \f$i^{th}\f$
+!! layer can be expressed using the drag for the layer immediately
+!! below. Thus, assuming \f$\tau_i=\tau_{i+1}\f$, we can get:
+!!\f[
+!! h_{d_i}^2=\frac{\triangle x}{m'}\frac{\tau_{i+1}}{\rho_{i}N_{i}U_{i}}
+!!\f]
+
+              BRVF = SQRT(BNV2(I,K))        ! Brunt-Vaisala Frequency
+!             TEM1 = XLINV(I)*(RO(I,KP1)+RO(I,K))*BRVF*VELCO(I,K)*0.5
+              TEM1 = XLINV(I)*(RO(I,KP1)+RO(I,K))*BRVF*0.5              &
+                             * max(VELCO(I,K),0.01)
+              HD   = SQRT(TAUP(I,K) / TEM1)
+              FRO  = BRVF * HD * TEMV
+!
+!    RIM is the  MINIMUM-RICHARDSON NUMBER BY SHUTTS (1985)
+!
+!> - The minimum Richardson number (\f$Ri_{m}\f$) or local
+!! wave-modified Richardson number, which determines the onset of wave
+!! breaking, is expressed in terms of \f$R_{i}\f$ and
+!! \f$F_{r_{d}}=Nh_{d}/U\f$:
+!!\f[
+!! Ri_{m}=\frac{Ri(1-Fr_{d})}{(1+\sqrt{Ri}\cdot Fr_{d})^{2}}
+!!\f]
+!! see eq.(4.6) in Kim and Arakawa (1995) \cite kim_and_arakawa_1995.
+
+              TEM2   = SQRT(ri_n(I,K))
+              TEM    = 1. + TEM2 * FRO
+              RIM    = ri_n(I,K) * (1.-FRO) / (TEM * TEM)
+!
+!    CHECK STABILITY TO EMPLOY THE 'SATURATION HYPOTHESIS'
+!    OF LINDZEN (1981) EXCEPT AT TROPOSPHERIC DOWNSTREAM REGIONS
+!
+!>  - Check stability to employ the 'saturation hypothesis' of Lindzen
+!! (1981) \cite lindzen_1981 except at tropospheric downstream regions.
+!! \n Wave breaking occurs when \f$Ri_{m}<Ri_{c}=0.25\f$. Then
+!! Lindzen's wave saturation hypothesis resets the displacement
+!! amplitude \f$h_{d}\f$ to that corresponding to \f$Ri_{m}=0.25\f$,
+!! we obtain the critical \f$h_{d}\f$(or \f$h_{c}\f$) expressed in
+!! terms of the mean values of \f$U\f$, \f$N\f$, and \f$Ri\f$ (
+!! eq.(4.7) in Kim and Arakawa (1995) \cite kim_and_arakawa_1995):
+!!\f[
+!! h_{c}=\frac{U}{N}\left\{2(2+\frac{1}{\sqrt{Ri}})^{1/2}-(2+\frac{1}{\sqrt{Ri}})\right\}
+!!\f]
+!! if \f$Ri_{m}\leq Ri_{c}\f$, obtain \f$\tau\f$ from the drag above
+!! the reference level by using \f$h_{c}\f$ computed above; otherwise
+!! \f$\tau\f$ is unchanged (note: scaled by the ratio of the Scorer
+!! paramter).
+!                                       ----------------------
+              IF (RIM <= RIC .AND.                                      &
+!    &           (OA(I) .LE. 0. .OR.  PRSI(ipt(I),KP1).LE.RLOLEV )) THEN
+                 (OA(I) <= 0. .OR.  kp1 >= kint(i) )) THEN
+                 TEMC = 2.0 + 1.0 / TEM2
+                 HD   = VELCO(I,K) * (2.*SQRT(TEMC)-TEMC) / BRVF
+                 TAUP(I,KP1) = TEM1 * HD * HD
+              ELSE
+                 TAUP(I,KP1) = TAUP(I,K) * RSCOR
+              ENDIF
+              taup(i,kp1) = min(taup(i,kp1), taup(i,k))
+            ENDIF
+          ENDIF
+        ENDDO
+      ENDDO
+!
+!     DO I=1,IM
+!       taup(i,km+1) = taup(i,km)
+!     ENDDO
+!
+      IF(LCAP .LE. KM) THEN
+         DO KLCAP = LCAPP1, KM+1
+            DO I = 1,npt
+              SIRA          = PRSI(ipt(I),KLCAP) / PRSI(ipt(I),LCAP)
+              TAUP(I,KLCAP) = SIRA * TAUP(I,LCAP)
+            ENDDO
+         ENDDO
+      ENDIF
+!
+!     Calculate - (g/p*)*d(tau)/d(sigma) and Decel terms DTAUX, DTAUY
+!
+      DO K = 1,KM
+        DO I = 1,npt
+          TAUD(I,K) = G * (TAUP(I,K+1) - TAUP(I,K)) / DEL(ipt(I),K)
+        ENDDO
+      ENDDO
+!
+!------LIMIT DE-ACCELERATION (MOMENTUM DEPOSITION ) AT TOP TO 1/2 VALUE
+!------THE IDEA IS SOME STUFF MUST GO OUT THE 'TOP'
+!
+      DO KLCAP = LCAP, KM
+         DO I = 1,npt
+            TAUD(I,KLCAP) = TAUD(I,KLCAP) * FACTOP
+         ENDDO
+      ENDDO
+!
+!------IF THE GRAVITY WAVE DRAG WOULD FORCE A CRITICAL LINE IN THE
+!------LAYERS BELOW SIGMA=RLOLEV DURING THE NEXT DELTIM TIMESTEP,
+!------THEN ONLY APPLY DRAG UNTIL THAT CRITICAL LINE IS REACHED.
+!
+      DO K = 1,KMM1
+        DO I = 1,npt
+           IF (K > kref(I) .and. PRSI(ipt(i),K) >= RLOLEV) THEN
+             IF(TAUD(I,K) /= 0.) THEN
+               TEM = DELTIM * TAUD(I,K)
+               DTFAC(I) = MIN(DTFAC(I),ABS(VELCO(I,K)/TEM))
+             ENDIF
+           ENDIF
+        ENDDO
+      ENDDO
+!
+!     if(lprnt .and. npr .gt. 0) then
+!       print *,' before  A=',A(npr,:)
+!       print *,' before  B=',B(npr,:)
+!     endif
+
+!> - Calculate outputs: A, B, DUSFC, DVSFC (see parameter description).
+!!  - Below the dividing streamline height (k < idxzb), mountain
+!!    blocking(\f$D_{b}\f$) is applied.
+!!  - Otherwise (k>= idxzb), orographic GWD (\f$\tau\f$) is applied.
+      DO K = 1,KM
+        DO I = 1,npt
+          J         = ipt(i)
+          TAUD(I,K) = TAUD(I,K) * DTFAC(I)
+          DTAUX     = TAUD(I,K) * XN(I)
+          DTAUY     = TAUD(I,K) * YN(I)
+          ENG0      = 0.5*(U1(j,K)*U1(j,K)+V1(J,K)*V1(J,K))
+! ---  lm mb (*j*)  changes overwrite GWD
+          if ( K < IDXZB(I) .AND. IDXZB(I) /= 0 ) then
+            DBIM    =   DB(I,K) / (1.+DB(I,K)*DELTIM)
+            A(J,K)  = - DBIM * V1(J,K) + A(J,K)
+            B(J,K)  = - DBIM * U1(J,K) + B(J,K)
+            ENG1    = ENG0*(1.0-DBIM*DELTIM)*(1.0-DBIM*DELTIM)
+!          if ( ABS(DBIM * U1(J,K)) .gt. .01 )
+!    & print *,' in gwdps_lmi.f KDT=',KDT,I,K,DB(I,K),
+!    &                      dbim,idxzb(I),U1(J,K),V1(J,K),me
+            DUSFC(J) = DUSFC(J) - DBIM * U1(J,K) * DEL(J,K)
+            DVSFC(J) = DVSFC(J) - DBIM * V1(J,K) * DEL(J,K)
+          else
+!
+            A(J,K)   = DTAUY     + A(J,K)
+            B(J,K)   = DTAUX     + B(J,K)
+            ENG1     = 0.5*(                                            &
+                       (U1(J,K)+DTAUX*DELTIM)*(U1(J,K)+DTAUX*DELTIM)    &
+                     + (V1(J,K)+DTAUY*DELTIM)*(V1(J,K)+DTAUY*DELTIM))
+            DUSFC(J) = DUSFC(J)  + DTAUX * DEL(J,K)
+            DVSFC(J) = DVSFC(J)  + DTAUY * DEL(J,K)
+          endif
+          C(J,K) = C(J,K) + max(ENG0-ENG1,0.)/CP/DELTIM
+        ENDDO
+      ENDDO
+!     if (lprnt) then
+!       print *,' in gwdps_lm.f after  A=',A(ipr,:)
+!       print *,' in gwdps_lm.f after  B=',B(ipr,:)
+!       print *,' DB=',DB(ipr,:)
+!     endif
+
+      DO I = 1,npt
+        J          = ipt(i)
+!       TEM    = (-1.E3/G)
+        DUSFC(J) = - onebg * DUSFC(J)
+        DVSFC(J) = - onebg * DVSFC(J)
+      ENDDO
+!
+!    MONITOR FOR EXCESSIVE GRAVITY WAVE DRAG TENDENCIES IF NCNT>0
+!
+!     IF(NCNT.GT.0) THEN
+!        IF(LAT.GE.38.AND.LAT.LE.42) THEN
+!CMIC$ GUARD 37
+!           DO 92 I = 1,IM
+!              IF(IKOUNT.GT.NCNT) GO TO 92
+!              IF(I.LT.319.OR.I.GT.320) GO TO 92
+!              DO 91 K = 1,KM
+!                 IF(ABS(TAUD(I,K)) .GT. CRITAC) THEN
+!                    IF(I.LE.IM) THEN
+!                       IKOUNT = IKOUNT+1
+!                       PRINT 123,I,LAT,KDT
+!                       PRINT 124,TAUB(I),BNV(I),ULOW(I),
+!    1                  GF(I),FR(I),ROLL(I),HPRIME(I),XN(I),YN(I)
+!                       PRINT 124,(TAUD(I,KK),KK = 1,KM)
+!                       PRINT 124,(TAUP(I,KK),KK = 1,KM+1)
+!                       PRINT 124,(ri_n(I,KK),KK = 1,KM)
+!                       DO 93 KK = 1,KMM1
+!                          VELKO(KK) =
+!    1                  0.5*((U1(I,KK)+U1(I,KK+1))*UBAR(I)+
+!    2                  (V1(I,KK)+V1(I,KK+1))*VBAR(I))*ULOI(I)
+!93                     CONTINUE
+!                       PRINT 124,(VELKO(KK),KK = 1,KMM1)
+!                       PRINT 124,(A    (I,KK),KK = 1,KM)
+!                       PRINT 124,(DTAUY(I,KK),KK = 1,KM)
+!                       PRINT 124,(B    (I,KK),KK = 1,KM)
+!                       PRINT 124,(DTAUX(I,KK),KK = 1,KM)
+!                       GO TO 92
+!                    ENDIF
+!                 ENDIF
+!91            CONTINUE
+!92         CONTINUE
+!CMIC$ END GUARD 37
+!123        FORMAT('  *** MIGWD PRINT *** I=',I3,' LAT=',I3,' KDT=',I3)
+!124        FORMAT(2X,  10E13.6)
+!        ENDIF
+!     ENDIF
+!
+!      print *,' in gwdps_lm.f 18  =',A(ipt(1),idxzb(1))
+!    &,                          B(ipt(1),idxzb(1)),me
+
+
+      ENDIF ! do_congwd & cnvgwd
+
+      RETURN
+      end subroutine GFS_GWD_generic_run
+!> @}
+
+!
+!> \section arg_table_GFS_GWD_generic_finalize Argument Table
+!!
+      subroutine GFS_GWD_generic_finalize()
+      end subroutine GFS_GWD_generic_finalize
+
+      end module GFS_GWD_generic
+
+!> This module contains the CCPP-compliant orographic gravity wave drag post
+!! interstitial codes.
+      module GFS_GWD_generic_post
+
+      contains
+
+!! \section arg_table_GFS_GWD_generic_post_init Argument Table
+!!
+      subroutine GFS_GWD_generic_post_init()
+      end subroutine GFS_GWD_generic_post_init
+
+!! \section arg_table_GFS_GWD_generic_post_run Argument Table
+!! | local_name     | standard_name                                                        | long_name                                                                | units | rank | type      | kind      | intent | optional |
+!! |----------------|----------------------------------------------------------------------|--------------------------------------------------------------------------|-------|------|-----------|-----------|--------|----------|
+!! | lssav          | flag_diagnostics                                                     | flag for calculating diagnostic fields                                   | flag  |    0 | logical   |           | in     | F        |
+!! | ldiag3d        | flag_diagnostics_3D                                                  | flag for calculating 3-D diagnostic fields                               | flag  |    0 | logical   |           | in     | F        |
+!! | dtf            | time_step_for_dynamics                                               | dynamics time step                                                       | s     |    0 | real      | kind_phys | in     | F        |
+!! | dusfcg         | instantaneous_x_stress_due_to_gravity_wave_drag                      | zonal surface stress due to orographic gravity wave drag                 | Pa    |    1 | real      | kind_phys | in     | F        |
+!! | dvsfcg         | instantaneous_y_stress_due_to_gravity_wave_drag                      | meridional surface stress due to orographic gravity wave drag            | Pa    |    1 | real      | kind_phys | in     | F        |
+!! | dudt           | tendency_of_x_wind_due_to_model_physics                              | zonal wind tendency due to model physics                                 | m s-2 |    2 | real      | kind_phys | in     | F        |
+!! | dvdt           | tendency_of_y_wind_due_to_model_physics                              | meridional wind tendency due to model physics                            | m s-2 |    2 | real      | kind_phys | in     | F        |
+!! | dtdt           | tendency_of_air_temperature_due_to_model_physics                     | air temperature tendency due to model physics                            | K s-1 |    2 | real      | kind_phys | in     | F        |
+!! | dugwd          | time_integral_of_x_stress_due_to_gravity_wave_drag                   | integral over time of zonal stress due to gravity wave drag              | Pa s  |    1 | real      | kind_phys | inout  | F        |
+!! | dvgwd          | time_integral_of_y_stress_due_to_gravity_wave_drag                   | integral over time of meridional stress due to gravity wave drag         | Pa s  |    1 | real      | kind_phys | inout  | F        |
+!! | du3dt          | cumulative_change_in_x_wind_due_to_orographic_gravity_wave_drag      | cumulative change in zonal wind due to orographic gravity wave drag      | m s-1 |    2 | real      | kind_phys | inout  | F        |
+!! | dv3dt          | cumulative_change_in_y_wind_due_to_orographic_gravity_wave_drag      | cumulative change in meridional wind due to orographic gravity wave drag | m s-1 |    2 | real      | kind_phys | inout  | F        |
+!! | dt3dt          | cumulative_change_in_temperature_due_to_orographic_gravity_wave_drag | cumulative change in temperature due to orographic gravity wave drag     | K     |    2 | real      | kind_phys | inout  | F        |
+!! | do_congwd      | do_congwd_flag                                                       | flag for turning off convective gwd if use UGWP                          | flag  |    0 | logical   |           | none   | F        |
+!! | cnvgwd         | flag_convective_gravity_wave_drag                                    | flag for conv gravity wave drag                                          | flag  |    0 | logical   |           | none   | F        |
+!! | errmsg         | ccpp_error_message                                                   | error message for error handling in CCPP                                 | none  |    0 | character | len=*     | out    | F        |
+!! | errflg         | ccpp_error_flag                                                      | error flag for error handling in CCPP                                    | flag  |    0 | integer   |           | out    | F        |
+!!
+      subroutine GFS_GWD_generic_post_run(                              &
+       lssav, ldiag3d, dtf, dusfcg, dvsfcg, dudt, dvdt, dtdt,           &
+       dugwd, dvgwd, du3dt, dv3dt, dt3dt,                               &
+       do_congwd, cnvgwd, errmsg, errflg)  
+
+      use machine, only : kind_phys
+      implicit none
+
+      logical, intent(in) :: lssav, ldiag3d, do_congwd, cnvgwd
+      real(kind=kind_phys), intent(in) :: dtf
+      real(kind=kind_phys), intent(in) ::                               &
+       dusfcg(:), dvsfcg(:), dudt(:,:), dvdt(:,:), dtdt(:,:)
+
+      real(kind=kind_phys), intent(inout) ::                            &
+       dugwd(:), dvgwd(:), du3dt(:,:), dv3dt(:,:), dt3dt(:,:)
+
+      character(len=*), intent(out) :: errmsg
+      integer,          intent(out) :: errflg
+
+      ! Initialize CCPP error handling variables
+      errmsg = ''
+      errflg = 0
+
+      IF (cnvgwd .and. do_congwd) THEN    
+
+
+      if (lssav) then
+        dugwd(:) = dugwd(:) + dusfcg(:)*dtf
+        dvgwd(:) = dvgwd(:) + dvsfcg(:)*dtf
+
+        if (ldiag3d) then
+          du3dt(:,:) = du3dt(:,:) + dudt(:,:) * dtf
+          dv3dt(:,:) = dv3dt(:,:) + dvdt(:,:) * dtf
+          dt3dt(:,:) = dt3dt(:,:) + dtdt(:,:) * dtf
+        endif
+      endif
+
+
+      ENDIF ! do_congwd & cnvgwd
+
+      end subroutine GFS_GWD_generic_post_run
+
+!> \section arg_table_GFS_GWD_generic_post_finalize Argument Table
+!!
+      subroutine GFS_GWD_generic_post_finalize()
+      end subroutine GFS_GWD_generic_post_finalize
+
+      end module GFS_GWD_generic_post

--- a/physics/GFS_PBL_generic.F90
+++ b/physics/GFS_PBL_generic.F90
@@ -100,18 +100,19 @@
           enddo
         elseif (imp_physics == imp_physics_thompson) then
   ! Thompson
-          ! DH* Thompson ntrw and ntsw?
           if(ltaerosol) then
             do k=1,levs
               do i=1,im
-                vdftra(i,k,1) = qgrs(i,k,ntqv)
-                vdftra(i,k,2) = qgrs(i,k,ntcw)
-                vdftra(i,k,3) = qgrs(i,k,ntiw)
-                vdftra(i,k,4) = qgrs(i,k,ntlnc)
-                vdftra(i,k,5) = qgrs(i,k,ntinc)
-                vdftra(i,k,6) = qgrs(i,k,ntoz)
-                vdftra(i,k,7) = qgrs(i,k,ntwa)
-                vdftra(i,k,8) = qgrs(i,k,ntia)
+                vdftra(i,k,1)  = qgrs(i,k,ntqv)
+                vdftra(i,k,2)  = qgrs(i,k,ntcw)
+                vdftra(i,k,3)  = qgrs(i,k,ntiw)
+                vdftra(i,k,4)  = qgrs(i,k,ntrw)
+                vdftra(i,k,5)  = qgrs(i,k,ntsw)
+                vdftra(i,k,6)  = qgrs(i,k,ntlnc)
+                vdftra(i,k,7)  = qgrs(i,k,ntinc)
+                vdftra(i,k,8)  = qgrs(i,k,ntoz)
+                vdftra(i,k,9)  = qgrs(i,k,ntwa)
+                vdftra(i,k,10) = qgrs(i,k,ntia)
               enddo
             enddo
           else
@@ -120,8 +121,10 @@
                 vdftra(i,k,1) = qgrs(i,k,ntqv)
                 vdftra(i,k,2) = qgrs(i,k,ntcw)
                 vdftra(i,k,3) = qgrs(i,k,ntiw)
-                vdftra(i,k,4) = qgrs(i,k,ntinc)
-                vdftra(i,k,5) = qgrs(i,k,ntoz)
+                vdftra(i,k,4) = qgrs(i,k,ntrw)
+                vdftra(i,k,5) = qgrs(i,k,ntsw)
+                vdftra(i,k,6) = qgrs(i,k,ntinc)
+                vdftra(i,k,7) = qgrs(i,k,ntoz)
               enddo
             enddo
           endif
@@ -362,18 +365,19 @@
           enddo
         elseif (imp_physics == imp_physics_thompson) then
   ! Thompson
-          ! DH* - Thompson ntrw, ntsw?
           if(ltaerosol) then
             do k=1,levs
               do i=1,im
                 dqdt(i,k,ntqv)  = dvdftra(i,k,1)
                 dqdt(i,k,ntcw)  = dvdftra(i,k,2)
                 dqdt(i,k,ntiw)  = dvdftra(i,k,3)
-                dqdt(i,k,ntlnc) = dvdftra(i,k,4)
-                dqdt(i,k,ntinc) = dvdftra(i,k,5)
-                dqdt(i,k,ntoz)  = dvdftra(i,k,6)
-                dqdt(i,k,ntwa)  = dvdftra(i,k,7)
-                dqdt(i,k,ntia)  = dvdftra(i,k,8)
+                dqdt(i,k,ntrw)  = dvdftra(i,k,4)
+                dqdt(i,k,ntsw)  = dvdftra(i,k,5)
+                dqdt(i,k,ntlnc) = dvdftra(i,k,6)
+                dqdt(i,k,ntinc) = dvdftra(i,k,7)
+                dqdt(i,k,ntoz)  = dvdftra(i,k,8)
+                dqdt(i,k,ntwa)  = dvdftra(i,k,9)
+                dqdt(i,k,ntia)  = dvdftra(i,k,10)
               enddo
             enddo
           else
@@ -382,8 +386,10 @@
                 dqdt(i,k,ntqv)  = dvdftra(i,k,1)
                 dqdt(i,k,ntcw)  = dvdftra(i,k,2)
                 dqdt(i,k,ntiw)  = dvdftra(i,k,3)
-                dqdt(i,k,ntinc) = dvdftra(i,k,4)
-                dqdt(i,k,ntoz)  = dvdftra(i,k,5)
+                dqdt(i,k,ntrw)  = dvdftra(i,k,4)
+                dqdt(i,k,ntsw)  = dvdftra(i,k,5)
+                dqdt(i,k,ntinc) = dvdftra(i,k,6)
+                dqdt(i,k,ntoz)  = dvdftra(i,k,7)
               enddo
             enddo
           endif

--- a/physics/cires_ugwp.F90
+++ b/physics/cires_ugwp.F90
@@ -1,0 +1,356 @@
+!>  \file cires_ugwp.F90
+!! This file contains the Unified Gravity Wave Physics (UGWP) scheme by Valery Yudin (University of Colorado, CIRES)
+!! See Valery Yudin's presentation at 2017 NGGPS PI meeting:
+!! Gravity waves (GWs): Mesoscale GWs transport momentum, energy (heat) , and create eddy mixing in the whole atmosphere domain; Breaking and dissipating GWs deposit: (a) momentum; (b) heat (energy); and create (c) turbulent mixing of momentum, heat, and tracers
+!! To properly incorporate GW effects (a-c) unresolved by DYCOREs we need GW physics
+!! "Unified": a) all GW effects due to both dissipation/breaking; b) identical GW solvers for all GW sources; c) ability to replace solvers.
+!! Unified Formalism: 
+!! 1. GW Sources: Stochastic and physics based mechanisms for GW-excitations in the lower atmosphere, calibrated by the high-res analyses/forecasts, and observations (3 types of GW sources: orography, convection, fronts/jets).
+!! 2. GW Propagation: Unified solver for “propagation, dissipation and breaking” excited from all type of GW sources. 
+!! 3. GW Effects: Unified representation of GW impacts on the ‘resolved’ flow for all sources (energy-balanced schemes for momentum, heat and mixing).
+!! https://www.weather.gov/media/sti/nggps/Presentations%202017/02%20NGGPS_VYUDIN_2017_.pdf
+
+module cires_ugwp
+
+    use cires_ugwp_module, only: cires_ugwp_mod_init, cires_ugwp_mod_finalize, GWDPS_V0, slat_geos5_tamp, fv3_ugwp_solv2_v0, edmix_ugwp_v0, diff_1d_wtend, diff_1d_ptend
+ 
+
+    implicit none
+
+    logical :: is_initialized = .False.
+
+contains
+! ------------------------------------------------------------------------
+! CCPP entry points for CIRES Unified Gravity Wave Physics (UGWP) scheme v0
+! ------------------------------------------------------------------------
+!>@brief The subroutine initializes the CIRES UGWP
+#if 0
+!> \section arg_table_cires_ugwp_init Argument Table
+!! | local_name       | standard_name                                                                 | long_name                                               | units  | rank | type      | kind      | intent | optional |
+!! |------------------|-------------------------------------------------------------------------------|---------------------------------------------------------|--------|------|-----------|-----------|--------|----------|
+!! | me               | mpi_rank                                                                      | MPI rank of current process                             | index  | 0    | integer   |           | in     | F        |
+!! | master           | mpi_root                                                                      | MPI rank of master process                              | index  | 0    | integer   |           | in     | F        |
+!! | nlunit           | iounit_namelist                                                               | fortran unit number for opening namelist file           | none   | 0    | integer   |           | in     | F        |
+!! | logunit          | iounit_log                                                                    | fortran unit number for writing logfile                 | none   | 0    | integer   |           | in     | F        |
+!! | fn_nml2          | namelist_filename                                                             | namelist filename for ugwp                              | none   | 0    | character | len=*     | in     | F        |
+!! | lonr             | number_of_equatorial_longitude_points                                         | number of global points in x-dir (i) along the equator  | count  | 0    | integer   |           | in     | F        |
+!! | latr             | number_of_latitude_points                                                     | number of global points in y-dir (j) along the meridian | count  | 0    | integer   |           | none   | F        |
+!! | levs             | vertical_dimension                                                            | number of vertical levels                               | count  | 0    | integer   |           | in     | F        |
+!! | ak               | a_parameter_of_the_hybrid_coordinate                                          | a parameter for sigma pressure level calculations       | Pa     | 1    | real      | kind_phys | none   | F        |
+!! | bk               | b_parameter_of_the_hybrid_coordinate                                          | b parameter for sigma pressure level calculations       | none   | 1    | real      | kind_phys | none   | F        |
+!! | dtp              | time_step_for_physics                                                         | physics timestep                                        | s      | 0    | real      | kind_phys | in     | F        |
+!! | cdmvgwd          | multiplication_factors_for_mountain_blocking_and_orographic_gravity_wave_drag | multiplication factors for cdmb and gwd                 | none   | 1    | real      | kind_phys | in     | F        |
+!! | cgwf             | multiplication_factors_for_convective_gravity_wave_drag                       | multiplication factor for convective GWD                | none   | 1    | real      | kind_phys | in     | F        | 
+!! | errmsg           | ccpp_error_message                                                            | error message for error handling in CCPP                | none   | 0    | character | len=*     | out    | F        |
+!! | errflg           | ccpp_error_flag                                                               | error flag for error handling in CCPP                   | flag   | 0    | integer   |           | out    | F        |
+!!
+#endif
+! -----------------------------------------------------------------------
+!
+    subroutine cires_ugwp_init (me, master, nlunit, logunit, fn_nml2, &
+              lonr, latr, levs, ak, bk, dtp, cdmvgwd, cgwf,  &
+              errmsg, errflg)
+
+    use physcons,      only: con_p0 ! pref in VAY's code
+
+!----  initialization of cires_ugwp 
+    implicit none
+    
+    integer, intent (in) :: me
+    integer, intent (in) :: master
+    integer, intent (in) :: nlunit
+    integer, intent (in) :: logunit
+    integer, intent (in) :: lonr
+    integer, intent (in) :: levs
+    integer, intent (in) :: latr   
+    real,    intent(in), dimension(levs+1):: ak, bk
+    !real(kind=kind_phys),    intent (in) :: ak(levs+1), bk(levs+1)
+    real,    intent (in) :: dtp   
+    real,    intent (in) :: cdmvgwd(2), cgwf(2)             ! "scaling" controls for "old" GFS-GW schemes     
+         
+    character(len=*), intent (in) :: fn_nml2
+    !character(len=*), parameter   :: fn_nml='input.nml' 
+
+
+    integer :: ios
+    logical :: exists
+    real    :: dxsg 
+    integer :: k
+
+    character(len=*), intent(out) :: errmsg
+    integer,          intent(out) :: errflg
+
+    ! Initialize CCPP error handling variables
+    errmsg = ''
+    errflg = 0
+    
+
+
+    if (is_initialized) return
+
+
+    call cires_ugwp_mod_init (me, master, nlunit, logunit, fn_nml2, &
+                              lonr, latr, levs, ak, bk, con_p0, dtp, cdmvgwd, cgwf) 
+
+    is_initialized = .true.
+
+
+    end subroutine cires_ugwp_init
+
+
+
+
+! -----------------------------------------------------------------------
+! finalize of cires_ugwp   (_finalize) 
+! -----------------------------------------------------------------------
+
+!>@brief The subroutine finalizes the CIRES UGWP
+#if 0
+!> \section arg_table_cires_ugwp_finalize Argument Table
+!! | local_name       | standard_name                                                                 | long_name                                               | units  | rank | type      | kind      | intent | optional |
+!! |------------------|-------------------------------------------------------------------------------|---------------------------------------------------------|--------|------|-----------|-----------|--------|----------|
+!! | errmsg           | ccpp_error_message                                                            | error message for error handling in CCPP                | none   | 0    | character | len=*     | out    | F        |
+!! | errflg           | ccpp_error_flag                                                               | error flag for error handling in CCPP                   | flag   | 0    | integer   |           | out    | F        |
+!!
+#endif
+    subroutine cires_ugwp_finalize(errmsg, errflg)
+
+    implicit none
+!
+    character(len=*), intent(out) :: errmsg
+    integer,          intent(out) :: errflg
+
+! Initialize CCPP error handling variables
+    errmsg = ''
+    errflg = 0
+
+    if (.not.is_initialized) return
+
+    call cires_ugwp_mod_finalize()
+
+    is_initialized = .false.
+            
+    end subroutine cires_ugwp_finalize  
+    
+
+
+
+
+! -----------------------------------------------------------------------
+!    originally from ugwp_driver_v0.f
+!    driver of cires_ugwp   (_driver)
+! -----------------------------------------------------------------------
+!   driver is called after pbl & before chem-parameterizations
+! -----------------------------------------------------------------------
+!  order = dry-adj=>conv=mp-aero=>radiation -sfc/land- chem -> vertdiff-> [rf-gws]=> ion-re
+! -----------------------------------------------------------------------
+!>@brief The subroutine executes the CIRES UGWP
+#if 0
+!> \section arg_table_cires_ugwp_run Argument Table
+!! | local_name       | standard_name                                                                  | long_name                                                    | units     | rank | type      | kind      | intent | optional |
+!! |------------------|--------------------------------------------------------------------------------|--------------------------------------------------------------|-----------|------|-----------|-----------|--------|----------|
+!! | do_ugwp          | do_ugwp                                                                        | flag to activate CIRES UGWP                                  | flag      | 0    | logical   |           | none   | F        |
+!! | me               | mpi_rank                                                                       | MPI rank of current process                                  | index     | 0    | integer   |           | in     | F        |
+!! | master           | mpi_root                                                                       | MPI rank of master process                                   | index     | 0    | integer   |           | in     | F        |
+!! | im               | horizontal_loop_extent                                                         | horizontal                                                   | count     | 0    | integer   |           | in     | F        |
+!! | levs             | vertical_dimension                                                             | number of vertical levels                                    | count     | 0    | integer   |           | in     | F        |
+!! | ntrac            | number_of_tracers                                                              | number of tracers                                            | count     | 0    | integer   |           | in     | F        |
+!! | dtp              | time_step_for_physics                                                          | physics timestep                                             | s         | 0    | real      | kind_phys | in     | F        |
+!! | kdt              | index_of_time_step                                                             | current forecast iteration                                   | index     | 0    | integer   |           | in     | F        |
+!! | lonr             | number_of_equatorial_longitude_points                                          | number of global points in x-dir (i) along the equator       | count     | 0    | integer   |           | in     | F        |
+!! | oro              | orography                                                                      | orography                                                    | m         | 1    | real      | kind_phys | in     | F        |
+!! | oro_uf           | orography_unfiltered                                                           | unfiltered orography                                         | m         | 1    | real      | kind_phys | in     | F        |
+!! | hprime           | standard_deviation_of_subgrid_orography                                        | standard deviation of subgrid orography                      | m         | 1    | real      | kind_phys | out    | F        |
+!! | nmtvr            | number_of_statistical_measures_of_subgrid_orography                            | number of topographic variables in GWD                       | count     | 0    | integer   |           | in     | F        |
+!! | oc               | convexity_of_subgrid_orography                                                 | convexity of subgrid orography                               | none      | 1    | real      | kind_phys | out    | F        |
+!! | oa4              | asymmetry_of_subgrid_orography                                                 | asymmetry of subgrid orography                               | none      | 2    | real      | kind_phys | out    | F        |
+!! | clx              | fraction_of_grid_box_with_subgrid_orography_higher_than_critical_height        | horizontal fraction of grid box covered by subgrid orography higher than critical height | frac    | 2 | real | kind_phys | out | F |
+!! | theta            | angle_from_east_of_maximum_subgrid_orographic_variations                       | angle with_respect to east of maximum subgrid orographic variations                      | degrees | 1 | real | kind_phys | out | F |
+!! | sigma            | slope_of_subgrid_orography                                                     | slope of subgrid orography                                   | none      | 1    | real      | kind_phys | out    | F        |
+!! | gamma            | anisotropy_of_subgrid_orography                                                | anisotropy of subgrid orography                              | none      | 1    | real      | kind_phys | out    | F        |
+!! | elvmax           | maximum_subgrid_orography                                                      | maximum of subgrid orography                                 | m         | 1    | real      | kind_phys | out    | F        |
+!! | do_tofd          | turb_oro_form_drag_flag                                                        | flag for turbulent orographic form drag                      | flag      | 0    | logical   |           | none   | F        | 
+!! | cdmbgwd          | multiplication_factors_for_mountain_blocking_and_orographic_gravity_wave_drag  | multiplication factors for cdmb and gwd                      | none      | 1    | real      | kind_phys | in     | F        |
+!! | xlat             | latitude                                                                       | grid latitude in radians                                     | radians   | 1    | real      | kind_phys | in     | F        | 
+!! | xlat_d           | latitude_degree                                                                | latitude in degrees                                          | degree    | 1    | real      | kind_phys | in     | F        |
+!! | sinlat           | sine_of_latitude                                                               | sine of the grid latitude                                    | none      | 1    | real      | kind_phys | in     | F        |
+!! | coslat           | cosine_of_latitude                                                             | cosine of the grid latitude                                  | none      | 1    | real      | kind_phys | in     | F        |  
+!! | area             | cell_area                                                                      | area of the grid cell                                        | m2        | 1    | real      | kind_phys | none   | F        |
+!! | ugrs             | x_wind                                                                         | zonal wind                                                   | m s-1     | 2    | real      | kind_phys | in     | F        |
+!! | vgrs             | y_wind                                                                         | meridional wind                                              | m s-1     | 2    | real      | kind_phys | in     | F        |
+!! | tgrs             | air_temperature                                                                | model layer mean temperature                                 | K         | 2    | real      | kind_phys | in     | F        |
+!! | qgrs             | tracer_concentration                                                           | model layer mean tracer concentration                        | kg kg-1   | 3    | real      | kind_phys | in     | F        |
+!! | prsi             | air_pressure_at_interface                                                      | air pressure at model layer interfaces                       | Pa        | 2    | real      | kind_phys | in     | F        |
+!! | prsl             | air_pressure                                                                   | mean layer pressure                                          | Pa        | 2    | real      | kind_phys | in     | F        |
+!! | prslk            | dimensionless_exner_function_at_model_layers                                   | dimensionless Exner function at model layer centers          | none      | 2    | real      | kind_phys | in     | F        |
+!! | phii             | geopotential_at_interface                                                      | geopotential at model layer interfaces                       | m2 s-2    | 2    | real      | kind_phys | in     | F        |
+!! | phil             | geopotential                                                                   | geopotential at model layer centers                          | m2 s-2    | 2    | real      | kind_phys | in     | F        |
+!! | del              | air_pressure_difference_between_midlayers                                      | air pressure difference between midlayers                    | Pa        | 2    | real      | kind_phys | none   | F        |
+!! | kpbl             | vertical_index_at_top_of_atmosphere_boundary_layer                             | vertical index at top atmospheric boundary layer             | index     | 1    | integer   |           | in     | F        |
+!! | dusfcg           | instantaneous_x_stress_due_to_gravity_wave_drag                                | zonal surface stress due to orographic gravity wave drag     | Pa        | 1    | real      | kind_phys | none   | F        |
+!! | dvsfcg           | instantaneous_y_stress_due_to_gravity_wave_drag                                | meridional surface stress due to orographic gravity wave drag| Pa        | 1    | real      | kind_phys | none   | F        |
+!! | gw_dudt          | tendency_of_x_wind_due_to_ugwp                                                 | zonal wind tendency due to UGWP                              | m s-2     | 2    | real      | kind_phys | none   | F        |
+!! | gw_dvdt          | tendency_of_y_wind_due_to_ugwp                                                 | meridional wind tendency due to UGWP                         | m s-2     | 2    | real      | kind_phys | none   | F        |
+!! | gw_dtdt          | tendency_of_air_temperature_due_to_ugwp                                        | air temperature tendency due to UGWP                         | K s-1     | 2    | real      | kind_phys | none   | F        |
+!! | gw_kdis          | eddy_mixing_due_to_ugwp                                                        | eddy mixing due to UGWP                                      | m2 s-1    | 2    | real      | kind_phys | none   | F        |
+!! | tau_tofd         | instantaneous_momentum_flux_due_to_turbulent_orographic_form_drag              | momentum flux or stress due to TOFD                          | Pa        | 2    | real      | kind_phys | none   | F        | 
+!! | tau_mtb          | instantaneous_momentum_flux_due_to_mountain_blocking_drag                      | momentum flux or stress due to mountain blocking drag        | Pa        | 2    | real      | kind_phys | none   | F        | 
+!! | tau_ogw          | instantaneous_momentum_flux_due_to_orographic_gravity_wave_drag                | momentum flux or stress due to orographic gravity wave drag  | Pa        | 2    | real      | kind_phys | none   | F        | 
+!! | tau_ngw          | instantaneous_momentum_flux_due_to_nonstationary_gravity_wave                  | momentum flux or stress due to nonstationary gravity waves   | Pa        | 2    | real      | kind_phys | none   | F        | 
+!! | zmtb             | height_of_mountain_blocking                                                    | height of mountain blocking drag                             | m         | 1    | real      | kind_phys | none   | F        |
+!! | zlwb             | height_of_low_level_wave_breaking                                              | height of low level wave breaking                            | m         | 1    | real      | kind_phys | none   | F        |   
+!! | zogw             | height_of_launch_level_of_orographic_gravity_wave                              | height of launch level of orographic gravity wave            | m         | 1    | real      | kind_phys | none   | F        | 
+!! | dudt_mtb         | instantaneous_change_in_x_wind_due_to_mountain_blocking_drag                   | instantaneous change in x wind due to mountain blocking drag | m s-2     | 2    | real      | kind_phys | none   | F        | 
+!! | dudt_ogw         | instantaneous_change_in_x_wind_due_to_orographic_gravity_wave_drag             | instantaneous change in x wind due to orographic gw drag     | m s-2     | 2    | real      | kind_phys | none   | F        | 
+!! | dudt_tms         | instantaneous_change_in_x_wind_due_to_turbulent_orographic_form_drag           | instantaneous change in x wind due to TOFD                   | m s-2     | 2    | real      | kind_phys | none   | F        | 
+!! | dudt             | tendency_of_x_wind_due_to_model_physics                                        | zonal wind tendency due to model physics                     | m s-2     | 2    | real      | kind_phys | none   | F        |
+!! | dvdt             | tendency_of_y_wind_due_to_model_physics                                        | meridional wind tendency due to model physics                | m s-2     | 2    | real      | kind_phys | none   | F        |
+!! | dtdt             | tendency_of_air_temperature_due_to_model_physics                               | air temperature tendency due to model physics                | K s-1     | 2    | real      | kind_phys | none   | F        |
+!! | rdxzb            | level_of_dividing_streamline                                                   | level of the dividing streamline                             | none      | 1    | real      | kind_phys | none   | F        |
+!! | errmsg           | ccpp_error_message                                                             | error message for error handling in CCPP                     | none      | 0    | character | len=*     | out    | F        |
+!! | errflg           | ccpp_error_flag                                                                | error flag for error handling in CCPP                        | flag      | 0    | integer   |           | out    | F        |
+!!
+#endif
+
+! subroutines original
+     subroutine cires_ugwp_run(do_ugwp, me,  master, im,  levs, ntrac, dtp, kdt, lonr,  &
+         oro, oro_uf, hprime, nmtvr, oc, theta, sigma, gamma, elvmax, clx, oa4,& 
+         do_tofd,  cdmbgwd,  xlat, xlat_d, sinlat, coslat, area,               &
+         ugrs, vgrs, tgrs, qgrs, prsi, prsl, prslk, phii, phil,                &
+         del, kpbl, dusfcg, dvsfcg, gw_dudt, gw_dvdt, gw_dtdt, gw_kdis,        &
+         tau_tofd, tau_mtb, tau_ogw, tau_ngw, zmtb, zlwb, zogw,                & 
+         dudt_mtb,dudt_ogw, dudt_tms, dudt, dvdt, dtdt, rdxzb,                 &
+         errmsg, errflg)
+
+               
+    use machine,       only: kind_phys
+    use physcons,      only: con_g, con_pi, con_cp, con_rd, con_rv, con_fvirt
+
+    implicit none
+
+    ! interface variables     
+    integer,                 intent(in) :: me, master, im, levs, ntrac, kdt, lonr, nmtvr
+    integer,                 intent(in), dimension(im)       :: kpbl
+    real(kind=kind_phys),    intent(in), dimension(im)       :: oro, oro_uf, hprime, oc, theta, sigma, gamma, elvmax
+    real(kind=kind_phys),    intent(in), dimension(im, 4)    :: clx, oa4
+    real(kind=kind_phys),    intent(in), dimension(im)       :: xlat, xlat_d, sinlat, coslat, area
+    real(kind=kind_phys),    intent(in), dimension(im, levs) :: del, ugrs, vgrs, tgrs, prsl, prslk, phil
+    real(kind=kind_phys),    intent(in), dimension(im, levs+1) :: prsi, phii
+    real(kind=kind_phys),    intent(in), dimension(im, levs, ntrac):: qgrs
+    real(kind=kind_phys),    intent(in) :: dtp, cdmbgwd(2)
+    logical,                 intent(in) :: do_ugwp, do_tofd
+
+    real(kind=kind_phys),    intent(out), dimension(im)      :: dusfcg, dvsfcg 
+    real(kind=kind_phys),    intent(out), dimension(im)      :: zmtb, zlwb, zogw, rdxzb
+    real(kind=kind_phys),    intent(out), dimension(im)      :: tau_mtb, tau_ogw, tau_tofd, tau_ngw
+    real(kind=kind_phys),    intent(out), dimension(im, levs):: gw_dudt, gw_dvdt, gw_dtdt, gw_kdis
+    real(kind=kind_phys),    intent(out), dimension(im, levs):: dudt_mtb, dudt_ogw, dudt_tms
+
+    real(kind=kind_phys),    intent(inout), dimension(im, levs):: dudt, dvdt, dtdt
+
+    character(len=*),        intent(out) :: errmsg
+    integer,                 intent(out) :: errflg
+
+
+    ! local variables
+    integer :: i, k
+    real(kind=kind_phys), dimension(im)       :: sgh30
+    real(kind=kind_phys), dimension(im, levs) :: Pdvdt, Pdudt
+    real(kind=kind_phys), dimension(im, levs) :: Pdtdt, Pkdis
+    real(kind=kind_phys), dimension(im, levs) :: ed_dudt, ed_dvdt, ed_dtdt
+    ! what is tamp_mpa? amplitude in a unit of mPa? need to confirm with VAY
+    real(kind=kind_phys), parameter :: tamp_mpa=30.e-3
+    ! switches that activate impact of OGWs and NGWs (WL* how to deal with them? *WL)
+    real(kind=kind_phys), parameter :: pogw=1., pngw=1., pked=1.
+
+
+    ! Initialize CCPP error handling variables
+    errmsg = ''
+    errflg = 0
+
+    ! wrap everything in a do_ugwp 'if test' in order not to break the namelist functionality
+    IF (do_ugwp) THEN
+
+        ! topo paras
+        ! w/ orographic effects
+        if(nmtvr == 14)then         
+            ! calculate sgh30 for TOFD
+            sgh30 = abs(oro - oro_uf)
+        ! w/o orographic effects
+        else
+            sgh30   = 0.
+        endif
+
+        zlwb(:)   = 0.
+
+        call GWDPS_V0(im, levs, lonr, do_tofd, Pdvdt, Pdudt, Pdtdt, Pkdis,          &
+             ugrs, vgrs, tgrs, qgrs(:,:,1), kpbl, prsi,del,prsl, prslk, phii, phil, &
+             dtp, kdt, sgh30, hprime, oc, oa4, clx, theta, sigma, gamma, elvmax,    &
+             dusfcg, dvsfcg, xlat_d, sinlat, coslat, area, nmtvr, cdmbgwd,          &
+             me, master, rdxzb, zmtb, zogw, tau_mtb, tau_ogw, tau_tofd, dudt_mtb, dudt_ogw, dudt_tms)
+
+
+
+        ! 1) non-stationary GW-scheme with GMAO/MERRA GW-forcing
+        call slat_geos5_tamp(im, tamp_mpa, xlat_d, tau_ngw)
+
+
+        ! 2) non-stationary GW-scheme with GEOS-5/MERRA GW-forcing
+        call fv3_ugwp_solv2_v0(im, levs, dtp, tgrs, ugrs, vgrs,qgrs(:,:,1), &
+             prsl, prsi, phil, xlat_d, sinlat, coslat, gw_dudt, gw_dvdt, gw_dtdt, gw_kdis, &
+             tau_ngw, me, master, kdt)
+
+    
+        if(pogw /= 0.)then
+
+            do k=1,levs
+            do i=1,im
+                gw_dtdt(i,k) = pngw*gw_dtdt(i,k)+ pogw*Pdtdt(i,k)
+                gw_dudt(i,k) = pngw*gw_dudt(i,k)+ pogw*Pdudt(i,k)
+                gw_dvdt(i,k) = pngw*gw_dvdt(i,k)+ pogw*Pdvdt(i,k)
+                gw_kdis(i,k) = pngw*gw_kdis(i,k)+ pogw*Pkdis(i,k)
+
+                ! accumulation of tendencies for CCPP to replicate EMC-physics updates (!! removed in latest code commit to VLAB)
+                dudt(i,k) = dudt(i,k) +gw_dudt(i,k)
+                dvdt(i,k) = dvdt(i,k) +gw_dvdt(i,k)
+                dtdt(i,k) = dtdt(i,k) +gw_dtdt(i,k)  
+            enddo
+            enddo
+
+        else
+
+            tau_mtb = 0.  ; tau_ogw =0.;     tau_tofd =0.
+            dudt_mtb =0. ; dudt_ogw = 0.;  dudt_tms=0.  
+
+        endif 
+
+        return
+
+
+        !=============================================================================
+        ! make "ugwp eddy-diffusion" update for gw_dtdt/gw_dudt/gw_dvdt by solving
+        ! vert diffusion equations & update "Statein%tgrs, Statein%ugrs, Statein%vgrs"
+        !=============================================================================
+        ! 3) application of "eddy"-diffusion to "smooth" UGWP-related tendencies
+        !------------------------------------------------------------------------------
+        ed_dudt(:,:) =0.; ed_dvdt(:,:) = 0. ; ed_dtdt(:,:) = 0.
+    
+        call edmix_ugwp_v0(im, levs, dtp, tgrs, ugrs, vgrs, qgrs(:,:,1), &
+             del, prsl, prsi, phil, prslk, gw_dudt, gw_dvdt, gw_dtdt, gw_kdis, &
+             ed_dudt, ed_dvdt, ed_dtdt, me, master, kdt)
+        
+        gw_dtdt = gw_dtdt*(1.-pked) +  ed_dtdt*pked
+        gw_dvdt = gw_dvdt*(1.-pked) +  ed_dvdt*pked
+        gw_dudt = gw_dudt*(1.-pked) +  ed_dudt*pked
+
+
+
+    ENDIF ! do_ugwp
+
+
+    end subroutine cires_ugwp_run
+
+
+
+
+end module cires_ugwp

--- a/physics/cires_ugwp_post.F90
+++ b/physics/cires_ugwp_post.F90
@@ -1,0 +1,115 @@
+!>  \file cires_ugwp_post.F90
+!! This file contains
+module cires_ugwp_post
+
+contains
+
+!>\defgroup cires_ugwp_post CIRES UGWP Scheme Post
+!! @{
+!> \section arg_table_cires_ugwp_post_init Argument Table
+!!
+    subroutine cires_ugwp_post_init ()
+    end subroutine cires_ugwp_post_init
+
+!>@brief The subroutine initializes the CIRES UGWP
+#if 0
+!> \section arg_table_cires_ugwp_post_run Argument Table
+!! | local_name       | standard_name                                                                  | long_name                                                              | units     | rank |  type     |   kind    | intent | optional |
+!! |------------------|--------------------------------------------------------------------------------|------------------------------------------------------------------------|-----------|------|-----------|-----------|--------|----------|
+!! | ldiag_ugwp       | diag_ugwp_flag                                                                 | flag for CIRES UGWP Diagnostics                                        | flag      | 0    | logical   |           | in     | F        |
+!! | dtf              | time_step_for_dynamics                                                         | dynamics timestep                                                      | s         | 0    | real      | kind_phys | none   | F        |
+!! | im               | horizontal_loop_extent                                                         | horizontal loop extent                                                 | count     | 0    | integer   |           | in     | F        |
+!! | levs             | vertical_dimension                                                             | number of vertical levels                                              | count     | 0    | integer   |           | in     | F        |
+!! | gw_dudt          | tendency_of_x_wind_due_to_ugwp                                                 | zonal wind tendency due to UGWP                                        | m s-2     | 2    | real      | kind_phys | none   | F        |
+!! | tau_tofd         | instantaneous_momentum_flux_due_to_turbulent_orographic_form_drag              | momentum flux or stress due to TOFD                                    | Pa        | 2    | real      | kind_phys | none   | F        |
+!! | tau_mtb          | instantaneous_momentum_flux_due_to_mountain_blocking_drag                      | momentum flux or stress due to mountain blocking drag                  | Pa        | 2    | real      | kind_phys | none   | F        |
+!! | tau_ogw          | instantaneous_momentum_flux_due_to_orographic_gravity_wave_drag                | momentum flux or stress due to orographic gravity wave drag            | Pa        | 2    | real      | kind_phys | none   | F        |
+!! | tau_ngw          | instantaneous_momentum_flux_due_to_nonstationary_gravity_wave                  | momentum flux or stress due to nonstationary gravity waves             | Pa        | 2    | real      | kind_phys | none   | F        |
+!! | zmtb             | height_of_mountain_blocking                                                    | height of mountain blocking drag                                       | m         | 1    | real      | kind_phys | none   | F        |
+!! | zlwb             | height_of_low_level_wave_breaking                                              | height of low level wave breaking                                      | m         | 1    | real      | kind_phys | none   | F        |
+!! | zogw             | height_of_launch_level_of_orographic_gravity_wave                              | height of launch level of orographic gravity wave                      | m         | 1    | real      | kind_phys | none   | F        |
+!! | dudt_mtb         | instantaneous_change_in_x_wind_due_to_mountain_blocking_drag                   | instantaneous change in x wind due to mountain blocking drag           | m s-2     | 2    | real      | kind_phys | none   | F        |
+!! | dudt_ogw         | instantaneous_change_in_x_wind_due_to_orographic_gravity_wave_drag             | instantaneous change in x wind due to orographic gw drag               | m s-2     | 2    | real      | kind_phys | none   | F        |
+!! | dudt_tms         | instantaneous_change_in_x_wind_due_to_turbulent_orographic_form_drag           | instantaneous change in x wind due to TOFD                             | m s-2     | 2    | real      | kind_phys | none   | F        |
+!! | do_congwd        | do_congwd_flag                                                                 | flag for turning off convective gwd if use UGWP                        | flag      | 0    | logical   |           | none   | F        |
+!! | tot_zmtb         | time_integral_of_height_of_mountain_blocking                                   | time integral of height of mountain blocking drag                      | m         | 1    | real      | kind_phys | none   | F        |
+!! | tot_zlwb         | time_integral_of_height_of_low_level_wave_breaking                             | time integral of height of drag due to low level wave breaking         | m         | 1    | real      | kind_phys | none   | F        |
+!! | tot_zogw         | time_integral_of_height_of_launch_level_of_orographic_gravity_wave             | time integral of height of launch level of orographic gravity wave     | m         | 1    | real      | kind_phys | none   | F        |
+!! | tot_tofd         | time_integral_of_momentum_flux_due_to_turbulent_orographic_form_drag           | time integral of momentum flux due to TOFD                             | Pa        | 2    | real      | kind_phys | none   | F        |
+!! | tot_mtb          | time_integral_of_momentum_flux_due_to_mountain_blocking_drag                   | time integral of momentum flux due to mountain blocking drag           | Pa        | 2    | real      | kind_phys | none   | F        |
+!! | tot_ogw          | time_integral_of_momentum_flux_due_to_orographic_gravity_wave_drag             | time integral of momentum flux due to orographic gravity wave drag     | Pa        | 2    | real      | kind_phys | none   | F        |
+!! | tot_ngw          | time_integral_of_momentum_flux_due_to_nonstationary_gravity_wave               | time integral of momentum flux due to nonstationary gravity waves      | Pa        | 2    | real      | kind_phys | none   | F        |
+!! | du3dt_mtb        | time_integral_of_change_in_x_wind_due_to_mountain_blocking_drag                | time integral of change in x wind due to mountain blocking drag        | m s-2     | 2    | real      | kind_phys | none   | F        |
+!! | du3dt_ogw        | time_integral_of_change_in_x_wind_due_to_orographic_gravity_wave_drag          | time integral of change in x wind due to orographic gw drag            | m s-2     | 2    | real      | kind_phys | none   | F        |
+!! | du3dt_tms        | time_integral_of_change_in_x_wind_due_to_turbulent_orographic_form_drag        | time integral of change in x wind due to TOFD                          | m s-2     | 2    | real      | kind_phys | none   | F        |
+!! | du3dt_ngw        | time_integral_of_change_in_x_wind_due_to_nonstationary_gravity_wave            | time integral of change in x wind due to NGW                           | m s-2     | 2    | real      | kind_phys | none   | F        |
+!! | errmsg           | ccpp_error_message                                                             | error message for error handling in CCPP                               | none      | 0    | character | len=*     | out    | F        |
+!! | errflg           | ccpp_error_flag                                                                | error flag for error handling in CCPP                                  | flag      | 0    | integer   |           | out    | F        |
+!!
+#endif
+
+
+     subroutine cires_ugwp_post_run (ldiag_ugwp, dtf, im, levs,      &
+         gw_dudt, tau_tofd, tau_mtb, tau_ogw, tau_ngw,              &
+         zmtb, zlwb, zogw, dudt_mtb, dudt_ogw, dudt_tms,            &
+         tot_zmtb, tot_zlwb, tot_zogw,                              &
+         tot_tofd, tot_mtb, tot_ogw, tot_ngw,                       &
+         du3dt_mtb,du3dt_ogw, du3dt_tms, du3dt_ngw,                 &
+         do_congwd, errmsg, errflg)
+
+        use machine,                only: kind_phys
+
+        implicit none
+
+        ! Interface variables
+        integer,              intent(in) :: im, levs
+        real(kind=kind_phys), intent(in) :: dtf
+        logical,              intent(in) :: ldiag_ugwp      !< flag for CIRES UGWP Diagnostics
+        logical,              intent(inout) :: do_congwd   !< flag to turn on/off convective gwd
+
+        real(kind=kind_phys), intent(in),  dimension(im)       :: zmtb, zlwb, zogw
+        real(kind=kind_phys), intent(in),  dimension(im)       :: tau_mtb, tau_ogw, tau_tofd, tau_ngw
+        real(kind=kind_phys), intent(out), dimension(im)       :: tot_mtb, tot_ogw, tot_tofd, tot_ngw
+        real(kind=kind_phys), intent(out), dimension(im)       :: tot_zmtb, tot_zlwb, tot_zogw
+        real(kind=kind_phys), intent(in),  dimension(im, levs) :: gw_dudt, dudt_mtb, dudt_ogw, dudt_tms 
+        real(kind=kind_phys), intent(out), dimension(im, levs) :: du3dt_mtb, du3dt_ogw, du3dt_tms, du3dt_ngw
+
+        character(len=*),        intent(out) :: errmsg
+        integer,                 intent(out) :: errflg
+
+
+        ! Initialize CCPP error handling variables
+        errmsg = ''
+        errflg = 0
+
+        if (.not. (ldiag_ugwp)) return
+
+
+        if (ldiag_ugwp) then
+            tot_zmtb =  tot_zmtb + dtf *zmtb
+            tot_zlwb =  tot_zlwb + dtf *zlwb
+            tot_zogw =  tot_zogw + dtf *zogw
+    
+            tot_tofd  = tot_tofd + dtf *tau_tofd
+            tot_mtb   = tot_mtb +  dtf *tau_mtb
+            tot_ogw   = tot_ogw +  dtf *tau_ogw
+            tot_ngw   = tot_ngw +  dtf *tau_ngw
+    
+            du3dt_mtb = du3dt_mtb + dtf *dudt_mtb
+            du3dt_tms = du3dt_tms + dtf *dudt_tms
+            du3dt_ogw = du3dt_ogw + dtf *dudt_ogw
+            du3dt_ngw = du3dt_ngw + dtf *gw_dudt 
+         endif          
+
+
+         do_congwd = .false.
+
+      end subroutine cires_ugwp_post_run
+
+!> \section arg_table_cires_ugwp_post_finalize Argument Table
+!!
+      subroutine cires_ugwp_post_finalize ()
+      end subroutine cires_ugwp_post_finalize
+
+!! @}
+end module cires_ugwp_post

--- a/physics/cu_gf_deep.F90
+++ b/physics/cu_gf_deep.F90
@@ -3227,9 +3227,9 @@ endif
         enddo
         do k=kts+1,ktf
           do i=its,itf
-           if(ierr(i).ne.0) exit
-           if(k.lt.kbcon(i)) exit
-           if(k.gt.ktop(i)) exit
+           if(ierr(i).ne.0) cycle
+           if(k.lt.kbcon(i)) cycle
+           if(k.gt.ktop(i)) cycle
            dz=z(i,k)-z(i,k-1)
            da=zu(i,k)*dz*(9.81/(1004.*( &
                   (t_cup(i,k)))))*dby(i,k-1)/ &
@@ -4379,8 +4379,8 @@ endif
         enddo
         do i=its,itf
           do k=kts,kbcon(i)
-            if(ierr(i).ne.0 ) exit
-!           if(k.gt.kbcon(i)) exit
+            if(ierr(i).ne.0 ) cycle
+!           if(k.gt.kbcon(i)) cycle
 
             dz = (z_cup (i,k+1)-z_cup (i,k))*g
             da = dz*(tn(i,k)*(1.+0.608*qo(i,k))-t(i,k)*(1.+0.608*q(i,k)))/dtime

--- a/physics/cu_ntiedtke.F90
+++ b/physics/cu_ntiedtke.F90
@@ -202,6 +202,10 @@ contains
       real(kind=kind_phys), dimension( ix , km ),     intent(inout) :: pu, pv, pt, pqv
       real(kind=kind_phys), dimension( ix , km ),     intent(in )   :: poz, prsl, pomg, pqvf, ptf
       real(kind=kind_phys), dimension( ix , km+1 ),   intent(in )   :: pzz, prsi
+      ! DH* TODO - check dimensions of clw, ktrac+2 seems to be smaller
+      ! than the actual dimensions (ok as long as only indices 1 and 2
+      ! are accessed here, and as long as these contain what is expected);
+      ! better to expand into the cloud-ice and cloud-water components *DH
       real(kind=kind_phys), dimension( ix , km, ktrac+2 ),    intent(inout ) ::  clw
 
       integer, dimension( lq ),   intent(out)  :: kbot, ktop, kcnv

--- a/physics/module_cires_ugwp.F90
+++ b/physics/module_cires_ugwp.F90
@@ -1,0 +1,2550 @@
+!
+module  cires_ugwp_module
+
+!
+!   driver is called after pbl & before chem-parameterizations
+!
+!....................................................................................
+!  order = dry-adj=>conv=mp-aero=>radiation -sfc/land- chem -> vertdiff-> [rf-gws]=> ion-re
+!...................................................................................
+!
+!
+    implicit none 
+    logical ::    module_is_initialized
+!    logical            :: do_ugwp   = .false.               ! control => true - ugwp false old gws + rayeleigh friction
+
+    logical            :: do_physb_gwsrcs   = .false.      ! control for physics-based GW-sources
+    logical            :: do_rfdamp         = .false.      ! control for Rayleigth friction inside ugwp_driver  
+  
+    real, parameter    :: arad=6370.e3
+    real, parameter    :: pi = atan(1.0)
+    real, parameter    :: pi2 = 2.*pi  
+    real, parameter    :: hps   = 7000.
+    real, parameter    :: hpskm = hps/1000. 
+!             
+    real               ::  kxw = 6.28e-3/100.               ! single horizontal wavenumber of ugwp schemes  
+    real, parameter    ::  ricrit = 0.25
+    real, parameter    ::  frcrit = 0.50
+    real, parameter    ::  linsat = 1.00
+    real, parameter    ::  linsat2 = linsat*linsat     
+!  
+
+    integer               :: knob_ugwp_solver=1             ! 1, 2, 3, 4 - (linsat, ifs_2010, ad_gfdl, dsp_dis)
+    integer, dimension(4) :: knob_ugwp_source               ! [1,1,1,0]  - (oro, fronts, conv, imbf-owp]
+    integer, dimension(4) :: knob_ugwp_wvspec               !  number of waves for- (oro, fronts, conv, imbf-owp]
+    integer, dimension(4) :: knob_ugwp_azdir                !   number of wave azimuths for- (oro, fronts, conv, imbf-owp]
+    integer, dimension(4) :: knob_ugwp_stoch                !  1 - deterministic ; 0 - stochastic
+    real,    dimension(4) :: knob_ugwp_effac                !  efficiency factors for- (oro, fronts, conv, imbf-owp]
+    
+    integer               :: knob_ugwp_doaxyz=1             ! 1 -gwdrag
+    integer               :: knob_ugwp_doheat=1             ! 1 -gwheat
+    integer               :: knob_ugwp_dokdis=0             ! 1 -gwmixing
+    integer               :: knob_ugwp_ndx4lh = 2           ! n-number  of  "unresolved" "n*dx" for lh_gw 
+!    
+    integer  :: ugwp_azdir
+    integer  :: ugwp_stoch
+
+    integer  :: ugwp_src    
+    integer  :: ugwp_nws 
+    real     :: ugwp_effac    
+     
+!                   
+    data knob_ugwp_source / 1,0, 1, 0 /                     !  oro-conv-fjet-okw-taub_lat:      1-active 0-off
+    data knob_ugwp_wvspec /1,32,32,32/                      !  number of waves for- (oro, fronts, conv, imbf-owp, taulat]
+    data knob_ugwp_azdir  /2, 4, 4,4/                       !  number of wave azimuths for- (oro, fronts, conv, imbf-okwp]
+    data knob_ugwp_stoch  /0, 0, 0,0/                       !  0 - deterministic ; 1 - stochastic, non-activated option
+    data knob_ugwp_effac  /1.,1.,1.,1./                     !  efficiency factors for- (oro, fronts, conv, imbf-owp] 
+    integer  :: knob_ugwp_version = 0    
+    namelist /cires_ugwp_nml/ knob_ugwp_solver, knob_ugwp_source,knob_ugwp_wvspec, knob_ugwp_azdir,  &
+            knob_ugwp_stoch,  knob_ugwp_effac,knob_ugwp_doaxyz,  knob_ugwp_doheat, knob_ugwp_dokdis, &
+            knob_ugwp_ndx4lh, knob_ugwp_version
+!&cires_ugwp_nml 
+! knob_ugwp_solver=2 
+! knob_ugwp_source=1,1,1,0
+! knob_ugwp_wvspec=1,32,32,32 
+! knob_ugwp_azdir =2, 4, 4,4   
+! knob_ugwp_stoch =0, 0, 0,0
+! knob_ugwp_effac=1, 1, 1,1   
+! knob_ugwp_doaxyz=1 
+! knob_ugwp_doheat=1 
+! knob_ugwp_dokdis=0 
+! knob_ugwp_ndx4lh=4
+!/ 
+!
+! allocatable arrays, initilized during "cires_ugwp_init" &
+!                     released   during "cires_ugwp_finalize" 
+!   	  
+   real, allocatable :: kvg(:), ktg(:), krad(:), kion(:)
+   real, allocatable :: zkm(:), pmb(:)   
+   real, allocatable :: rfdis(:), rfdist(:) 
+   integer           :: levs_rf
+   real              :: pa_rf, tau_rf
+!
+! limiters
+!   
+   real, parameter ::  max_kdis = 400.              ! 400 m2/s
+   real, parameter ::  max_axyz = 400.e-5           ! 400 m/s/day
+   real, parameter ::  max_eps =  max_kdis*4.e-7    ! ~16   K/day    
+!
+!======================================================================   
+   real, parameter :: F_coriol=1                    ! Coriolis effects
+   real, parameter :: F_nonhyd=1                    ! Nonhydrostatic waves
+   real, parameter :: F_kds   =0                    ! Eddy mixing due to GW-unstable below      
+   real, parameter :: iPr_ktgw =1./3., iPr_spgw=iPr_ktgw 
+   real, parameter :: iPr_turb =1./3., iPr_mol =1.95
+   real, parameter ::  rhp1=1./hps, rhp2=0.5*rhp1, rhp4 = rhp2*rhp2
+   real, parameter ::  khp =  0.287*rhp1            ! R/Cp/Hp 
+   real, parameter ::  cd_ulim = 1.0                ! critical level precision or Lz ~ 0 ~dz of model   
+      
+   contains
+!   
+! -----------------------------------------------------------------------
+!
+! init  of cires_ugwp   (_init)  called from GFS_driver.F90
+!
+! -----------------------------------------------------------------------
+subroutine cires_ugwp_mod_init (me, master, nlunit, logunit, fn_nml2, &
+              lonr, latr, levs, ak, bk, pref, dtp, cdmvgwd, cgwf)
+!
+!  input_nml_file ='input.nml'=fn_nml 
+!
+    use  ugwp_oro_init,     only :  init_oro_gws
+    use  ugwp_conv_init,    only :  init_conv_gws  
+    use  ugwp_fjet_init,    only :  init_fjet_gws
+    use  ugwp_okw_init,     only :  init_okw_gws
+    use  ugwp_wmsdis_init,  only :  initsolv_wmsdis
+    use  ugwp_lsatdis_init, only :  initsolv_lsatdis             
+    implicit none
+    
+    integer, intent (in) :: me
+    integer, intent (in) :: master
+    integer, intent (in) :: nlunit
+    integer, intent (in) :: logunit
+    integer, intent (in) :: lonr
+    integer, intent (in) :: levs
+    integer, intent (in) :: latr   
+    real,    intent (in) :: ak(levs+1), bk(levs+1), pref
+    real,    intent (in) :: dtp   
+    real,    intent (in) :: cdmvgwd(2), cgwf(2)             ! "scaling" controls for "old" GFS-GW schemes     
+         
+    character(len=64), intent (in) :: fn_nml2
+    character(len=64), parameter   :: fn_nml='input.nml' 
+       
+!    character,  intent (in) :: input_nml_file
+!    integer, parameter :: logunit =  6   
+    integer :: ios
+    logical :: exists
+    real    :: dxsg 
+    integer :: k
+!       
+    if (me == master) print *, trim (fn_nml), ' GW-namelist file '
+    inquire (file =trim (fn_nml) , exist = exists)
+!    
+    if (.not. exists) then
+       if (me == master) &
+        write (6, *) 'separate ugwp :: namelist file: ', trim (fn_nml), ' does not exist'
+    else
+        open (unit = nlunit, file = trim(fn_nml), readonly, status = 'old', iostat = ios)
+    endif
+    rewind (nlunit)
+    read   (nlunit, nml = cires_ugwp_nml)
+    close  (nlunit)
+!
+    ! write version number and namelist to log file
+    if (me == master) then
+        write (logunit, *) " ================================================================== "
+        write (logunit, *) "cires_ugwp_cires"
+        write (logunit, nml = cires_ugwp_nml)
+    endif
+!
+! effective kxw - resolution-aware
+!    
+    dxsg =  pi2*arad/float(lonr) * knob_ugwp_ndx4lh
+!
+!    kxw  =  pi2/dxsg
+!
+! init global background dissipation for ugwp -> 4d-variable for fv3wam linked with pbl-vert_diff 
+!    
+
+!    allocate(fcor(latr), fcor2(latr)  )
+!
+    allocate( kvg(levs+1),   ktg(levs+1)  ) 
+    allocate( krad(levs+1),  kion(levs+1) )        
+    allocate( zkm(levs),   pmb(levs) )  
+    allocate( rfdis(levs), rfdist(levs) )      
+!    
+! ak -pa  bk-dimensionless  from surf => tol_lid_pressure =0
+!    
+    do k=1, levs 
+       pmb(k) = 1.e0*(ak(k) + pref*bk(k))    ! Pa -unit  Pref = 1.e5
+       zkm(k) = -hpskm*alog(pmb(k)/pref)
+    enddo   
+! 
+! Part-1 :init_global_gwdis
+!    
+    call init_global_gwdis(levs, zkm, pmb, kvg, ktg, krad, kion)
+    call rf_damp_init     (levs, pa_rf, tau_rf, dtp, pmb, rfdis, rfdist, levs_rf)   
+! 
+! Part-2 :init_SOURCES_gws
+!    
+    
+!    
+! call init-solver for "stationary" multi-wave spectra and sub-grid oro
+!  
+    call init_oro_gws( knob_ugwp_wvspec(1), knob_ugwp_azdir(1), &
+         knob_ugwp_stoch(1), knob_ugwp_effac(1), lonr, kxw, cdmvgwd )
+!    
+! call init-sources for "non-sationary" multi-wave spectra 
+!
+    do_physb_gwsrcs=.true.
+    
+    IF (do_physb_gwsrcs) THEN
+
+     if (me == master) print *, ' do_physb_gwsrcs ',  do_physb_gwsrcs, ' in cires_ugwp_init '
+    if (knob_ugwp_wvspec(4) > 0) then 	
+! okw     
+       call init_okw_gws(knob_ugwp_wvspec(4), knob_ugwp_azdir(4), &
+         knob_ugwp_stoch(4), knob_ugwp_effac(4), lonr, kxw )
+       if (me == master) print *, ' init_okw_gws '
+    endif	
+    
+    if (knob_ugwp_wvspec(3) > 0) then 
+! fronts    	
+       call init_fjet_gws(knob_ugwp_wvspec(3), knob_ugwp_azdir(3), &
+         knob_ugwp_stoch(3), knob_ugwp_effac(3), lonr, kxw )
+       if (me == master) print *, ' init_fjet_gws '	 
+    endif 
+    
+     if (knob_ugwp_wvspec(2) > 0) then 
+! conv    	
+       call init_conv_gws(knob_ugwp_wvspec(2), knob_ugwp_azdir(2), &
+         knob_ugwp_stoch(2), knob_ugwp_effac(2), lonr, kxw, cgwf )
+       if (me == master)   &
+           print *, ' init_convective GWs cgwf', knob_ugwp_wvspec(2), knob_ugwp_azdir(2)
+       
+    endif 
+    
+    ENDIF   !IF (do_physb_gwsrcs)
+
+!======================    
+! Part-3 :init_SOLVERS
+! =====================       	      		      	 
+	 
+!
+! call init-solvers for "broad" non-stationary multi-wave spectra
+!    
+    if   (knob_ugwp_solver==1) then
+!   
+      call initsolv_lsatdis(me, master, knob_ugwp_wvspec(2), knob_ugwp_azdir(2), &
+           knob_ugwp_stoch(2), knob_ugwp_effac(2), do_physb_gwsrcs, kxw )
+	  
+    endif
+    	   
+     if   (knob_ugwp_solver==2) then 
+
+       call initsolv_wmsdis(me, master, knob_ugwp_wvspec(2), knob_ugwp_azdir(2), &
+         knob_ugwp_stoch(2), knob_ugwp_effac(2), do_physb_gwsrcs, kxw)
+	 
+     endif 
+!
+! other solvers not yet tested for fv3gfs
+!     
+!<    if   (knob_ugwp_solver==3) call init_dspdis
+!<    if   (knob_ugwp_solver==4) call init_adodis
+! 
+
+!======================                
+    module_is_initialized = .true.
+    if (me == master)   print *, ' VAY-ugwp is initialized ', module_is_initialized
+
+end subroutine cires_ugwp_mod_init
+
+!   
+!=====================================================================  
+!
+!ugwp-v0 subroutines: GWDPS_V0 and fv3_ugwp_solv2_v0    
+!  
+!=====================================================================
+      SUBROUTINE GWDPS_V0(IM, levs, imx, do_tofd,   &
+         Pdvdt, Pdudt, Pdtdt, Pkdis, U1,V1,T1,Q1,KPBL, &
+         PRSI,DEL,PRSL,PRSLK,PHII, PHIL,DTP,KDT, &
+         sgh30, HPRIME,OC,OA4,CLX4,THETA,vSIGMA,vGAMMA,ELVMAXD, &
+         DUSFC, DVSFC,  xlatd, sinlat, coslat, sparea, &
+         nmtvr, cdmbgwd, me, master, rdxzb, &
+         zmtb, zogw, tau_mtb, tau_ogw, tau_tofd, &
+         dudt_mtb, dudt_ogw, dudt_tms)
+!       
+!----------------------------------------
+! ugwp_v0
+!
+! modified/revised version of gwdps.f (with bug fixes, tofd, appropriate
+!   computation of kref for OGW + COORDE diagnostics
+!   all constants/parameters inside cires_ugwp_initialize.F90 
+!----------------------------------------    
+
+      USE MACHINE , ONLY : kind_phys
+      use ugwp_common ,      only : rgrav, grav, cpd, rd, rv, rcpd, rcpd2      
+      use ugwp_common ,      only : pi, rad_to_deg, deg_to_rad, pi2       
+      use ugwp_common ,      only : rdi, gor,  grcp,  gocp,  fv,    gr2
+      use ugwp_common ,      only : bnv2min, dw2min, velmin, arad 
+      
+      use ugwp_oro_init, only: rimin, ric, efmin, efmax,hpmax,hpmin
+      use ugwp_oro_init, only: dpmin, minwnd, hminmt,hncrit
+      use ugwp_oro_init, only: sigfaci => sigfac    
+      use ugwp_oro_init, only: RLOLEV,GMAX, VELEPS, FACTOP 
+      use ugwp_oro_init, only: FRC, CE, CEOFRC, frmax, CG                  
+      use ugwp_oro_init, only: FDIR, MDIR, NWDIR
+      use ugwp_oro_init, only: cdmb, cleff, fcrit_gfs,fcrit_mtb 
+      use ugwp_oro_init, only: n_tofd, ze_tofd, ztop_tofd    
+                    
+!      use cires_ugwp_module, only  : kxw,  max_kdis, max_axyz 
+!      use sso_coorde,       only   : pgwd, pgwd4      
+!----------------------------------------                  
+      implicit none
+      character(len=8)    :: strsolver='PSS-1986'  ! current operational solver or  'WAM-2017'
+      integer, intent(in) :: im, levs, imx, kdt
+      integer, intent(in) :: me, master, nmtvr
+      integer             :: km
+      logical, intent(in) :: do_tofd
+      real(kind=kind_phys), parameter  :: sigfac =3, sigfacS = 0.5    
+      real(kind=kind_phys)             :: ztopH,zlowH,ph_blk, dz_blk            
+      integer, intent(in)              :: KPBL(IM)    ! Index for the PBL top layer!
+      real(kind=kind_phys), intent(in) :: dtp         !  time step
+      real(kind=kind_phys), intent(in) :: cdmbgwd(2) 
+          
+      real(kind=kind_phys), intent(in), dimension(im,levs) :: u1,  v1, t1,   q1, del,  prsl, prslk, phil   
+      real(kind=kind_phys), intent(in),dimension(im,levs+1):: prsi, phii
+      real(kind=kind_phys), intent(in) :: xlatd(im),sinlat(im),coslat(im)
+      real(kind=kind_phys), intent(in) :: sparea(im)      
+            
+      real(kind=kind_phys), intent(in) :: OC(IM), OA4(im,4), CLX4(im,4) 
+      real(kind=kind_phys), intent(in) :: HPRIME(IM), sgh30(IM)                     
+      real(kind=kind_phys), intent(in) :: ELVMAXD(IM), THETA(IM)
+      real(kind=kind_phys), intent(in) :: vSIGMA(IM),vGAMMA(IM)  
+      real(kind=kind_phys)             :: SIGMA(IM),GAMMA(IM)        
+      
+!output -phys-tend
+      real(kind=kind_phys),dimension(im,levs),intent(out):: Pdvdt,Pdudt
+      real(kind=kind_phys),dimension(im,levs),intent(out):: Pkdis,Pdtdt
+!     
+!
+! output          
+! diag-coorde
+      real(kind=kind_phys), dimension(im,levs), intent(out) :: dudt_mtb, dudt_ogw, dudt_tms
+!                     
+      real(kind=kind_phys),dimension(im) :: RDXZB,  zmtb,   zogw
+      real(kind=kind_phys),dimension(im) :: tau_ogw, tau_mtb, tau_tofd
+      real(kind=kind_phys),dimension(im) :: dusfc, dvsfc                    
+         
+! 
+! locals       
+! mean flow
+      real(kind=kind_phys) :: RI_N(IM,levs), BNV2(IM,levs), RO(IM,levs)
+      real(kind=kind_phys) :: VTK(IM,levs),VTJ(IM,levs),VELCO(IM,levs)  
+!mtb     
+      real(kind=kind_phys) ::  OA(IM),  CLX(IM) , elvmax(im)       
+      real(kind=kind_phys) ::  wk(IM)
+      real(kind=kind_phys), dimension(im) :: PE, EK, UP      
+      
+      real(kind=kind_phys) :: DB(IM,levs),ANG(IM,levs),UDS(IM, levs)
+      real(kind=kind_phys) :: ZLEN, DBTMP, R, PHIANG, DBIM, ZR
+      real(kind=kind_phys) :: ENG0, ENG1, COSANG2, SINANG2
+      real(kind=kind_phys) :: bgam, cgam, gam2, rnom, rdem       
+!
+! TOFD
+!     Some constants now in "use ugwp_oro_init" +   "use ugwp_common"
+!
+!==================
+      real(kind=kind_phys)   :: unew, vnew,  zpbl,  sigflt  
+      real(kind=kind_phys), dimension(levs)    ::  utofd1, vtofd1
+      real(kind=kind_phys), dimension(levs)    :: epstofd1, krf_tofd1 
+      real(kind=kind_phys), dimension(levs)    ::  up1, vp1, zpm
+      real(kind=kind_phys)                     ::  zsurf
+      real(kind=kind_phys),dimension(im, levs) :: axtms, aytms 
+! 
+! OGW
+!                     
+      LOGICAL ICRILV(IM)
+!
+      real(kind=kind_phys) :: XN(IM), YN(IM), UBAR(IM),    & 
+                     VBAR(IM),  ULOW(IM),                  &
+                     ROLL(IM),  bnv2bar(im), SCOR(IM),     &
+                    DTFAC(IM), XLINV(IM), DELKS(IM), DELKS1(IM)
+!
+      real(kind=kind_phys) :: TAUP(IM,levs+1), TAUD(IM,levs)         
+      real(kind=kind_phys) :: taub(im), taulin(im), heff, hsat, hdis       
+         
+      integer ::  kref(IM), idxzb(im), ipt(im), k_mtb,k_zlow 
+      integer ::  kreflm(IM), iwklm(im), iwk(im), izlow(im)
+      integer ::  ktrial, klevm1
+!      
+!check what we need
+!
+      real(kind=kind_phys) :: bnv,  fr, ri_gw , brvf,   tem,   tem1,  tem2, temc, temv, & 
+                         ti,    rdz,   dw2,   shr2, bvf2, rdelks, efact, coefm, gfobnv,& 
+                         scork,  rscor, hd,  fro,  sira, dtaux,  dtauy, pkp1log, pklog
+     
+      integer ::   kmm1, kmm2, lcap, lcapp1
+      integer ::   npt       
+      integer ::   kbps, kbpsp1,kbpsm1, kmps, idir, nwd,  klcap, kp1, kmpbl, kmll 
+!---------------------------------------------------------------------
+! # of permissible sub-grid orography hills for "any" resolution  < 25
+!    correction for "elliptical" hills based on shilmin-area =sgrid/25 
+!     4.*gamma*b_ell*b_ell  >=  shilmin
+!     give us limits on [b_ell & gamma *b_ell] > 5 km =sso_min
+!     gamma_min = 1/4*shilmin/sso_min/sso_min
+!23.01.2019:  cdmb = 4.*192/768_c192=1 x 0.5
+!     192: cdmbgwd        = 0.5, 2.5
+!     cleff = 2.5*0.5e-5 * sqrt(192./768.) => Lh_eff = 1004. km
+!      6*dx = 240 km 8*dx = 320. ~ 3-5 more effective
+!---------------------------------------------------------------------
+      real(kind=kind_phys)            :: gammin = 0.00999999 
+      real(kind=kind_phys)            :: shilmin, sgrmax, sgrmin
+      real(kind=kind_phys)            :: belpmin, dsmin,  dsmax        
+      real(kind=kind_phys), parameter :: nhilmax =  25.
+      real(kind=kind_phys), parameter :: sso_min = 3000. 
+      real(kind=kind_phys)            :: xlingfs
+      real(kind=kind_phys)            :: arhills(im)       
+      logical, parameter :: do_adjoro = .true.                     
+! 
+       integer  ::  i, j, k
+       real(kind=kind_phys)     :: grav2, rcpdt, windik, wdir
+       real(kind=kind_phys)     :: sigmin, dxres,sigres,hdxres
+       real(kind=kind_phys)     :: cdmb4, mtbridge
+       real(kind=kind_phys)     :: kxridge, inv_b2eff, zw1, zw2
+       real(kind=kind_phys)     :: belps, aelps, nhills, selps             
+       rcpdt = 1./cpd/dtp       
+       grav2 = 2.*grav
+!       
+! mtb-blocking  sigma_min and dxres => cires_initialize
+!  
+       sgrmax = maxval(sparea) ; sgrmin = minval(sparea)
+        dsmax = sqrt(sgrmax)   ; dsmin = sqrt(sgrmin)      
+
+        dxres = pi2*arad/float(IMX)
+        hdxres = .5*dxres   
+        shilmin = sgrmin/nhilmax
+
+    gammin = min(sso_min/dsmax, 1.)
+    
+        sigmin = 2.*hpmin/dsmax      !dxres 
+       if (kdt==1) then 
+    print *, sgrmax, sgrmin , ' min-max sparea '
+    print *, 'sigmin-hpmin-dsmax',  sigmin, hpmin, dsmax
+    print *, 'dxres/dsmax ', dxres, dsmax
+    print *, ' shilmin gammin ', shilmin, gammin    
+       endif
+                  
+        kxridge = float(IMX)/arad * cdmbgwd(2)
+       
+       if (me == master .and. kdt==1) then
+        print *, ' gwdps_v0 kxridge ', kxridge
+        print *, ' gwdps_v0 scale2 ', cdmbgwd(2)
+        print *, ' gwdps_v0 IMX ', imx
+        print *, ' gwdps_v0 GAM_MIN ',  gammin
+    print *, ' gwdps_v0 SSO_MIN ', sso_min      
+       endif
+              
+       idxzb(:) = 0     
+       zmtb(:) = 0.    ; zogw(:) =0.
+       rdxzb(:) =0.       
+       tau_ogw(:) =0. ; tau_mtb(:) =0.; dusfc(:)=0. ; dvsfc(:)=0. 
+       tau_tofd(:) =0.
+       
+       pdvdt  =0.   ; pdudt =0.    ; pdtdt =0. ; pkdis =0.
+       dudt_mtb =0. ; dudt_ogw =0. ; dudt_tms =0. 
+          
+! ----  for lm and gwd calculation points
+      
+        ipt(:) = 0
+        npt = 0
+    sigma = vsigma
+    gamma = vgamma
+        do i = 1,im
+    
+          if ( (elvmaxd(i) .ge. hminmt)   .and. (gamma(i)   .ge. gammin)   .and. (hprime(i)  .ge. hpmin) ) then
+          
+             npt      = npt + 1
+             ipt(npt) = i
+         arhills(i) = 1.0
+!
+          if (gamma(i) .lt. gammin) gamma(i)= gammin         
+          sigres = max(sigmin, sigma(i))
+          if (sigma(i) .lt. sigmin) sigma(i)=  sigmin         
+      dxres = sqrt(sparea(i))
+       if (2.*hprime(i)/sigres.gt.dxres) sigres=2.*hprime(i)/dxres       
+      aelps = min(2.*hprime(i)/sigres, 0.5*dxres)
+      if (gamma(i) > 0.0 ) belps=min(aelps/gamma(i),.5*dxres) 
+!
+! small-scale "turbulent" oro-scales < sso_min
+!     
+     if( aelps < sso_min .and. do_adjoro) then
+     
+! a, b > sso_min upscale ellipse  a/b > 0.1 a>sso_min & h/b=>new_sigm
+!
+             aelps = sso_min 
+         if (belps < sso_min ) then
+            gamma(i) = 1.0
+            belps = aelps*gamma(i)
+        
+         else   
+             gamma(i) = min(aelps/belps, 1.0)
+         endif 
+          sigma(i) = 2.*hprime(i)/aelps
+          gamma(i) = min(aelps/belps, 1.0)               
+       endif     
+       
+      selps = belps*belps*gamma(i)*4.    ! ellipse area of the el-c hill 
+      nhills = sparea(i)/selps
+      if (nhills > nhilmax) nhills=nhilmax
+      arhills(i)= max(nhills, 1.0)
+!333   format( ' nhil: ', I6, 4(2x, F9.3), 2(2x, E9.3))     
+!      if (kdt==1 )
+!     & write(6,333) nint(nhills)+1,xlatd(i), hprime(i),aelps*1.e-3,
+!     &   belps*1.e-3, sigma(i),gamma(i)
+          endif
+        enddo         
+        
+        IF (npt .eq. 0) then        
+!        print *,  'oro-npt = 0 elvmax ', maxval(elvmaxd), hminmt
+!        print *,  'oro-npt = 0 hprime ', maxval(hprime), hpmin             
+    RETURN     ! No gwd/mb calculation done
+    endif
+    
+    
+      iwklm(1:npt)  = 2
+          IDXZB(1:npt)  = 0 
+          kreflm(1:npt) = 0
+        
+    db =0. ; ang = 0. ; uds =0. 
+        km = levs
+    KMM1   = levs- 1 ; KMM2   = levs - 2 ; KMLL   = kmm1
+        LCAP   = levs   ;  LCAPP1 = LCAP + 1       
+        
+          DO I = 1, npt
+            j = ipt(i)
+            ELVMAX(J) = min (ELVMAXd(J)*0. + sigfac * hprime(j), hncrit)
+          ENDDO
+!
+         izlow(:) =1                       ! surface-level
+        DO K = 1, levs-1
+          DO I = 1, npt
+            j = ipt(i)
+        ztopH  = sigfac * hprime(j)
+        zlowH  = sigfacs* hprime(j) 
+            pkp1log =  phil(j,k+1) *rgrav
+            pklog =    phil(j,k)   *rgrav
+!        if (( ELVMAX(j).le.pkp1log) .and. (ELVMAX(j).ge.pklog) )
+!     &      iwklm(I)  =  MAX(iwklm(I), k+1 ) 
+        if (( ztopH.le.pkp1log) .and. (zTOPH.ge.pklog) )      iwklm(I)  =  MAX(iwklm(I), k+1 )
+!     
+        if (( zlowH.le.pkp1log) .and. (zlowH.ge.pklog) )      izlow(I)  =  MAX(izlow(I), k )      
+          ENDDO
+        ENDDO       
+!
+      DO K = 1,levs
+        DO I =1,npt
+          J         = ipt(i)
+          VTJ(I,K)  = T1(J,K)  * (1.+FV*Q1(J,K))
+          VTK(I,K)  = VTJ(I,K) / PRSLK(J,K)
+          RO(I,K)   = RDI * PRSL(J,K) / VTJ(I,K)       ! DENSITY mid-levels
+          TAUP(I,K) = 0.0
+        ENDDO
+      ENDDO
+!
+! check RI_N or RI_MF computation
+!      
+      DO K = 1,levs-1
+        DO I =1,npt
+          J         = ipt(i)
+          RDZ       = grav   / (phil(j,k+1) - phil(j,k))
+          TEM1      = U1(J,K) - U1(J,K+1)
+          TEM2      = V1(J,K) - V1(J,K+1)
+          DW2       = TEM1*TEM1 + TEM2*TEM2
+          SHR2      = MAX(DW2,DW2MIN) * RDZ * RDZ
+!          TI        = 2.0 / (T1(J,K)+T1(J,K+1))          
+!          BVF2      = Grav*(GOCP+RDZ*(VTJ(I,K+1)-VTJ(I,K)))* TI
+!          RI_N(I,K) = MAX(BVF2/SHR2,RIMIN)   ! Richardson number
+!                                             
+          BVF2 = grav2 * RDZ * (VTK(I,K+1)-VTK(I,K))  / (VTK(I,K+1)+VTK(I,K))
+          bnv2(i,k+1) = max( BVF2, bnv2min )
+          RI_N(I,K+1) = Bnv2(i,k)/SHR2        ! Richardson number consistent with BNV2  
+!
+! add here computation for Ktur and OGW-dissipation fro VE-GFS
+!       
+        ENDDO
+      ENDDO         
+        K = 1 
+        DO I = 1, npt
+       bnv2(i,k) =bnv2(i,k+1) 
+    ENDDO
+!       
+! level iwklm =>phil(j,k)/g < sigfac * hprime(j) < phil(j,k+1)/g 
+!
+        DO I = 1, npt
+          J   = ipt(i)
+      k_zlow = izlow(I)
+      if (k_zlow == iwklm(i)) k_zlow = 1
+          DELKS(I)  = 1.0 / (PRSI(J,k_zlow) - PRSI(J,iwklm(i)))
+!          DELKS1(I) = 1.0 /(PRSL(J,k_zlow) - PRSL(J,iwklm(i)))
+          UBAR (I)  = 0.0
+          VBAR (I)  = 0.0
+          ROLL (I)  = 0.0
+          PE   (I)  = 0.0
+          EK   (I)  = 0.0
+          BNV2bar(I) = 0.0   
+        ENDDO
+!
+        DO I = 1, npt     
+      k_zlow = izlow(I)
+      if (k_zlow == iwklm(i)) k_zlow = 1
+          DO K = k_zlow, iwklm(I)-1                                !Kreflm(I)= iwklm(I)-1 
+            J        = ipt(i)                                 ! laye-aver Rho, U, V
+            RDELKS     = DEL(J,K) * DELKS(I)
+            UBAR(I)    = UBAR(I)  + RDELKS * U1(J,K)          ! trial Mean U below 
+            VBAR(I)    = VBAR(I)  + RDELKS * V1(J,K)          ! trial Mean V below 
+            ROLL(I)    = ROLL(I)  + RDELKS * RO(I,K)          !   trial Mean RO below 
+!       
+            BNV2bar(I)=BNV2bar(I)+.5*(BNV2(I,K)+BNV2(I,K+1))* RDELKS
+          ENDDO
+        ENDDO
+!
+        DO I = 1, npt
+          J = ipt(i)
+!
+! integrate from Ztoph = sigfac*hprime  down to Zblk if exists
+! find ph_blk, dz_blk like in LM-97 and IFS
+!   
+          ph_blk =0.  
+          DO K = iwklm(I), 1, -1
+            PHIANG   =  atan2(V1(J,K),U1(J,K))*RAD_TO_DEG
+            ANG(I,K) = ( THETA(J) - PHIANG )
+            if ( ANG(I,K) .gt.  90. ) ANG(I,K) = ANG(I,K) - 180.
+            if ( ANG(I,K) .lt. -90. ) ANG(I,K) = ANG(I,K) + 180.
+            ANG(I,K) = ANG(I,K) * DEG_TO_RAD
+            UDS(I,K) =    MAX(SQRT(U1(J,K)*U1(J,K) + V1(J,K)*V1(J,K)), velmin)
+!
+            IF (IDXZB(I) .eq. 0 ) then
+          dz_blk=( PHII(J,K+1) - PHII(J,K) ) *rgrav
+              PE(I) = PE(I) + BNV2(I,K) *   ( ELVMAX(J) - phil(J,K)*rgrav ) * dz_blk
+
+              UP(I)  =  max(UDS(I,K) * cos(ANG(I,K)), velmin)  
+              EK(I)  = 0.5 *  UP(I) * UP(I) 
+          
+          ph_blk = ph_blk + dz_blk*sqrt(BNV2(I,K))/UP(I)
+
+! --- Dividing Stream lime  is found when PE =exceeds EK. oper-l GFS
+!              IF ( PE(I) .ge.  EK(I) ) THEN
+              IF ( ph_blk .ge.  fcrit_gfs ) THEN
+                 IDXZB(I) = K
+         zmtb (J) =PHIL(J, K)*rgrav
+                 RDXZB(J) =real(k, kind=kind_phys)       
+              ENDIF
+
+            ENDIF
+          ENDDO
+!
+! Alternative expression: ZMTB = max(Heff*(1. -Fcrit_gfs/Fr), 0)
+! fcrit_gfs/fr   
+!
+         goto 788 
+      
+     BNV    = SQRT( BNV2bar(I) )
+         heff  = 2.*min(HPRIME(J),hpmax)
+     zw2 = UBAR(I)*UBAR(I)+VBAR(I)*VBAR(I)
+     Ulow(i)=sqrt(max(zw2,dw2min))
+     Fr = heff*bnv/Ulow(i)
+     ZW1 =max(Heff*(1. -fcrit_gfs/fr), 0.)  
+     zw2 =  phil(j,2)*rgrav
+     if (Fr > fcrit_gfs .and. zw1 > zw2 ) then 
+       do k=2, levs-1
+            pkp1log =  phil(j,k+1) *rgrav
+            pklog =    phil(j,k)   *rgrav       
+             if (zw1.le.pkp1log .and. zw1.ge.pklog)  exit         
+       enddo
+        IDXZB(I) =K
+        zmtb (J) =PHIL(J, K)*rgrav
+     else
+        zmtb (J) = 0.
+        IDXZB(I) = 0
+     endif  
+788     continue      
+        ENDDO
+
+!
+! --- The drag for mtn blocked flow
+! 
+        cdmb4 = 0.25*cdmb 
+        DO I = 1, npt
+          J = ipt(i)
+!
+          IF ( IDXZB(I) .gt. 0 ) then
+! (4.16)-IFS      
+      gam2 = gamma(j)*gamma(j)
+      BGAM = 1.0-0.18*gamma(j)-0.04*gam2
+      CGAM =    0.48*gamma(j) +0.30*gam2      
+            DO K = IDXZB(I)-1, 1, -1
+
+                ZLEN = SQRT( ( PHIL(J,IDXZB(I)) - PHIL(J,K) ) /   ( PHIL(J,K ) + Grav * hprime(J) ) )
+
+               COSANG2 = cos(ANG(I,K))*cos(ANG(I,K))
+               SINANG2 =1.0 -COSANG2 
+!         
+!  cos =1 sin =0 =>   1/R= gam     ZR = 2.-gam 
+!  cos =0 sin =1 =>   1/R= 1/gam   ZR = 2.- 1/gam
+!
+           rdem = COSANG2 +  GAM2 * SINANG2
+           rnom = COSANG2*GAM2 +    SINANG2
+!          
+! metOffice Dec 2010
+! correction of H. Wells & A. Zadra for the
+! aspect ratio  of the hill seen by MF
+! (1/R , R-inverse below: 2-R)
+
+                 rdem = max(rdem, 1.e-6)       
+                 R = sqrt(rnom/rdem)
+                 ZR =  MAX( 2. - R, 0. )
+                   
+           sigres = max(sigmin, sigma(J))
+       if (hprime(J)/sigres.gt.dxres) sigres=hprime(J)/dxres
+           mtbridge = ZR * sigres*ZLEN / hprime(J)     
+! (4.15)-IFS       
+!           DBTMP = CDmb4 * mtbridge *
+!     &           MAX(cos(ANG(I,K)), gamma(J)*sin(ANG(I,K))) 
+! (4.16)-IFS     
+           DBTMP = CDmb4*mtbridge*(bgam* COSANG2 +cgam* SINANG2)          
+           DB(I,K)= DBTMP * UDS(I,K)  
+           ENDDO            
+!                  
+         endif         
+        ENDDO   
+! 
+!.............................
+!.............................
+! end  mtn blocking section
+!.............................
+!.............................
+!
+!--- Orographic Gravity Wave Drag Section
+!     
+!  Scale cleff between IM=384*2 and 192*2 for T126/T170 and T62
+!  inside "cires_ugwp_initialize.F90" now
+!
+      KMPBL  = km / 2 
+      iwk(1:npt) = 2
+!
+! METO-scheme: 
+! k_mtb = max(k_zmtb, k_n*hprime/2] to reduce diurnal variations taub_ogw 
+!     
+      DO K=3,KMPBL
+        DO I=1,npt
+          j   = ipt(i)
+          tem = (prsi(j,1) - prsi(j,k))
+          if (tem .lt. dpmin) iwk(i) = k    ! dpmin=50 mb
+      
+!===============================================================      
+! lev=111      t=311.749     hkm=0.430522     Ps-P(iwk)=52.8958 
+!           below "Hprime" - source of OGWs  and below Zblk !!!
+!           27           2  kpbl ~ 1-2 km   < Hprime
+!===============================================================      
+        enddo
+      enddo
+!
+! iwk - adhoc GFS-parameter to select OGW-launch level between
+!      LEVEL ~0.4-0.5 KM from surface or/and  PBL-top
+! in UGWP-V1: options to modify as  Htop ~ (2-3)*Hprime > Zmtb
+! in UGWP-V0 we ensured that : Zogw > Zmtb
+!      
+
+      KBPS = 1
+      KMPS = levs
+      K_mtb =    1 
+      DO I=1,npt
+        J         = ipt(i)
+    K_mtb     =    max(1, idxzb(i))
+        
+    kref(I)   = MAX(IWK(I), KPBL(J)+1 )             ! reference level PBL or smt-else ????
+    kref(I)   = MAX(kref(i), iwklm(i) )             ! iwklm => sigfac*hprime
+    
+      if (kref(i) .lt. idxzb(i)) kref(i) = idxzb(i) + 1 ! layer above zmtb
+        KBPS      = MAX(KBPS,  kref(I))
+        KMPS      = MIN(KMPS,  kref(I))         
+!
+        DELKS(I)  = 1.0 / (PRSI(J,k_mtb) - PRSI(J,kref(I)))
+        UBAR (I)  = 0.0
+        VBAR (I)  = 0.0
+        ROLL (I)  = 0.0
+        BNV2bar(I)= 0.0
+      ENDDO
+!  
+      KBPSP1 = KBPS + 1
+      KBPSM1 = KBPS - 1
+        K_mtb  = 1 
+!   
+      DO I = 1,npt
+    K_mtb = max(1, idxzb(i))
+       DO K = k_mtb,KBPS            !KBPS = MAX(kref) ;KMPS= MIN(kref)
+          IF (K .LT. kref(I)) THEN
+            J          = ipt(i)
+            RDELKS     = DEL(J,K) * DELKS(I)
+            UBAR(I)    = UBAR(I)  + RDELKS * U1(J,K)   ! Mean U below kref
+            VBAR(I)    = VBAR(I)  + RDELKS * V1(J,K)   ! Mean V below kref
+            ROLL(I)    = ROLL(I)  + RDELKS * RO(I,K)   ! Mean RO below kref
+          BNV2bar(I)=BNV2bar(I)+.5*(BNV2(I,K)+BNV2(I,K+1))* RDELKS  
+          ENDIF
+        ENDDO
+      ENDDO
+!
+! orographic asymmetry parameter (OA), and (CLX) 
+      DO I = 1,npt
+        J      = ipt(i)
+        wdir   = atan2(UBAR(I),VBAR(I)) + pi
+        idir   = mod(nint(fdir*wdir),mdir) + 1
+        nwd    = nwdir(idir)
+        OA(I)  = (1-2*INT( (NWD-1)/4 )) * OA4(J,MOD(NWD-1,4)+1)
+        CLX(I) = CLX4(J,MOD(NWD-1,4)+1)
+      ENDDO
+!
+      DO I = 1,npt
+       DTFAC(I)  = 1.0
+       ICRILV(I) = .FALSE.                      ! INITIALIZE CRITICAL LEVEL CONTROL VECTOR 
+       ULOW(I) = MAX(SQRT(UBAR(I)*UBAR(I)+VBAR(I)*VBAR(I)),velmin)
+       XN(I)  = UBAR(I) / ULOW(I)
+       YN(I)  = VBAR(I) / ULOW(I)       
+      ENDDO
+!
+      DO  K = 1, levs-1
+        DO  I = 1,npt
+          J            = ipt(i)
+          VELCO(I,K)   = 0.5 * ((U1(J,K)+U1(J,K+1))*XN(I) + (V1(J,K)+V1(J,K+1))*YN(I))
+        ENDDO
+      ENDDO
+!
+!------------------
+! v0: incorporates latest modifications for kxridge and heff/hsat
+!             and taulin for Fr <=fcrit_gfs 
+!             and concept of "clipped" hill if zmtb > 0. to make
+! the integrated "tau_sso = tau_ogw +tau_mtb" close to reanalysis data
+!      it is still used the "single-OGWave"-approach along ULOW-upwind
+!
+!      in contrast to the 2-orthogonal wave (2OTW) schemes of IFS/METO/E-CANADA  
+! 2OTW scheme requires "aver angle" and wind projections on 2 axes of ellipse a-b
+!     with 2-stresses:  taub_a & taub_b from AS of Phillips et al. (1984)
+!------------------
+      taub(:)  = 0. ; taulin(:)= 0.
+      DO I = 1,npt
+        J      = ipt(i)
+        BNV    = SQRT( BNV2bar(I) )
+        heff  = min(HPRIME(J),hpmax)
+    
+        if( zmtb(j) > 0.)heff=max(sigfac*heff-zmtb(j), 0.)/sigfac  
+    if (heff .le. 0) cycle   
+    
+    hsat     = fcrit_gfs*ULOW(I)/bnv
+    heff     = min(heff, hsat)
+        
+        FR = min(BNV  * heff /ULOW(I), FRMAX)
+!
+        EFACT    = (OA(I) + 2.) ** (CEOFRC*FR)
+        EFACT    = MIN( MAX(EFACT,EFMIN), EFMAX )
+!
+        COEFM    = (1. + CLX(I)) ** (OA(I)+1.)
+!
+        XLINV(I) = COEFM * CLEFF           ! effective kxw for Lin-wave
+    XLINGFS =  COEFM * CLEFF 
+!
+        TEM      = FR    * FR * OC(J)               
+        GFOBNV   = GMAX  * TEM / ((TEM + CG)*BNV) 
+!
+!new specification of XLINV(I) & taulin(i)
+
+        sigres = max(sigmin, sigma(J))
+    if (heff/sigres.gt.hdxres) sigres=heff/hdxres
+        inv_b2eff =  0.5*sigres/heff    
+    kxridge =    1./sqrt(sparea(J))
+        XLINV(I) = XLINGFS    !or max(kxridge, inv_b2eff)         ! 6.28/Lx ..0.5*sigma(j)/heff = 1./Lridge  
+      taulin(i)=.5*ROLL(I)*XLINV(I)*BNV*ULOW(I)* heff*heff
+
+       if ( FR > fcrit_gfs ) then
+        TAUB(I)  = XLINV(I) * ROLL(I) * ULOW(I) * ULOW(I) * ULOW(I)  * GFOBNV  * EFACT       ! nonlinear FLUX Tau0...XLINV(I)
+!
+         else
+!    
+        TAUB(I)  = XLINV(I) * ROLL(I) * ULOW(I) * ULOW(I)  * ULOW(I)  * GFOBNV  * EFACT  
+!     
+!        TAUB(I)  = taulin(i)                             !  linear flux for FR <= fcrit_gfs
+!   
+        endif
+!        
+!
+        K        = MAX(1, kref(I)-1)
+        TEM      = MAX(VELCO(I,K)*VELCO(I,K), dw2min)
+        SCOR(I)  = BNV2(I,K) / TEM  ! Scorer parameter below ref level
+!
+! diagnostics for zogw > zmtb
+!
+    zogw(J)    = PHII(j, kref(I)) *rgrav
+      ENDDO
+
+!    
+!                                                                       
+!----SET UP BOTTOM VALUES OF STRESS
+!
+      DO K = 1, KBPS
+        DO I = 1,npt
+          IF (K .LE. kref(I)) TAUP(I,K) = TAUB(I)
+        ENDDO
+      ENDDO
+      
+      if (strsolver=='PSS-1986') then     
+       
+!======================================================
+!   V0-GFS OROGW-solver of Palmer et al 1986 -"PSS-1986"
+!   in V1-OROGW  LINSATDIS of                 "WAM-2017"
+!     with LLWB-mechanism for
+!     rotational/non-hydrostat OGWs important for 
+!     HighRES-FV3GFS with dx < 10 km
+!======================================================
+      
+      DO K = KMPS, KMM1                   ! Vertical Level Loop
+        KP1 = K + 1
+        DO I = 1, npt
+!
+          IF (K .GE. kref(I)) THEN
+            ICRILV(I) = ICRILV(I) .OR. ( RI_N(I,K) .LT. RIC)   .OR. (VELCO(I,K) .LE. 0.0)
+          ENDIF
+        ENDDO
+!
+        DO I = 1,npt
+          IF (K .GE. kref(I))   THEN
+            IF (.NOT.ICRILV(I) .AND. TAUP(I,K) .GT. 0.0 ) THEN
+              TEMV = 1.0 / max(VELCO(I,K), velmin)
+!
+              IF (OA(I).GT.0. .AND. kp1 .lt. kref(i)) THEN
+                SCORK   = BNV2(I,K) * TEMV * TEMV
+                RSCOR   = MIN(1.0, SCORK / SCOR(I))
+                SCOR(I) = SCORK
+              ELSE 
+                RSCOR   = 1.
+              ENDIF
+!
+              BRVF = SQRT(BNV2(I,K))        ! Brent-Vaisala Frequency interface
+!             TEM1 = XLINV(I)*(RO(I,KP1)+RO(I,K))*BRVF*VELCO(I,K)*0.5
+
+              TEM1 = XLINV(I)*(RO(I,KP1)+RO(I,K))*BRVF*0.5  * max(VELCO(I,K), velmin)
+              HD   = SQRT(TAUP(I,K) / TEM1)
+              FRO  = BRVF * HD * TEMV
+!
+!    RIM is the  "WAVE"-RICHARDSON NUMBER BY PALMER,Shutts, Swinbank 1986
+!
+
+              TEM2   = SQRT(ri_n(I,K))
+              TEM    = 1. + TEM2 * FRO
+              RI_GW    = ri_n(I,K) * (1.-FRO) / (TEM * TEM)
+!
+!    CHECK STABILITY TO EMPLOY THE 'dynamical SATURATION HYPOTHESIS'
+!    OF PALMER,Shutts, Swinbank 1986
+!                                       ----------------------
+              IF (RI_GW .LE. RIC .AND.  (OA(I) .LE. 0. .OR.  kp1 .ge. kref(i) )) THEN
+                 TEMC = 2.0 + 1.0 / TEM2
+                 HD   = VELCO(I,K) * (2.*SQRT(TEMC)-TEMC) / BRVF
+                 TAUP(I,KP1) = TEM1 * HD * HD
+              ELSE 
+                 TAUP(I,KP1) = TAUP(I,K) * RSCOR
+              ENDIF
+              taup(i,kp1) = min(taup(i,kp1), taup(i,k))
+            ENDIF
+          ENDIF
+        ENDDO
+      ENDDO
+!     
+!  zero momentum deposition at the top model layer
+!      
+         taup(1:npt,levs+1) = taup(1:npt,levs)      
+!
+!     Calculate wave acc-n: - (grav)*d(tau)/d(p) = taud
+!
+      DO K = 1,KM
+        DO I = 1,npt
+          TAUD(I,K)=GRAV*(TAUP(I,K+1) - TAUP(I,K))/DEL(ipt(I),K)
+        ENDDO
+      ENDDO
+!
+!------scale MOMENTUM DEPOSITION  AT TOP TO 1/2 VALUE
+! it is zero now      
+!         DO I = 1,npt
+!            TAUD(I, levs) = TAUD(I,levs) * FACTOP
+!         ENDDO
+    
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!------IF THE GRAVITY WAVE DRAG WOULD FORCE A CRITICAL LINE IN THE
+!------LAYERS BELOW SIGMA=RLOLEV DURING THE NEXT DELTIM TIMESTEP,
+!------THEN ONLY APPLY DRAG UNTIL THAT CRITICAL LINE IS REACHED.
+! Empirical implementation of the LLWB-mechanism: Lower Level Wave Breaking
+! by limiting "Ax = Dtfac*Ax" due to possible LLWB around Kref and 500 mb
+! critical line [V - Ax*dtp = 0.] is smt like "LLWB" for stationary OGWs
+!2019:  this option limits sensitivity of taux/tauy to  increase/decreaseof TAUB
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      DO K = 1,KMM1
+        DO I = 1,npt
+         IF (K .GE. kref(I) .and. PRSI(ipt(i),K) .GE. RLOLEV) THEN
+         
+             IF(TAUD(I,K).NE.0.) THEN
+               TEM = DTP * TAUD(I,K)
+               DTFAC(I) = MIN(DTFAC(I),ABS(VELCO(I,K)/TEM))
+!          DTFAC(I) = 1.0
+             ENDIF
+          ENDIF
+        ENDDO
+      ENDDO
+!
+!--------------------------- OROGW-solver of GFS PSS-1986
+!  
+      else 
+!
+!--------------------------- OROGW-solver of WAM2017
+!
+!          sigres = max(sigmin, sigma(J))
+!      if (heff/sigres.gt.dxres) sigres=heff/dxres
+!          inv_b2eff =  0.5*sigres/heff     
+!        XLINV(I) = max(kxridge, inv_b2eff)           ! 0.5*sigma(j)/heff = 1./Lridge      
+       dtfac(:) =  1.0
+       
+      call oro_wam_2017(im, levs, npt, ipt, kref, kdt, me, master,&
+      dtp, dxres, taub, u1, v1, t1, xn, yn, bnv2, ro, prsi,prsL, &
+        del, sigma, hprime, gamma, theta,&
+        sinlat, xlatd, taup, taud, pkdis)
+     
+      endif            !  oro_wam_2017 - LINSATDIS-solver of WAM-2017
+!      
+!--------------------------- OROGW-solver of WAM2017
+! 
+! TOFD as in BELJAARS-2004
+!
+! ---------------------------    
+      IF( do_tofd ) then
+      axtms(:,:) = 0.0 ; aytms(:,:) = 0.0 
+       if ( kdt == 1) then
+           print *, 'VAY do_tofd  from surface to ', ztop_tofd 
+       endif
+       DO I = 1,npt          
+     J = ipt(i)
+     zpbl  =rgrav*phil( j, kpbl(j) )
+     
+         sigflt = min(sgh30(j), 0.3*hprime(j)) ! cannot exceed 30% of LS-SSO
+     
+     zsurf = phii(j,1)*rgrav
+     zpm(1:levs) =phiL(j,1:levs)*rgrav
+     up1(1:levs) = u1(j,1:levs)
+     vp1(1:levs) = v1(j,1:levs)
+     
+         call ugwp_tofd1d(levs, sigflt, elvmaxd(j), zsurf, zpbl,& 
+           up1, vp1, zpm,  utofd1, vtofd1, epstofd1, krf_tofd1)
+     
+         axtms(j,1:levs) = utofd1
+         aytms(j,1:levs) = vtofd1
+!    
+! add TOFD to GW-tendencies
+!    
+     pdvdt(J,:)  = pdvdt(J,:) + aytms(j,:)
+     pdudt(J,:)  = pdudt(J,:) + axtms(j,:)       
+!2018-diag
+          tau_tofd(J) = sum( utofd1(1:levs)* del(j,1:levs))
+        enddo
+       ENDIF    ! do_tofd 
+
+!---------------------------
+! combine oro-drag effects
+!---------------------------  
+! +  diag-3d
+
+     dudt_tms = axtms 
+     tau_ogw =0.
+     tau_mtb =0.
+     
+      DO K = 1,KM
+        DO I = 1,npt
+          J          = ipt(i)
+!
+          ENG0       = 0.5*(U1(j,K)*U1(j,K)+V1(J,K)*V1(J,K))
+!
+          if ( K .lt. IDXZB(I) .AND. IDXZB(I) .ne. 0 ) then
+!
+! if blocking layers -- no OGWs
+!     
+            DBIM = DB(I,K) / (1.+DB(I,K)*DTP)               
+            Pdvdt(j,k) = - DBIM * V1(J,K) +Pdvdt(j,k)
+        Pdudt(j,k) = - DBIM * U1(J,K) +Pdudt(j,k)       
+            ENG1    = ENG0*(1.0-DBIM*DTP)*(1.-DBIM*DTP)
+            
+            DUSFC(J)   = DUSFC(J) - DBIM * U1(J,K) * DEL(J,K)
+            DVSFC(J)   = DVSFC(J) - DBIM * V1(J,K) * DEL(J,K)
+!2018-diag 
+            dudt_mtb(j,k) = -DBIM * U1(J,K)     
+        tau_mtb(j) = tau_mtb(j) + dudt_mtb(j,k)* DEL(J,K)
+        
+          else
+!
+! OGW-s above blocking height
+!     
+            TAUD(I,K)  = TAUD(I,K) * DTFAC(I)
+            DTAUX      = TAUD(I,K) * XN(I) 
+            DTAUY      = TAUD(I,K) * YN(I)    
+        
+            Pdvdt(j,k)   = DTAUY  +Pdvdt(j,k)
+        Pdudt(j,k)   = DTAUX  +Pdudt(j,k)
+        
+        unew = U1(J,K) + DTAUX*dtp       !   Pdudt(J,K)*DTP
+        vnew = V1(J,K) + DTAUY*dtp       !   Pdvdt(J,K)*DTP
+            ENG1   = 0.5*(unew*unew + vnew*vnew)                        
+!
+            DUSFC(J)   = DUSFC(J)  + DTAUX * DEL(J,K)
+            DVSFC(J)   = DVSFC(J)  + DTAUY * DEL(J,K)
+!2018-diag
+        dudt_ogw(j,k) =DTAUX        
+        tau_ogw(j)    = tau_ogw(j) +DTAUX*DEL(j,k)              
+          endif
+!     
+! local energy deposition SSO-heat
+!   
+        Pdtdt(j,k) = max(ENG0-ENG1,0.)*rcpdt  
+        ENDDO
+      ENDDO
+! dusfc w/o tofd  sign as in the ERA-I, MERRA  and CFSR
+      DO I = 1,npt
+         J          = ipt(i)
+         DUSFC(J)   = -rgrav * DUSFC(J)
+         DVSFC(J)   = -rgrav * DVSFC(J)
+     tau_mtb(j) = -rgrav * tau_mtb(j)
+     tau_ogw(j) = -rgrav * tau_ogw(j)    
+     tau_tofd(J)= -rgrav * tau_tofd(j)
+       ENDDO
+  
+       RETURN
+
+
+!============ debug ------------------------------------------------      
+       if (kdt .le. 2 ) then
+        print *, 'vgw-oro done gwdps_v0 in ugwp-v0 step-proc ', kdt, me
+!
+        print *, maxval(pdudt)*86400.,  minval(pdudt)*86400, 'vgw_axoro'
+        print *, maxval(pdvdt)*86400.,  minval(pdvdt)*86400, 'vgw_ayoro'
+!        print *, maxval(kdis),  minval(kdis),  'vgw_kdispro m2/sec'
+        print *, maxval(pdTdt)*86400.,  minval(pdTdt)*86400,'vgw_epsoro'
+        print *, maxval(zmtb), ' z_mtb ',  maxval(tau_mtb), ' tau_mtb '
+        print *, maxval(zogw), ' z_ogw ',  maxval(tau_ogw), ' tau_ogw '
+!        print *, maxval(tau_tofd),  ' tau_tofd '
+!        print *, maxval(axtms)*86400.,  minval(axtms)*86400, 'vgw_axtms'
+!      print *,maxval(dudt_mtb)*86400.,minval(dudt_mtb)*86400,'vgw_axmtb'
+        if (maxval(abs(pdudt))*86400. > 100.) then
+    
+        print *,  maxval(u1), minval(u1), ' u1 gwdps-v0 '
+        print *,  maxval(v1), minval(v1), ' v1 gwdps-v0 '
+        print *,  maxval(t1), minval(t1), ' t1 gwdps-v0 '
+        print *,  maxval(q1), minval(q1), ' q1 gwdps-v0 '
+        print *,  maxval(del), minval(del), ' del gwdps-v0 '
+        print *,  maxval(phil)*rgrav,minval(phil)*rgrav, 'zmet'
+        print *,  maxval(phii)*rgrav,minval(phii)*rgrav, 'zmeti'
+        print *,  maxval(prsi), minval(prsi), ' prsi '
+        print *,  maxval(prsL), minval(prsL), ' prsL '
+        print *,  maxval(RO), minval(RO), ' RO-dens '
+        print*,maxval(bnv2(1:npt,:)), minval(bnv2(1:npt,:)),' BNV2 '
+        print *,  maxval(kpbl), minval(kpbl), ' kpbl ' 
+    print *, maxval(sgh30), maxval(hprime), maxval(elvmax),'oro-d'
+    print *  
+    do i =1, npt
+       j= ipt(i)
+      print *,zogw(J)/hprime(j), zmtb(j)/hprime(j), phil(j,1)/9.81, nint(hprime(j)/sigma(j))
+!
+!....................................................................
+!
+!   zogw/hp=5.9   zblk/hp=10.7    zm=11.1m   ridge/2=2,489m/9,000m
+!   from 5 to 20 km , we need to count for "ridges" > dx/4 ~ 15 km
+!   we must exclude blocking by small ridges
+!   VAY-kref < iblk           zogw-lev 15        block-level:  39
+!
+! velmin => 1.0, 0.01, 0.1 etc.....unification of wind limiters
+! MAX(SQRT(U1(J,K)*U1(J,K) + V1(J,K)*V1(J,K)), minwnd)
+! MAX(DW2,DW2MIN) * RDZ * RDZ
+! ULOW(I) = MAX(SQRT(UBAR(I)*UBAR(I) + VBAR(I)*VBAR(I)), 1.0)
+! TEM      = MAX(VELCO(I,K)*VELCO(I,K), 0.1)
+!              TEMV = 1.0 / max(VELCO(I,K), 0.01)
+!     &                   * max(VELCO(I,K),0.01) 
+!....................................................................     
+    enddo 
+    print *  
+       stop                             
+    endif         
+        endif
+      
+!
+      RETURN
+!---------------------------------------------------------------
+! review of OLD-GFS code 2017/18 most substantial changes
+!  a) kref > idxzb if idxzb > KPBL "OK" clipped-hill for OGW
+!  b) tofd -sgh30                   "OK"
+!
+!  c) FR < Frc linear theory for taub-specification
+!
+!  d) solver of Palmer et al. (1987) => Linsat of McFarlane
+!
+!---------------------------------------------------------------   
+      end subroutine gwdps_v0  
+      
+      
+      
+!===============================================================================
+!    use fv3gfs-v0
+!    first beta version of ugwp for fv3gfs-128
+!    cires/swpc - jan 2018
+!    non-tested wam ugwp-solvers in fv3gfs: "lsatdis", "dspdis", "ado99dis"
+!    they reqiure extra-work to put them in with intializtion and namelists
+!          next will be lsatdis for both fv3wam & fv3gfs-128l implementations
+!    with (a) stochastic-deterministic propagation solvers for wave packets/spectra
+!         (b) gw-sources: oro/convection/dyn-instability (fronts/jets/pv-anomalies)
+!         (c) guidance from high-res runs for GW sources and res-aware tune-ups  
+!23456 
+!
+!      call gwdrag_wam(1,  im,   ix,  levs,   ksrc, dtp,
+!     & xlat, gw_dudt, gw_dvdt,  taux,  tauy)
+!        call fv3_ugwp_wms17(kid1, im,  ix,  levs,  ksrc_ifs, dtp,
+!     &  adt,adu,adv,prsl,prsi,phil,xlat, gw_dudt, gw_dvdt, gw_dtdt, gw_ked,
+!     &  taux,tauy,grav, amol_i, me, lstep_first )
+!
+!
+!23456==============================================================================
+
+      subroutine slat_geos5_tamp(im, tau_amp, xlatdeg, tau_gw)
+!=================
+! GEOS-5 & MERRA-2 lat-dependent GW-source function  tau(z=Zlaunch) =rho*<u'w'>
+!=================
+      implicit none
+      integer :: im
+      real  :: xlatdeg(im),  tau_amp
+      real  :: tau_gw(im)
+      real  :: latdeg
+!      real, parameter  :: tau_amp = 100.e-3
+      real             :: trop_gw,  flat_gw
+      integer :: i
+
+!
+! if-lat
+      trop_gw = 0.75
+      do i=1, im
+      latdeg = xlatdeg(i)
+      if (-15.3 < latdeg .and. latdeg < 15.3) then
+          flat_gw = trop_gw*exp(-( (abs(latdeg)-3.)/8.0)**2)
+          if (flat_gw < 1.2 .and. abs(latdeg) <= 3.) flat_gw = trop_gw
+      else if (latdeg > -31. .and. latdeg <= -15.3) then
+          flat_gw =  0.10
+      else if (latdeg <  31. .and. latdeg >=  15.3) then
+           flat_gw =  0.10
+      else if (latdeg > -60. .and. latdeg <= -31.) then
+        flat_gw =  0.50*exp(-((abs(latdeg)-60.)/23.)**2)
+      else if (latdeg <  60. .and. latdeg >=  31.) then
+        flat_gw =  0.50*exp(-((abs(latdeg)-60.)/23.)**2)
+      else if (latdeg <= -60.) then
+         flat_gw =  0.50*exp(-((abs(latdeg)-60.)/70.)**2)
+      else if (latdeg >=  60.) then
+         flat_gw =  0.50*exp(-((abs(latdeg)-60.)/70.)**2)
+      end if
+      tau_gw(i) = tau_amp*flat_gw
+      enddo
+!      
+      end subroutine slat_geos5_tamp
+
+
+
+      subroutine fv3_ugwp_solv2_v0(klon, klev, dtime, &
+      tm1 , um1, vm1, qm1, &
+      prsl, prsi,   philg, xlatd, sinlat, coslat, &
+      pdudt, pdvdt, pdtdt, dked, tau_ngw, mpi_id, master, kdt)
+!
+
+
+!=======================================================
+!
+!      nov 2015 alternative gw-solver for nggps-wam
+!      nov 2017 nh/rotational gw-modes for nh-fv3gfs
+! ---------------------------------------------------------------------------------
+!  
+  
+      use ugwp_common ,      only : rgrav, grav, cpd, rd, rv
+      use ugwp_common ,      only : omega2, rcpd2      
+      use ugwp_common ,      only : pi, rad_to_deg, deg_to_rad, pi2       
+      use ugwp_common ,      only : rdi, gor,  grcp,  gocp,  fv,  gr2
+      use ugwp_common ,      only : bnv2min, dw2min, velmin                
+!
+      use ugwp_wmsdis_init, only : hpscale, rhp2, bv2min, gssec 
+      use ugwp_wmsdis_init, only : v_kxw, v_kxw2, tamp_mpa, zfluxglob    
+      use ugwp_wmsdis_init, only : maxdudt, gw_eff, dked_min
+      use ugwp_wmsdis_init, only : nslope, ilaunch  
+      use ugwp_wmsdis_init, only : zms, zci,  zdci, zci4, zci3, zci2
+      use ugwp_wmsdis_init, only : zaz_fct, zcosang, zsinang 
+      use ugwp_wmsdis_init, only : nwav, nazd  , zcimin, zcimax 
+! 
+       implicit none
+!23456 
+       
+        integer  ,intent(in)  :: klev              ! vertical level
+        integer  ,intent(in)  :: klon              ! horiz tiles
+    
+        real ,intent(in)   :: dtime               ! model time step       
+        real ,intent(in)   :: vm1(klon,klev)      ! meridional wind 
+        real ,intent(in)   :: um1(klon,klev)      ! zonal wind
+        real ,intent(in)   :: qm1(klon,klev)      ! spec. humidity
+        real ,intent(in)   :: tm1(klon,klev)      ! kin temperature 
+
+        real ,intent(in) :: prsl(klon,klev)       ! mid-layer pressure
+        real ,intent(in) :: philg(klon,klev)      ! m2/s2-phil => meters !!!!!       phil =philg/grav
+        real ,intent(in) :: prsi(klon,klev+1)     !   prsi interface pressure
+        real ,intent(in) :: xlatd(klon)           ! lat was in radians, now with xlat_d in degrees
+        real ,intent(in) :: sinlat(klon)
+        real ,intent(in) :: coslat(klon)                
+        real ,intent(in) :: tau_ngw(klon)
+            
+        integer, intent(in)   :: mpi_id, master, kdt
+!  
+!
+! out-gw effects
+!
+        real ,intent(out):: pdudt(klon,klev)     ! zonal momentum tendency
+        real ,intent(out):: pdvdt(klon,klev)     ! meridional momentum tendency
+        real ,intent(out):: pdtdt(klon,klev)     ! gw-heating (u*ax+v*ay)/cp
+        real ,intent(out):: dked(klon,klev)      ! gw-eddy diffusion    
+        real, parameter  :: minvel = 0.5    !      
+                     
+!vay-2018
+   
+        real             :: taux(klon,klev+1)  ! EW component of vertical momentum flux (pa)
+        real             :: tauy(klon,klev+1)  ! NS component of vertical momentum flux (pa)
+        real             :: phil(klon,klev)    !   gphil/grav   
+!
+! local ===============================================================================================
+!
+     
+         real  :: zbvfhm1(klon,klev), zbn2(klon,klev)    ! interface BV-frequency 
+         real  :: zbvfl(klon)                            ! BV at launch level    
+         real  :: zrhohm1(klon,klev)                     ! interface density 
+         real  :: zuhm1(klon,klev)                       ! interface zonal wind
+         real  :: zvhm1(klon,klev)                       ! meridional wind
+         real  :: zthm1(klon,klev)                       !temperature interface levels       
+         real  :: v_zmet(klon, klev)         
+         real  :: vueff(klon, klev)  
+     real  :: c2f2(klon)     
+    
+!23456
+         real  :: zul(klon,nazd)                !velocity in azimuthal direction at launch level
+         real  :: zci_min(klon,nazd)
+         real  :: zcrt(klon,klev,nazd)
+         real  :: zact(klon, nwav, nazd)        !if =1 then critical level encountered => c-u
+         real  :: zacc(klon, nwav, nazd)
+!
+         real  :: zpu(klon,klev,  nazd)         !momentum flux
+         real  :: zdfl(klon,klev, nazd)  
+         real  :: zfct(klon,klev)
+         real  :: zfnorm(klon)                 !normalisation factor
+     
+       real  ::  zfluxlaun(klon)
+       real  ::  zui(klon, klev,nazd)
+!
+       real  :: zdfdz_v(klon,klev, nazd)   ! axj = -df*rho/dz       directional momentum depositiom
+       real  :: zflux(klon, nwav, nazd)   ! momentum flux at each level   stored as ( ix, mode, iazdim)
+
+       real  :: zflux_z (klon, nwav,klev)    !momentum flux at each azimuth stored as ( ix, mode, klev)
+!
+       real  :: vm_zflx_mode, vc_zflx_mode
+       real  :: kzw2, kzw3, kdsat, cdf2, cdf1, wdop2
+
+       real  :: zang, znorm, zang1, ztx
+       real  :: zu, zcin, zcpeak, zcin4, zbvfl4
+       real  :: zcin2, zbvfl2, zcin3, zbvfl3, zcinc
+       real  :: zatmp, zfluxs, zdep, zfluxsq, zulm, zdft, ze1, ze2
+
+!  
+       real  :: zdelp,zrgpts
+       real  :: zthstd,zrhostd,zbvfstd
+       real  :: tvc1,  tvm1       
+       real  :: zhook_handle
+
+
+       real  :: rcpd, grav2cpd
+       
+       real :: fmode, expdis, fdis
+       real :: v_kzi, v_kzw, v_cdp, v_wdp, sc
+                  
+       integer :: j, k, inc, jk, jl, iazi             
+!       
+!--------------------------------------------------------------------------
+!
+        pdvdt  =0.   ; pdudt =0.    ; pdtdt =0. ; dked =0. 
+!-----------------------------------------------------------    
+! also other options to alter tropical values
+! tamp = 100.e-3*1.e3 = 100 mpa
+! vay-2017   zfluxglob=> lat-dep here from geos-5/merra-2 
+!-----------------------------------------------------------
+!        call slat_geos5_tamp(klon, tamp_mpa, xlatd, tau_ngw)   
+    
+     
+         phil =philg*rgrav
+                                
+         rcpd = 1./(grav/cpd)        ! 1/[g/cp]
+         grav2cpd=grav*grav/cpd      ! g*(g/cp)= g^2/cp
+
+        if (kdt ==1 .and. mpi_id == master) then
+
+         print *,  maxval(tm1), minval(tm1), 'vgw: temp-res '
+         print *,  'ugwp-v0: zcimin=' , zcimin
+         print *,  'ugwp-v0: zcimax=' , zcimax 
+         print *
+     
+        endif    
+!
+!=================================================
+       do iazi=1, nazd
+          do jk=1,klev
+          do jl=1,klon                       
+         zpu(jl,jk,iazi) =0.0 
+         zcrt(jl,jk,iazi)=0.0 
+         zdfl(jl,jk,iazi)=0.0 
+         enddo
+         enddo      
+       enddo  
+
+!   
+! set initial min Cxi for critical level absorption
+       do iazi=1,nazd
+        do jl=1,klon
+            zci_min(jl,iazi)=zcimin
+        enddo
+       enddo
+!       define half model level winds and temperature
+!       -----------------------------------
+       do jk=2,klev
+        do jl=1,klon  
+    tvc1 = tm1(jl,jk)*(1. +fv*qm1(jl,jk)) 
+    tvm1 = tm1(jl,jk-1)*(1. +fv*qm1(jl,jk-1))                                     
+        zthm1(jl,jk) =0.5 *(tvc1+tvm1) 
+        zuhm1(jl,jk) =0.5 *(um1(jl,jk-1)+um1(jl,jk))
+        zvhm1(jl,jk) =0.5 *(vm1(jl,jk-1)+vm1(jl,jk))
+        zrhohm1(jl,jk)=prsi(jl,jk)*rdi/zthm1(jl,jk)                !  rho = p/(RTv) 
+        zdelp=phil(jl,jk)-phil(jl,jk-1)      !>0 ...... dz-meters
+        v_zmet(jl,jk) = 2.*zdelp
+        vueff(jl,jk) =  2.e-5*exp( (phil(jl,jk)+phil(jl,jk-1))*rhp2)+dked_min
+!     
+        zbn2(jl,jk)= grav2cpd/zthm1(jl,jk)*    (1.0 + rcpd*(tm1(jl,jk)-tm1(jl,jk-1))/zdelp)
+         zbn2(jl,jk)=min(zbn2(jl,jk),gssec)
+         zbn2(jl,jk)=max(zbn2(jl,jk),bv2min)
+         zbvfhm1(jl,jk)=sqrt(zbn2(jl,jk))       ! bn = sqrt(bn2)                    
+        enddo
+       enddo
+
+          jk=1
+       do jl=1,klon                                        
+         zthm1(jl,jk)=tm1(jl,jk)*(1. +fv*qm1(jl,jk))
+         zuhm1(jl,jk)=um1(jl,jk)
+         zvhm1(jl,jk)=vm1(jl,jk)
+         ZBVFHM1(JL,1)  = ZBVFHM1(JL,2)
+         V_ZMET(JL,1)  = V_ZMET(JL,2)
+         VUEFF(JL,1)   = DKED_MIN
+     ZBN2(JL,1)   = ZBN2(JL,2)
+     C2F2(JL) = (OMEGA2*SINLAT(JL))**2/V_KXW2
+         zbvfl(jl)=zbvfhm1(jl,ilaunch)      
+        enddo
+!   
+!        define intrinsic velocity (relative to launch level velocity) u(z)-u(zo), and coefficinets
+!       ------------------------------------------------------------------------------------------        
+        do iazi=1, nazd
+         do jl=1,klon
+         zul(jl,iazi)=zcosang(iazi)*zuhm1(jl,ilaunch)+  zsinang(iazi)*zvhm1(jl,ilaunch)
+         enddo
+        enddo
+!
+         do jk=ilaunch, klev-1     ! from z-launch up   model level from which gw spectrum is launched
+          do iazi=1, nazd
+           do jl=1,klon
+          zu=zcosang(iazi)*zuhm1(jl,jk)+zsinang(iazi)*zvhm1(jl,jk)
+          zui(jl,jk,iazi) =  zu - zul(jl,iazi)
+          enddo
+        enddo
+
+        enddo
+!                                         define rho(zo)/n(zo)
+!       ------------------- 
+      do jk=ilaunch, klev-1               
+        do jl=1,klon
+        zfct(jl,jk)=zrhohm1(jl,jk)/zbvfhm1(jl,jk)
+        enddo
+      enddo
+
+!      ----------------------------------------- 
+!       set launch momentum flux spectral density
+!       ----------------------------------------- 
+
+      if(nslope==1) then
+! s=1 case
+       do inc=1,nwav
+             zcin=zci(inc)
+             zcin4= zci4(inc)
+       do jl=1,klon
+!n4
+         zbvfl4=zbvfl(jl)**4
+         zflux(jl,inc,1)=zfct(jl,ilaunch)*zbvfl4*zcin/(zbvfl4+zcin4)
+      enddo
+      enddo
+           elseif(nslope==2) then
+! s=2 case
+      do inc=1, nwav
+      zcin=zci(inc)
+      zcin4= zci4(inc)
+        do jl=1,klon
+         zbvfl4=zbvfl(jl)**4
+         zcpeak=zbvfl(jl)/zms
+        zflux(jl,inc,1)=zfct(jl,ilaunch)* zbvfl4*zcin*zcpeak/(zbvfl4*zcpeak+zcin4*zcin)
+         enddo
+       enddo
+          elseif(nslope==-1) then
+! s=-1 case
+       do inc=1,nwav
+         zcin=zci(inc)
+         zcin2= zci2(inc)
+       do jl=1,klon
+        zbvfl2=zbvfl(jl)**2
+        zflux(jl,inc,1)=zfct(jl,ilaunch)*zbvfl2*zcin/(zbvfl2+zcin2) 
+       enddo
+       enddo
+!s=0 case
+           elseif(nslope==0) then
+
+       do inc=1, nwav
+           zcin=zci(inc)
+           zcin3= zci3(inc)
+       do jl=1,klon
+        zbvfl3=zbvfl(jl)**3
+        zflux(jl,inc,1)=zfct(jl,ilaunch)*zbvfl3*zcin/(zbvfl3+zcin3)
+       enddo
+       enddo
+
+       endif  ! for slopes
+!
+! normalize momentum flux at the src-level
+!       ------------------------------
+! integrate (zflux x dx)
+      do inc=1, nwav
+         zcinc=zdci(inc)
+      do jl=1,klon
+      zpu(jl,ilaunch,1)=zpu(jl,ilaunch,1)+zflux(jl,inc,1)*zcinc
+      enddo    
+      enddo
+!      
+!       normalize and include lat-dep  (precip or merra-2)
+!       -----------------------------------------------------------
+! also other options to alter tropical values
+!
+       do jl=1,klon       
+        zfluxlaun(jl)=tau_ngw(jl)     !*(.5+.75*coslat(JL))      !zfluxglob/2  on poles
+        zfnorm(jl)= zfluxlaun(jl)/zpu(jl,ilaunch,1)
+       enddo
+!
+      do iazi=1,nazd
+      do jl=1,klon
+      zpu(jl,ilaunch,iazi)=zfluxlaun(jl)
+      enddo
+      enddo
+
+!       adjust constant zfct
+
+         do jk=ilaunch, klev-1
+        do jl=1,klon
+            zfct(jl,jk)=zfnorm(jl)*zfct(jl,jk)
+        enddo
+        enddo
+!               renormalize each spectral mode
+
+        do inc=1, nwav
+         do jl=1,klon
+          zflux(jl,inc,1)=zfnorm(jl)*zflux(jl,inc,1)
+         enddo
+         enddo
+
+!       copy zflux into all other azimuths
+!       --------------------------------
+          zact(:,:,:) = 1.0 ; zacc(:,:,:) = 1.0
+          do iazi=2, nazd
+            do inc=1,nwav
+            do jl=1,klon
+            zflux(jl,inc,iazi)=zflux(jl,inc,1)
+           enddo
+          enddo
+          enddo
+
+! -------------------------------------------------------------      
+!                                        azimuth do-loop
+! --------------------
+        do iazi=1, nazd
+!                                       vertical do-loop
+! ----------------
+          do jk=ilaunch, klev-1                     
+! first check for critical levels
+! ------------------------
+           do jl=1,klon
+            zci_min(jl,iazi)=max(zci_min(jl,iazi),zui(jl,jk,iazi))               
+           enddo
+! set zact to zero if critical level encountered
+! ----------------------------------------------
+           do inc=1, nwav
+            zcin=zci(inc)
+            do jl=1,klon
+               zatmp= minvel+sign(minvel,zcin-zci_min(jl,iazi))
+               zacc(jl,inc,iazi)=zact(jl,inc,iazi)-zatmp
+               zact(jl,inc,iazi)=zatmp
+            enddo
+           enddo
+!
+! integrate to get critical-level contribution to mom deposition
+! ---------------------------------------------------------------
+           do inc=1, nwav
+            zcinc=zdci(inc)
+            do jl=1,klon
+               zdfl(jl,jk,iazi)=zdfl(jl,jk,iazi)+ zacc(jl,inc,iazi)*zflux(jl,inc,iazi)*zcinc
+            enddo
+           enddo
+! --------------------------------------------
+! get weighted average of phase speed in layer
+! --------------------------------------------
+          do jl=1,klon
+            if(zdfl(jl,jk,iazi)>0.0 ) then
+               zatmp=zcrt(jl,jk,iazi)
+             do inc=1, nwav
+                  zatmp=zatmp+zci(inc)*  zacc(jl,inc,iazi)*zflux(jl,inc,iazi)*zdci(inc)
+             enddo
+!
+               zcrt(jl,jk,iazi)=zatmp/zdfl(jl,jk,iazi)
+            else
+               zcrt(jl,jk,iazi)=zcrt(jl,jk-1,iazi)
+            endif
+         enddo
+
+!
+             do inc=1, nwav
+                zcin=zci(inc)
+                zcinc=1.0 /zcin
+                do jl=1,klon
+!=======================================================================
+! saturated limit    wfit = kzw*kzw*kt; wfdt = wfit/(kxw*cx)*betat
+! & dissipative      kzi = 2.*kzw*(wfdm+wfdt)*dzpi(k)
+!           define   kxw = 
+!=======================================================================  
+               v_cdp =  abs(zcin-zui(jL,jk,iazi))
+               v_wdp = v_kxw*v_cdp
+           wdop2 = v_wdp* v_wdp
+           cdf2 = v_cdp*v_cdp - c2f2(jL) 
+           if (cdf2 .gt. 0) then
+               kzw2 = (zBn2(jL,jk)-wdop2)/Cdf2  - v_kxw2  
+        else
+         kzw2 = 0.0
+           endif                       
+               if ( kzw2 .gt. 0 ) then 
+           v_kzw = sqrt(kzw2)
+!          
+!linsatdis:  kzw2, kzw3, kdsat, c2f2,  cdf2, cdf1
+!                
+!kzw2 = (zBn2(k)-wdop2)/Cdf2  - rhp4 - v_kx2w  ! full lin DS-NiGW (N2-wd2)*k2=(m2+k2+[1/2H]^2)*(wd2-f2) 
+!              Kds = kxw*Cdf1*rhp2/kzw3
+!
+                v_cdp = sqrt( cdf2 ) 
+            v_wdp = v_kxw *  v_cdp    
+                v_kzi  = abs(v_kzw*v_kzw*vueff(jl,jk)/v_wdp*v_kzw)
+                  expdis = exp(-v_kzi*v_zmet(jl,jk))
+               else
+                  v_kzi = 0.
+                  expdis = 1.0  
+          v_kzw = 0.
+          v_cdp = 0.   ! no effects of reflected waves
+               endif
+           
+               fmode =  zflux(jl,inc,iazi) 
+               fdis  =  fmode*expdis
+!
+! saturated flux + wave dissipation - Keddy_gwsat in UGWP-V1
+!  linsatdis = 1.0 , here:   u'^2 ~ linsatdis* [v_cdp*v_cdp]
+!
+               zfluxs= zfct(jl,jk)*v_cdp*v_cdp*zcinc
+!                                     
+!               zfluxs= zfct(jl,jk)*(zcin-zui(jl,jk,iazi))**2/zcin
+! flux_tot - sat.flux
+! 
+
+               zdep=zact(jl,inc,iazi)* (fdis-zfluxs)           
+                  if(zdep>0.0 ) then
+! subs on sat-limit
+                      zflux(jl,inc,iazi)=zfluxs
+                      zflux_z(jl,inc,jk)=zfluxs
+                   else
+! assign dis-ve flux
+                      zflux(jl,inc,iazi)=fdis 
+                      zflux_z(jl,inc,jk)=fdis 
+                   endif  
+               enddo                 
+             enddo
+!
+! integrate over spectral modes  zpu(y, z, azimuth)    zact(jl,inc,iazi)*zflux(jl,inc,iazi)*[d("zcinc")]
+!
+           zdfdz_v(:,jk, iazi) =0.
+        
+          do inc=1, nwav
+                 zcinc=zdci(inc)                    ! dc-integration
+            do jl=1,klon
+
+               vc_zflx_mode = zact(jl,inc,iazi)*zflux(jl,inc,iazi)
+               zpu(jl,jk,iazi)=zpu(jl,jk,iazi) + vc_zflx_mode*zcinc
+              
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+! check monotonic decrease
+!     (heat deposition integration over spectral mode for each azimuth
+!      later sum over selected azimuths as "non-negative" scalars)
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      if (jk.gt.ilaunch)then
+       zdelp= grav/(prsi(jl,jk-1)-prsi(jl,jk))*  abs(zcin-zui(jl,jk,iazi)) *zcinc
+       vm_zflx_mode=zact(jl,inc,iazi)* zflux_z(jl,inc,jk-1)
+
+      if (vc_zflx_mode.gt.vm_zflx_mode) vc_zflx_mode =vm_zflx_mode ! no-flux increase
+      zdfdz_v( jl,jk,iazi) =zdfdz_v( jl,jk,iazi) + (vm_zflx_mode-vc_zflx_mode)*zdelp                 ! heating >0            
+!
+!              
+       endif              
+            enddo                          !jl=1,klon             
+         enddo                             !waves inc=1,nwav
+
+! --------------
+        enddo                              ! end jk do-loop vertical loop
+! ---------------
+       enddo                               ! end nazd do-loop
+! ----------------------------------------------------------------------------    
+!       sum contribution for total zonal and meridional flux +
+!           energy dissipation
+!       ---------------------------------------------------
+!      
+       do jk=1,klev+1
+        do jl=1,klon
+         taux(jl,jk)=0.0 
+         tauy(jl,jk)=0.0 
+       enddo
+       enddo     
+    
+      do iazi=1,nazd
+        do jk=ilaunch,  klev-1      
+        do jl=1,klon
+       taux(jl,jk)=taux(jl,jk)+zpu(jl,jk,iazi)*zaz_fct*zcosang(iazi)       ! zaz_fct - "azimuth"-norm-n
+       tauy(jl,jk)=tauy(jl,jk)+zpu(jl,jk,iazi)*zaz_fct*zsinang(iazi)
+      pdtdt(jl,jk) =pdtdt(jl,jk)+ zdfdz_v(jl,jk,iazi)*zaz_fct/cpd      ! eps_dis =sum( +d(flux_e)/dz) > 0.
+        enddo
+        enddo
+
+      enddo
+!
+!    update du/dt and dv/dt tendencies   ..... no contribution to heating => keddy/tracer-mom-heat
+!    ----------------------------   
+! 
+ 
+
+        do jk=ilaunch,klev
+        do jl=1, klon
+        zdelp= grav/(prsi(jl,jk-1)-prsi(jl,jk))            
+        ze1=(taux(jl,jk)-taux(jl,jk-1))*zdelp
+        ze2=(tauy(jl,jk)-tauy(jl,jk-1))*zdelp  
+    if (abs(ze1) .ge. maxdudt ) then
+        ze1 = sign(maxdudt, ze1)
+    endif 
+    if (abs(ze2) .ge. maxdudt ) then
+        ze2 = sign(maxdudt, ze2)
+    endif   
+        pdudt(jl,jk)=-ze1
+        pdvdt(jl,jk)=-ze2
+!   
+! Cx =0 based Cx=/= 0. above
+!
+        pdtdt(jl,jk) = (ze1*um1(jl,jk) + ze2*vm1(jl,jk))/cpd
+!
+        dked(jl,jk)=pdtdt(jl,jk)/zbn2(jl,jk)
+        if (dked(jl,jk).lt.0)  dked(jl,jk) = dked_min
+        enddo
+        enddo
+!   
+! add limiters/efficiency for "unbalanced ics" if it is needed
+!       
+    pdudt = gw_eff*pdudt
+    pdvdt = gw_eff*pdvdt
+    pdtdt = gw_eff*pdtdt        
+    dked =  gw_eff* dked                
+!  
+!--------------------------------------------------------------------------- 
+!
+       if (kdt == 1 .and. mpi_id == master) then
+             print *, 'vgw done  '
+!
+        print *, maxval(pdudt)*86400.,  minval(pdudt)*86400, 'vgw ax'
+        print *, maxval(pdvdt)*86400.,  minval(pdvdt)*86400, 'vgw ay'
+        print *, maxval(dked)*1.,  minval(dked)*1,  'vgw keddy m2/sec'
+        print *, maxval(pdtdt)*86400.,  minval(pdtdt)*86400,'vgw eps'
+!
+!        print *, ' ugwp -heating rates '
+        endif
+
+        return
+        end subroutine fv3_ugwp_solv2_v0
+!-------------------------------------------------------------------------------
+!
+! Part-3 of UGWP-V01 Dissipative (eddy) effects of UGWP it will be activated
+!           after tests of OGW (new revision) and NGW with MERRA-2 forcing.
+!
+!-------------------------------------------------------------------------------
+      subroutine edmix_ugwp_v0(im, levs, dtp, & 
+        t1, u1, v1, q1, del,       &
+        prsl,  prsi, phil, prslk,&
+        pdudt, pdvdt, pdTdt, pkdis,&
+        ed_dudt, ed_dvdt, ed_dTdt,&
+        me, master, kdt )
+!
+      use machine,           only : kind_phys
+      use ugwp_common ,      only : rgrav, grav, cpd, rd, rdi, fv      
+!      use ugwp_common ,      only : pi, rad_to_deg, deg_to_rad, pi2       
+      use ugwp_common ,      only : bnv2min, velmin, arad
+      
+      implicit none
+         
+        integer, intent(in) :: me,  master, kdt
+        integer, intent(in) :: im, levs 
+    real(kind=kind_phys), intent(in) :: dtp 
+        real(kind=kind_phys), intent(in), dimension(im,levs) ::  u1,  v1, t1,   q1, del,  prsl, prslk, phil  
+!       
+      real(kind=kind_phys), intent(in),dimension(im,levs+1):: prsi
+      real(kind=kind_phys),dimension(im,levs) :: pdudt, pdvdt, pdTdt
+      real(kind=kind_phys),dimension(im,levs) :: pkdis
+!
+! out
+!
+      real(kind=kind_phys),dimension(im,levs) :: ed_dudt, ed_dvdt
+      real(kind=kind_phys),dimension(im,levs) :: ed_dTdt 
+!         
+! locals
+!
+       integer :: i, j, k
+!------------------------------------------------------------------------       
+!      solving 1D-vertical eddy diffusion to "smooth" 
+!      GW-related tendencies:   du/dt, dv/dt, d(PT)/dt
+!      we need to use sum of molecular + eddy terms including turb-part
+!       of PBL extended to the model top, because "phys-tend" dx/dt 
+!       should be smoothed as "entire" fields therefore one should
+!       first estimate and collect "effective" diffusion and applied
+!       it to each part of tendency or "sum of tendencies + Xdyn"
+!       this "diffusive-way" is tested with UGWP-tendencies
+!       forced by various       wave sources. X' =dx/dt *dt
+!       d(X + X')/dt = K*diff(X + X') =>
+!   
+!   wave1 dX'/dt = Kw * diff(X')... eddy part  "Kwave" on wave-part
+!   turb2 dX/dt  = Kturb * diff(X) ... resolved scale mixing "Kturb"  like PBL
+!       we may assume "zero-GW"-tendency at the top lid and "zero" flux
+!       or "vertical gradient" near the surface
+!
+!  1-st trial w/o PBL interactions: add dU, dV dT tendencies
+!  compute BV, SHR2, Ri => Kturb, Kturb + Kwave => Apply it to "X_Tend +X "
+!  ed_X = X_ed - X => final eddy tendencies
+!--------------------------------------------------------------------------- 
+!    rzs=30m              dk       = rzs*rzs*sqrt(shr2(i,k))
+!                  Ktemp     = dk/(1+5.*ri)**2  Kmom = Pr*Ktemp
+!
+      real(kind=kind_phys) :: Sw(levs), Sw1(levs), Fw(levs), Fw1(levs) 
+      real(kind=kind_phys) :: Km(levs), Kpt(levs), Pt(levs), Ptmap(levs)
+      real(kind=kind_phys) :: rho(levs), rdp(levs), rdpm(levs-1)
+      real(kind=kind_phys),dimension(levs) :: ktur, vumol, up, vp, tp
+      real(kind=kind_phys),dimension(levs) :: bn2,  shr2, ksum 
+      real(kind=kind_phys) ::  eps_shr, eps_bn2, eps_dis
+      real(kind=kind_phys) ::  rdz , uz, vz, ptz               
+! -------------------------------------------------------------------------     
+! Prw*Lsat2 =1, for GW-eddy diffusion Pr_wave = Kv/Kt
+!  Pr_wave ~1/Lsat2 = 1/Frcit2 = 2. => Lsat2 = 1./2 (Frc ~0.7)
+!  m*u'/N = u'/{c-U) = h'N/(c-U) = Lsat = Fcrit 
+! > PBL:  0.25 < prnum = 1.0 + 2.1*ri < 4
+!     monin-edmf parameter(rlam=30.0,vk=0.4,vk2=vk*vk) rlamun=150.0
+!
+      real(kind=kind_phys), parameter :: iPr_pt = 0.5, dw2min = 1.e-4  
+      real(kind=kind_phys), parameter :: lturb = 30., sc2 = lturb*lturb 
+      real(kind=kind_phys),parameter :: ulturb=150.,sc2u=ulturb* ulturb    
+      real(kind=kind_phys), parameter :: ric =0.25
+      real(kind=kind_phys), parameter :: rimin = -10., prmin = 0.25
+      real(kind=kind_phys), parameter :: prmax = 4.0  
+      real(kind=kind_phys), parameter :: hps = 7000., h4 = 0.25/hps
+      real(kind=kind_phys), parameter :: kedmin  = 0.01, kedmax = 250.
+      
+            
+      real(kind=kind_phys) :: rdtp, rineg, kamp, zmet, zgrow
+      real(kind=kind_phys) ::  stab, stab_dt, dtstab, ritur
+      integer              ::  nstab   
+      real(kind=kind_phys) ::  w1, w2, w3    
+      rdtp  = 1./dtp     
+       nstab = 1
+       stab_dt = 0.9999      
+         
+      do i =1, im
+      
+         rdp(1:levs) = grav/del(i, 1:levs)
+     
+     up(1:levs) = u1(i,1:levs) +pdudt(i,1:levs)*dtp
+     vp(1:levs) = v1(i,1:levs) +pdvdt(i,1:levs)*dtp  
+     tp(1:levs) = t1(i,1:levs) +pdTdt(i,1:levs)*dtp  
+     Ptmap(1:levs) = (1.+fv*q1(i,1:levs))/prslk(i,1:levs)
+         rho(1:levs) = rdi*prsl(i, 1:levs)/tp(1:levs)    
+     Pt(1:levs) = tp(1:levs)*Ptmap(1:levs)
+        
+     do k=1, levs-1
+        rdpm(k) = grav/(prsl(i,k)-prsl(i,k+1))
+        rdz = .5*rdpm(k)*(rho(k)+rho(k+1))
+        uz = up(k+1)-up(k)
+        vz = vp(k+1)-vp(k)
+        ptz =2.*(pt(k+1)-pt(k))/(pt(k+1)+pt(k)) 
+        shr2(k) = rdz*rdz*(max(uz*uz+vz*vz, dw2min)) 
+        bn2(k) = grav*rdz*ptz  
+        zmet = phil(j,k)*rgrav
+        zgrow = exp(zmet*h4)
+        if ( bn2(k) < 0. ) then
+!       
+! adjust PT-profile to bn2(k) = bnv2min -- neutral atmosphere
+!  adapt "pdtdt = (Ptadj-Ptdyn)/Ptmap" 
+!
+            print *,' UGWP-V0 unstab PT(z) via gwdTdt ', bn2(k), k
+        
+        rineg = bn2(k)/shr2(k)
+        bn2(k) = max(bn2(k), bnv2min) 
+        kamp = sqrt(shr2(k))*sc2u *zgrow
+        ktur(k) =kamp* (1+8.*(-rineg)/(1+1.746*sqrt(-rineg)))
+            endif
+        ritur = max(bn2(k)/shr2(k), rimin)     
+       if (ritur > 0. ) then
+        kamp = sqrt(shr2(k))*sc2 *zgrow
+        w1 = 1./(1. + 5*ritur)
+        ktur(k)= kamp * w1 * w1
+       endif
+        vumol(k) = 2.e-5 *exp(zmet/hps)
+        ksum(k) =ktur(k)+Pkdis(i,k)+vumol(k)
+        ksum(k) = max(ksum(k), kedmin)
+        ksum(k) = min(ksum(k), kedmax)
+        stab = 2.*ksum(k)*rdz*rdz*dtp
+        if ( stab .ge. 1.0 ) then
+            stab_dt = max(stab_dt, stab)
+        endif    
+       enddo   
+       nstab = max(1, nint(stab_dt)+1)
+       dtstab = dtp /float(nstab)     
+         ksum(levs) = ksum(levs-1)
+         Fw(1:levs) =  pdudt(i, 1:levs)
+         Fw1(1:levs) = pdvdt(i, 1:levs)      
+     Km(1:levs) = ksum(1:levs) * rho(1:levs)* rho(1:levs)
+     
+     do j=1, nstab   
+     !call diff_1d_wtend(levs, dtstab, Fw, Fw1, Km, del(i,:), Sw, Sw1)
+     !WL*
+      call diff_1d_wtend(levs, dtstab, Fw, Fw1, Km, rdp, rdpm, Sw, Sw1)
+     !*WL
+     Fw  = Sw
+     Fw1 = Sw1   
+     enddo
+         
+      ed_dudt(i,:) = Sw
+      ed_dvdt(i,:) = Sw1
+     
+      Pt(1:levs) = t1(i,1:levs)*Ptmap(1:levs)      
+      Kpt = Km*iPr_pt
+          Fw(1:levs) =  pdTdt(i, 1:levs)*Ptmap(1:levs)
+     do j=1, nstab                 
+     ! call diff_1d_ptend(levs, dtstab, Fw, Kpt, del(i,:), Sw)
+     !WL*
+         call diff_1d_ptend(levs, dtstab, Fw, Kpt, rdp, rdpm, Sw)
+     !*WL
+       Fw  = Sw  
+     enddo      
+      ed_dtdt(i,1:levs) = Sw(1:levs)/Ptmap(1:levs)
+            
+      enddo 
+                    
+      end subroutine edmix_ugwp_v0
+        
+      subroutine diff_1d_wtend(levs, dt, F, F1, Km, rdp, rdpm, S, S1)
+      use machine,      only: kind_phys
+      implicit none
+      integer :: levs
+      real(kind=kind_phys) :: dt      
+      real(kind=kind_phys) :: S(levs), S1(levs), F(levs), F1(levs) 
+      real(kind=kind_phys) :: Km(levs),  rdp(levs), rdpm(levs-1) 
+      integer              :: i, k
+      real(kind=kind_phys) :: Km1, Kp1, ad, cd, bd 
+!      S(:) = 0.0 ; S1(:) = 0.0
+!         
+! explicit diffusion solver
+!
+      k = 1 
+      km1 = 0. ; ad =0.
+      kp1 = .5*(Km(k)+Km(k+1)) 
+      cd = rdp(1)*rdpm(1)*kp1*dt
+      bd = 1. - cd -ad
+!      S(k) = cd*F(k+1) + ad *F(k-1) + bd *F(k)
+      S(K)  = F(k)
+      S1(K) = F1(k)      
+      do k=2, levs-1
+       ad = cd
+       kp1 = .5*(Km(k)+Km(k+1))    
+       cd = rdp(k)*rdpm(k)*kp1*dt
+       bd = 1.-(ad +cd) 
+       S(k) = cd*F(k+1) +   ad *F(k-1)  + bd *F(k)
+       S1(k)= cd*F1(k+1)  + ad *F1(k-1) + bd *F1(k)     
+      enddo 
+       k =levs
+       S(k) = F(k)
+       S1(k) = F1(k)            
+      end subroutine diff_1d_wtend
+      
+      subroutine diff_1d_ptend(levs, dt, F, Km, rdp, rdpm, S)
+       use machine,      only: kind_phys
+       implicit none
+       integer :: levs
+      real(kind=kind_phys) :: dt      
+      real(kind=kind_phys) :: S(levs), S1(levs), F(levs), F1(levs) 
+      real(kind=kind_phys) :: Km(levs),  rdp(levs), rdpm(levs-1)
+      integer              :: i, k     
+      real(kind=kind_phys) :: Km1, Kp1, ad, cd, bd 
+!        
+! explicit "eddy" smoother for tendencies
+!           
+
+      k = 1 
+      km1 = 0. ; ad =0.
+      kp1 = .5*(Km(k)+Km(k+1)) 
+      cd = rdp(1)*rdpm(1)*kp1*dt
+      bd = 1. -(cd +ad)
+!      S(k) = cd*F(k+1) + ad *F(k-1) + bd *F(k)
+      S(K) = F(k)
+      do k=2, levs-1
+       ad = cd
+       kp1 = .5*(Km(k)+Km(k+1))    
+       cd = rdp(k)*rdpm(k)*kp1*dt
+       bd = 1.-(ad +cd) 
+       S(k) = cd*F(k+1) + ad *F(k-1) + bd *F(k)
+      enddo 
+       k =levs
+       S(k) = F(k)  
+      end subroutine diff_1d_ptend  
+        
+
+     subroutine ugwp_tofd1d(levs, sigflt, elvmax, zsurf, zpbl,  u, v, zmid, utofd, vtofd, epstofd, krf_tofd)
+       use machine ,          only : kind_phys
+       use ugwp_common      , only :  rcpd2
+       use ugwp_oro_init, only : n_tofd, const_tofd, ze_tofd, a12_tofd, ztop_tofd
+!       
+     implicit none
+      integer ::  levs
+      real(kind_phys), dimension(levs)        ::   u, v, zmid
+      real(kind_phys)                         ::  sigflt, elvmax, zpbl, zsurf
+      real(kind_phys), dimension(levs)        ::  utofd, vtofd, epstofd, krf_tofd     
+!
+! locals
+!
+     integer :: i, k
+     real    :: sghmax = 5.
+     real    :: sgh2, ekin
+     real    :: zdec, rzdec
+     real    :: umag, zmet, zarg, ztexp, krf
+!     
+     utofd =0.0 ; vtofd = 0.0 ;  epstofd =0.0 ; krf_tofd =0.0
+!         
+       zdec = max(n_tofd*sigflt, zpbl)             ! ntimes*sgh_turb or Zpbl
+       zdec = min(ze_tofd, zdec)                ! cannot exceed 18 km
+       rzdec =1./zdec
+       sgh2 = max(sigflt*sigflt, sghmax*sghmax) ! 25 meters dz-of the first layer
+
+      do k=1, levs
+         zmet = zmid(k)-zsurf
+      if (zmet > ztop_tofd) cycle
+         ekin = u(k)*u(k) + v(k)*v(k)
+         umag = sqrt(ekin)
+         zarg = zmet*rzdec
+         ztexp = exp(-zarg*sqrt(zarg))
+         krf         = const_tofd* a12_tofd *sgh2* zmet ** (-1.2) *ztexp
+         utofd(k)  = -krf*u(k)
+         vtofd(k)  = -krf*v(k)
+         epstofd(k)= rcpd2*krf*ekin  ! more accurate heat/mom form using "implicit tend-solver"
+                                     ! to update momentum and temp-re; epstofd(k) can be skipped
+         krf_tofd(k) = krf
+     enddo
+!                
+     end subroutine ugwp_tofd1d
+
+!===================================================  
+!   
+!part-1 init =>   wave dissipation + rfriction
+!
+!===================================================
+     subroutine init_global_gwdis(levs, zkm, pmb, kvg, ktg, krad, kion)
+     implicit none
+
+     integer                              :: levs
+     real, intent(in)                     :: zkm(levs), pmb(levs)
+     real, intent(out), dimension(levs+1) :: kvg, ktg, krad, kion
+!
+!locals + data 
+!  
+     integer :: k
+     real, parameter :: vusurf = 2.e-5
+     real, parameter :: musurf = vusurf/1.95
+     real, parameter :: hpmol  = 8.5
+!      
+     real, parameter :: kzmin  =  0.1
+     real, parameter :: kturbo = 100.
+     real, parameter :: zturbo = 130.
+     real, parameter :: zturw  = 30.
+     real, parameter :: inv_pra = 3.  !kt/kv =inv_pr     
+!     
+     real, parameter :: alpha  = 1./86400./15.
+!     
+     real, parameter :: kdrag  = 1./86400./10.
+     real, parameter :: zdrag  = 100.
+     real, parameter :: zgrow  = 50.
+!
+     real ::    vumol, mumol, keddy, ion_drag
+!     
+     do k=1, levs
+      vumol =vusurf*exp(-zkm(k)/hpmol)
+      mumol =musurf*exp(-zkm(k)/hpmol)
+
+      keddy = kturbo*exp(-((zkm(k)-zturbo) /zturw)**2)
+
+      kvg(k) = vumol +keddy
+      ktg(k) = mumol +keddy*inv_pra
+
+      krad(k) = alpha
+!
+      ion_drag = kdrag
+!       
+      kion(k) = ion_drag
+     enddo
+
+      k= levs+1
+      kion(k) = kion(k-1)
+      krad(k) = krad(k-1)
+      kvg(k) =  kvg(k-1)
+      ktg(k) =  ktg(k-1)
+!                                                          
+     end subroutine init_global_gwdis
+
+     subroutine  rf_damp_init(levs, pa_rf, tau_rf, dtp, pmb, rfdis, rfdist, levs_rf)
+     implicit none
+
+     integer         ::   levs
+     real            ::   pa_rf, tau_rf
+     real            ::   dtp
+
+     real            ::   pmb(levs)
+     real            ::   rfdis(levs),  rfdist(levs)
+     integer         ::   levs_rf
+
+     real    ::            krf, krfz
+     integer ::            k
+!
+     rfdis(1:levs) =  1.0
+     rfdist(1:levs) = 0.0
+     levs_rf = levs
+     if (tau_rf <= 0.0 .or. pa_rf == 0.0) return
+
+      krf = 1.0/(tau_rf*86400.0)
+
+      do k=levs, 1, -1
+        if(pmb(k) < pa_rf ) then                ! applied only on constant pressure surfaces fixed pmb in "Pa"
+         krfz = krf*alog(pa_rf/pmb(k))
+         rfdis(k)  =  1.0/(1.+krfz*dtp)
+     rfdist(k)  =  (rfdis(k) -1.0)/dtp  ! du/dtp  
+         levs_rf = k
+        endif
+      enddo
+        
+     end subroutine  rf_damp_init
+
+      subroutine oro_wam_2017(im, levs,npt,ipt, kref,kdt,me,master, &
+        dtp,dxres, taub, u1, v1, t1, xn, yn, bn2, rho, prsi, prsL, &
+        del, sigma, hprime, gamma, theta, sinlat, xlatd, taup, taud, pkdis) 
+!     
+      USE MACHINE , ONLY          : kind_phys
+      use ugwp_common ,      only : rgrav, grav, cpd, rd, rv, rcpd, rcpd2 
+      use ugwp_common ,      only : rdi   
+      use ugwp_common ,      only : pi, rad_to_deg, deg_to_rad, pi2 
+      use ugwp_common ,      only : omega2, velmin, dw2min    
+!      
+      implicit none    
+      
+      integer :: im, levs
+      integer :: npt
+      integer :: kdt, me, master     
+      integer :: kref(im), ipt(im)
+      real(kind=kind_phys), intent(in) :: dtp, dxres 
+      real(kind=kind_phys), intent(in) :: taub(im)
+      
+      real(kind=kind_phys), intent(in) :: sinlat(im), xlatd(im)
+      real(kind=kind_phys), intent(in), dimension(im) :: sigma, hprime, gamma, theta
+     
+      real(kind=kind_phys), intent(in), dimension(im) :: xn, yn
+      
+      real(kind=kind_phys), intent(in), dimension(im, levs) :: u1, v1, t1,  bn2,  rho,   prsl, del
+     
+      real(kind=kind_phys), intent(in), dimension(im, levs+1) :: prsi
+!
+! out : taup,  taud, pkdis
+!
+      real(kind=kind_phys), intent(inout), dimension(im, levs+1) :: taup
+      real(kind=kind_phys), intent(inout), dimension(im, levs)  :: taud
+      real(kind=kind_phys), intent(inout), dimension(im, levs)  :: pkdis
+      real(kind=kind_phys)     :: belps, aelps, nhills, selps
+!
+! multiwave oro-spectra
+! locals
+!
+      integer :: i, j, k, isp, iw
+      
+      integer, parameter               :: nworo = 30     
+      real(kind=kind_phys), parameter  :: fc_flag = 0.
+      real(kind=kind_phys), parameter  :: mkzmin = 6.28e-3/50.
+      real(kind=kind_phys), parameter  :: mkz2min = mkzmin* mkzmin    
+      real(kind=kind_phys), parameter  :: kedmin = 1.e-3 
+      real(kind=kind_phys), parameter  :: kedmax = 350.,axmax=250.e-5
+      real(kind=kind_phys), parameter  :: rtau   = 0.01   ! nonlin-OGW scale 1/10sec  
+      real(kind=kind_phys), parameter  :: Linsat2 =0.5 
+      real(kind=kind_phys), parameter  :: kxmin = 6.28e-3/100.
+      real(kind=kind_phys), parameter  :: kxmax = 6.28e-3/5.0
+      real(kind=kind_phys), parameter  :: dkx = (kxmax -kxmin)/(nworo-1)
+      real(kind=kind_phys), parameter  :: kx_slope= -5./3. 
+      real(kind=kind_phys), parameter  :: hps =7000., rhp2 = .5/hps  
+      real(kind=kind_phys), parameter  :: cxmin=0.5, cxmin2=cxmin*cxmin
+                          
+      real  :: akx(nworo),  cxoro(nworo), akx2(nworo)
+      real  :: aspkx(nworo), c2f2(nworo) , cdf2(nworo)        
+      real  :: tau_sp(nworo,levs+1), wkdis(nworo, levs+1)
+      real  :: tau_kx(nworo),taub_kx(nworo)      
+      real, dimension(nworo, levs+1)  :: wrms, akzw  
+          
+      real  :: tauz(levs+1), rms_wind(levs+1)    
+      real  :: wave_act(nworo,levs+1) 
+      
+      real  :: kxw, kzw, kzw2, kzw3, kzi, dzmet, rhoint 
+      real  ::  rayf, kturb                
+      real  ::  uz, bv, bv2,kxsp, fcor2, cf2 
+      
+      real  ::  fdis       
+      real  ::  wfdm, wfdt, wfim, wfit   
+      real  ::  betadis, betam, betat, kds, cx, rhofac  
+      real  ::  etwk, etws, tauk, cx2sat
+      real  ::  cdf1, tau_norm     
+!
+! mean flow
+!      
+      real, dimension(levs+1) :: uzi,rhoi,ktur, kalp, dzi
+      
+      integer :: nw, nzi, ksrc
+      taud (:, :) = 0.0 ; pkdis(:,:) = 0.0 ; taup (:,:) = 0.0
+      tau_sp (:,:) = 0.0 ; wrms(:,:) = 0.0
+      nw  =  nworo 
+      nzi = levs+1  
+       
+      do iw = 1, nw
+!                                 !kxw =  0.25/(dxres)*iw
+     kxw = kxmin+(iw-1)*dkx 
+     akx(iw)  = kxw
+     akx2(iw) = kxw*kxw
+     aspkx(iw) = kxw ** (kx_slope)
+     tau_kx(iw) = aspkx(iw)*dkx  
+      enddo
+      
+         tau_norm = sum(tau_kx) 
+     tau_kx(:) =  tau_kx(:)/tau_norm 
+      
+    if (kdt == 1) then
+771     format( 'vay-oro19 ', 3(2x,F8.3))   
+        write(6,771)    maxval(tau_kx)*maxval(taub)*1.e3,   minval(tau_kx), maxval(tau_kx)
+        endif         
+!
+! main loop over oro-points
+!
+      do i =1, npt      
+         j = ipt(i)
+    
+!
+! estimate "nhills" => stochastic choices for OGWs
+!   
+    if (taub(i) > 0.) then
+!       
+! max_kxridge =min( .5*sigma(j)/hprime(j), kmax)
+! ridge-dependent dkx = (max_kxridge -kxmin)/(nw-1)
+! option to make grid-box variable kx-spectra kxw = kxmin+(iw-1)*dkx
+!
+      wave_act(1:nw, 1:levs+1) = 1.0    
+      ksrc = kref(i)    
+      tauz(1:ksrc) = taub(i)    
+      taub_kx(1:nw) =tau_kx(1:nw) * taub(i)
+          wkdis(:,:) = kedmin   
+     
+    call oro_meanflow(levs, nzi, u1(j,:), v1(j,:), t1(j,:), prsi(j,:), &
+       prsL(j,:),del(j,:),rho(i,:),bn2(i,:), uzi, rhoi,ktur, kalp,dzi,&
+       xn(i), yn(i))    
+     
+      fcor2 = (omega2*sinlat(j))*(omega2*sinlat(j))*fc_flag
+
+      k = ksrc
+      
+      bv2 =bn2(i,k)
+      uz = uzi(k)           !u1(j,ksrc)*xn(i)+v1(j,ksrc)*yn(i)!
+          kturb =ktur(k) 
+      rayf  =kalp(k)
+      rhoint = rhoi(k)
+      dzmet = dzi(k)
+          kzw =max(sqrt(bv2)/max(cxmin, uz), mkzmin) 
+!             
+! specify oro-kx spectra and related variables k=ksrc
+!     
+      do iw = 1, nw
+        kxw =  akx(iw)      
+        cxoro(iw) = 0.0 - uz 
+        c2f2(iw) = fcor2/akx2(iw)       
+            wrms(iw,k)= taub_kx(iw)/rhoint*kzw/kxw    
+        tau_sp(iw, k) = taub_kx(iw)    
+!           
+!               
+           if ( cxoro(iw) .gt. cxmin) then
+            wave_act(iw,k:levs+1) = 0.                 ! crit-level     
+        else
+        cdf2(iw) =  cxoro(iw)*cxoro(iw) -c2f2(iw) 
+         if ( cdf2(iw) .lt. cxmin2)  then 
+              wave_act(iw,k:levs+1) = 0.               ! coriolis cut-off        
+          else     
+          kzw2 = max(Bv2/Cdf2(iw) - akx2(iw), mkz2min)
+          kzw = sqrt(kzw2)
+          akzw(iw,k)= kzw
+          wrms(iw,k)= taub_kx(iw)/rhoint * kzw/kxw
+         endif
+        endif 
+       enddo             !  nw-spectral loop 
+!
+! defined abobe, k = ksrc: akx(nworo),  cxoro(nworo), tau_sp(ksrc, nworo)
+! propagate upward multiwave-spectra are filtered by dissipation & instability
+!
+!          tau_sp(:,ksrc+1:levs+1) = tau_sp(:, ksrc)                  
+      do k= ksrc+1, levs
+          uz = uzi(k)
+          bv2 =bn2(i,k)
+          bv = sqrt(bv2)
+             rayf = kalp(k)
+             rhoint= rhoi(k) 
+             dzmet = dzi(k)
+         rhofac = rhoi(k-1)/rhoi(k)       
+         
+       do iw = 1, nworo
+!       
+        if (wave_act(iw, k-1) .le. 0.) cycle
+           cxoro(iw)= 0.-uz
+             if ( cxoro(iw) .gt. cxmin) then
+               wave_act(iw,k:levs+1) = 0.     ! crit-level
+          else                  
+             cdf2(iw) =  cxoro(iw)*cxoro(iw) -c2f2(iw)
+         if ( cdf2(iw) .lt. cxmin2)  wave_act(iw,k:levs+1) = 0.
+             endif       
+             if ( wave_act(iw,k) .le. 0.) cycle 
+!          
+! upward propagation
+!          
+             kzw2 = Bv2/Cdf2(iw) - akx2(iw) 
+               
+             if (kzw2 .lt. mkz2min) then 
+                 wave_act(iw,k:levs+1) =0.
+             else  
+!          
+! upward propagation w/o reflection
+!                    
+           kxw = akx(iw)         
+               kzw =sqrt(kzw2)
+           akzw(iw,k)= kzw
+               kzw3 =kzw2*kzw
+         
+         cx = cxoro(iw)
+         betadis = cdf2(iw)/(Cx*Cx+c2f2(iw)) 
+         betaM =1./(1.+betadis)
+         betaT =1.- BetaM        
+         kds  = wkdis(iw,k-1)
+            
+         etws =  wrms(iw,k-1)*rhofac * kzw/akzw(iw,k-1)
+
+         kturb = ktur(k)+pkdis(j,k-1)
+         wfiM = kturb*kzw2 +rayf
+             wfiT = wfiM                   ! do updates with Pr-numbers Kv/Kt
+         cdf1 = sqrt(Cdf2(iw))
+         wfdM = wfiM/(kxw*Cdf1)*BetaM
+             wfdT = wfiT/(kxw*Cdf1)*BetaT
+         kzi = 2.*kzw*(wfdM+wfdT)*dzmet
+         Fdis  = exp(-kzi)  
+         
+         etwk = etws*Fdis   
+         Cx2sat = Linsat2*Cdf2(iw)
+                          
+       if (etwk .gt. cx2sat) then       
+        Kds =  kxw*Cdf1*rhp2/kzw3
+        etwk =cx2sat
+        wfiM = kds*kzw2
+        wfdM = wfiM/(kxw*Cdf1)
+        kzi = 2.*kzw*(wfdm + wfdm)*dzmet
+        etwk = cx2sat*exp(-kzi)     
+       endif 
+!                                if( lat(j) eq 40.5 ) then stop
+        wkdis(iw,k) = kds
+        wrms(iw,k) =  etwk 
+            tauk = etwk*kxw/kzw 
+        tau_sp(iw,k) = tauk *rhoint 
+    if ( tau_sp(iw,k)>tau_sp(iw,k-1)) tau_sp(iw,k)=tau_sp(iw,k-1)  
+    
+        ENDIF    ! upward 
+        ENDDO    ! spectral
+    
+!......... do spectral sum of rms, wkdis, tau    
+
+        tauz(k)    = sum( tau_sp(:,k)*wave_act(:,k) )   
+    rms_wind(k)= sum(   wrms(:,k)*wave_act(:,k) )
+    
+    pkdis(j,k)=sum(wkdis(:,k)*wave_act(:,k))+rms_wind(k)*rtau
+            
+    if (pkdis(j,k) .gt. kedmax) pkdis(j,k)= kedmax
+    
+        ENDDO   ! k=ksrc+1, levs
+    
+        k = ksrc
+        tauz(k)      = sum(tau_sp(:,k)*wave_act(:,k))
+    tauz(k)      = tauz(k+1)   ! zero momentum dep-n at k=ksrc 
+    
+    pkdis(j,k) =  sum(wkdis(:,k)*wave_act(:,k)) 
+    rms_wind(k)  = sum(wrms(:,k)*wave_act(:,k)) 
+          tauz(levs+1) = tauz(levs)
+      taup(i, 1:levs+1) = tauz(1:levs+1)     
+        do  k=ksrc, levs  
+         taud(i,k) = ( tauz(k+1) - tauz(k))*grav/del(j,k)  
+!    if (taud(i,k) .gt. 0)taud(i,k)=taud(i,k)*.01
+!    if (abs(taud(i,k)).ge.axmax)taud(i,k)=sign(taud(i,k),axmax)    
+    enddo       
+      endif                    ! taub > 0
+      enddo                    ! oro-points (i, j, ipt)
+!23456      
+      end subroutine oro_wam_2017
+
+!-------------------------------------------------------------
+!
+! define mean flow  and dissipation for OGW-kx spectrum
+!
+!-------------------------------------------------------------      
+      subroutine oro_meanflow(nz, nzi, u1, v1, t1, pint, pmid, &
+       delp, rho, bn2, uzi, rhoi, ktur, kalp, dzi, xn, yn)
+        
+      use ugwp_common ,  only : grav, rgrav, rdi,  velmin, dw2min   
+      implicit none
+      
+      integer :: nz, nzi
+      real, dimension(nz  ) ::  u1,  v1, t1, delp, rho, pmid
+      real, dimension(nz  ) ::  bn2  ! define at the interfaces
+      real, dimension(nz+1) ::  pint
+      real                  ::  xn, yn      
+! output     
+ 
+      real, dimension(nz+1) ::  dzi,  uzi, rhoi, ktur, kalp  
+      
+! locals      
+      integer :: i, j, k
+      real :: ui, vi, ti, uz, vz, shr2, rdz, kamp
+      real :: zgrow, zmet, rdpm, ritur, kmol, w1
+! paremeters
+      real, parameter :: hps = 7000., rpspa = 1.e-5
+      real, parameter :: rhps=1./hps
+      real, parameter :: h4= 0.25/hps
+      real, parameter :: rimin = 1./8., kedmin = 0.01
+      real, parameter :: lturb = 30. ,  uturb = 150.    
+      real, parameter :: lsc2 = lturb*lturb,usc2 = uturb*uturb         
+      kalp(1:nzi) = 2.e-7        ! radiative damping
+      
+      do k=2, nz
+        rdpm = grav/(pmid(k-1)-pmid(k)) 
+        ui = .5*(u1(k-1)+u1(k))
+        vi = .5*(v1(k-1)+v1(k))
+    uzi(k) = Ui*xn + Vi*yn
+        ti = .5*(t1(k-1)+t1(k))
+    rhoi(k) = rdi*pint(k)/ti
+    rdz = rdpm *rhoi(k)
+    dzi(k) = 1./rdz
+    uz = u1(k)-u1(k-1)
+    vz = v1(k)-v1(k-1)
+    shr2 = rdz*rdz*(max(uz*uz+vz*vz, dw2min))
+    zmet = -hps*alog(pint(k)*rpspa)
+    zgrow = exp(zmet*h4)    
+    kmol =  2.e-5*exp(zmet*rhps)+kedmin
+    ritur = max(bn2(k)/shr2, rimin)
+        kamp = sqrt(shr2)*lsc2 *zgrow
+     w1 = 1./(1. + 5*ritur)
+     ktur(k)= kamp * w1 * w1 +kmol
+      enddo 
+       
+      k=1 
+      uzi(k) = uzi(k+1)
+      ktur(k) = ktur(k+1)
+      rhoi(k) = rdi*pint(k)/t1(k+1)
+      dzi(k) = rgrav*delp(k)/rhoi(k)
+      
+      k = nzi
+      uzi(k) = uzi(k-1)
+      ktur(k) = ktur(k-1)
+      rhoi(k) = rhoi(k-1)*.5
+      dzi(k) =  dzi(k-1)   
+         
+      end subroutine oro_meanflow  
+
+subroutine cires_ugwp_advance
+!-----------------------------------------------------------------------
+!
+!   options for the day-to-day variable sources/spectra + diagnostics
+!           for stochastic "triggers"
+!   diagnose GW-source functions * FGF + OKWP + SGO/CONV from IAU-fields
+!     or use for stochastic GWP-sources "memory"
+!-----------------------------------------------------------------------
+      implicit none
+!
+! update sources
+!  a) physics-based triggers for multi-wave
+!  b) stochastic-based spectra and amplitudes
+!  c) use "memory" on GW-spectra from previous time-step
+!  d) update "background" GW  dissipation as needed 
+!      
+end subroutine cires_ugwp_advance   
+ 
+!      
+! -----------------------------------------------------------------------
+! finalize  of cires_ugwp   (_finalize) 
+! -----------------------------------------------------------------------
+subroutine cires_ugwp_mod_finalize
+!
+! deallocate sources/spectra & some diagnostics need to find where "deaalocate them"
+! before "end" of the FV3GFS
+!
+    implicit none
+!    
+!   deallocate arrays employed in:
+!     cires_ugwp_advance / cires_ugwp_driver / cires_ugwp_init
+!
+    deallocate( kvg,   ktg  ) 
+    deallocate( krad,  kion )        
+    deallocate( zkm,   pmb  )  
+    deallocate( rfdis,   rfdist)   
+            
+end subroutine cires_ugwp_mod_finalize    
+!
+
+
+
+end module cires_ugwp_module
+

--- a/physics/module_ugwp_common.F90
+++ b/physics/module_ugwp_common.F90
@@ -1,0 +1,26 @@
+    module ugwp_common
+!
+     implicit none
+     
+      real, parameter ::  grav =9.80665, cpd = 1004.6, grcp = grav/cpd 
+      real, parameter ::  rd = 287.05 , rv =461.5      
+      real, parameter ::  rgrav = 1.0/grav
+           
+      real, parameter ::  fv   = rv/rd - 1.0  
+      real, parameter ::  rdi  = 1.0 / rd
+      real, parameter ::  gor  = grav/rd
+      real, parameter ::  gr2  = grav*gor
+      real, parameter ::  gocp = grav/cpd
+      real, parameter ::  pi = 4.*atan(1.0), pi2 = 2.*pi
+!   
+      real, parameter ::  rad_to_deg=180.0/pi, deg_to_rad=pi/180.0
+
+      real, parameter ::  arad = 6370.e3
+      real, parameter ::  rcpd2 = 0.5/cpd,  rcpd = 1./cpd                  
+      real, parameter ::  dw2min=1.0
+      real, parameter ::  bnv2min=1.e-6
+      real, parameter ::  velmin=sqrt(dw2min)     
+      real, parameter ::  omega1 = pi2/86400.
+      real, parameter ::  omega2 = 2.*omega1   
+     end module ugwp_common
+!

--- a/physics/module_ugwp_conv_init.F90
+++ b/physics/module_ugwp_conv_init.F90
@@ -1,0 +1,103 @@
+! ========================================================================= 
+!
+!    ugwp_conv_init
+!    
+!=========================================================================     
+    module ugwp_conv_init      
+
+     implicit none
+      real    ::  eff_con                   ! scale factors for conv GWs
+      integer ::  nwcon                     ! number of waves      
+      integer ::  nazcon                    ! number of azimuths
+      integer ::  nstcon                    ! flag for stochastic choice of launch level above Conv-cloud    
+      real    ::  con_dlength 
+      real    ::  con_cldf
+      
+      real, parameter    :: cmin =  5  !2.5
+      real, parameter    :: cmax = 95. !82.5
+      real, parameter    :: cmid = 22.5  
+      real, parameter    :: cwid = cmid  
+      real, parameter    :: bns = 2.e-2, bns2 = bns*bns, bns4=bns2*bns2
+      real, parameter    :: mstar = 6.28e-3/2.  !  2km        
+      real               :: dc
+      
+      real, allocatable  :: ch_conv(:), spf_conv(:)    
+      real, allocatable  :: xaz_conv(:),   yaz_conv(:)                         
+     contains 
+!     
+     subroutine init_conv_gws(nwaves, nazdir, nstoch, effac, &
+                              lonr, kxw, cgwf )
+     use ugwp_common,  only : pi2, arad     
+     implicit none
+     
+      integer :: nwaves, nazdir, nstoch
+      integer :: lonr
+      real    :: cgwf(2)    
+      real    :: kxw,  effac 
+      real    :: work1 = 0.5
+      real    :: chk, tn4, snorm      
+      integer :: k   
+         
+      nwcon  =  nwaves
+      nazcon =  nazdir
+      nstcon =  nstoch      
+      eff_con  =  effac
+      
+      con_dlength = pi2*arad/float(lonr)
+      con_cldf   = cgwf(1)    * work1 + cgwf(2) *(1.-work1)     
+!
+! allocate & define spectra in "selected direction": "dc" "ch(nwaves)"
+!
+       if (.not. allocated(ch_conv))  allocate (ch_conv(nwaves))
+       if (.not. allocated(spf_conv)) allocate (spf_conv(nwaves)) 
+       if (.not. allocated(xaz_conv)) allocate (xaz_conv(nazdir))
+       if (.not. allocated(yaz_conv)) allocate (yaz_conv(nazdir)) 
+          
+      dc = (cmax-cmin)/float(nwaves-1)
+!
+! we may use different spectral "shapes"
+! for example FVS-93 "Desabeius"
+!  E(s=1, t=3,m, w, k) ~ m^s/(m*^4 + m^4) ~ m^-3 saturated tail
+!  
+      do k = 1,nwaves
+         chk         = cmin + (k-1)*dc
+	 tn4 = (mstar*chk)**4
+         ch_conv(k)  =  chk
+         spf_conv(k) =  bns4*chk/(bns4+tn4)	 
+      enddo
+         
+	 snorm = sum(spf_conv)
+	 spf_conv = spf_conv/snorm*1.5
+	 
+      call init_nazdir(nazdir,  xaz_conv,  yaz_conv)
+     end subroutine init_conv_gws  
+
+      subroutine init_nazdir(naz,  xaz,  yaz)
+      use ugwp_common , only : pi2
+      implicit none
+      integer :: naz
+      real, dimension(naz) :: xaz,  yaz
+      integer :: idir
+      real    :: phic, drad
+      drad  = pi2/float(naz)
+      if (naz.ne.4) then
+        do idir =1, naz
+         Phic = drad*(float(idir)-1.0)
+         xaz(idir) = cos(Phic)
+         yaz(idir) = sin(Phic)
+        enddo
+      else
+!                         if (naz.eq.4) then
+          xaz(1) = 1.0     !E
+          yaz(1) = 0.0
+          xaz(2) = 0.0
+          yaz(2) = 1.0     !N
+          xaz(3) =-1.0     !W
+          yaz(3) = 0.0
+          xaz(4) = 0.0
+          yaz(4) =-1.0     !S
+      endif
+      end  subroutine init_nazdir     
+        
+    end module ugwp_conv_init 
+!=========================================================================

--- a/physics/module_ugwp_fjet_init.F90
+++ b/physics/module_ugwp_fjet_init.F90
@@ -1,0 +1,58 @@
+!=========================================================================
+!
+!    ugwp_fjet_init
+!    
+!=========================================================================  
+     
+   module ugwp_fjet_init 
+      implicit none
+      real    ::  eff_fj                      ! scale factors for conv GWs
+      integer ::  nwfj                       ! number of waves      
+      integer ::  nazfj                      ! number of azimuths
+      integer ::  nstfj                      ! flag for stochastic choice of launch level above Conv-cloud  
+!        
+      real, parameter    ::  fjet_trig=0.       ! if ( abs(frgf) > fjet_trig ) launch GW-packet
+      
+      
+      real, parameter    :: cmin =  2.5
+      real, parameter    :: cmax = 67.5  
+      real               :: dc
+      real, allocatable  :: ch_fjet(:) , spf_fjet(:) 
+      real, allocatable  :: xaz_fjet(:), yaz_fjet(:)
+     contains    
+     subroutine init_fjet_gws(nwaves, nazdir, nstoch, effac, &
+                              lonr, kxw )
+     use ugwp_common,  only : pi2, arad
+     use ugwp_conv_init, only: init_nazdir
+
+     implicit none
+     
+      integer :: nwaves, nazdir, nstoch
+      integer :: lonr 
+      real    :: kxw,  effac , chk
+      
+      integer :: k
+              
+      nwfj  =  nwaves
+      nazfj =  nazdir
+      nstfj =  nstoch      
+      eff_fj  =  effac
+      
+       if (.not. allocated(ch_fjet))  allocate (ch_fjet(nwaves))
+       if (.not. allocated(spf_fjet)) allocate (spf_fjet(nwaves))
+       if (.not. allocated(xaz_fjet)) allocate (xaz_fjet(nazdir))
+       if (.not. allocated(yaz_fjet)) allocate (yaz_fjet(nazdir)) 
+           
+      dc = (cmax-cmin)/float(nwaves-1)
+      do k = 1,nwaves
+         
+         chk        = cmin + (k-1)*dc
+         ch_fjet(k) =  chk
+         spf_fjet(k) =  1.0	 
+      enddo	
+      call init_nazdir(nazdir,  xaz_fjet,  yaz_fjet)
+           
+     end subroutine init_fjet_gws
+
+    end module ugwp_fjet_init      
+!

--- a/physics/module_ugwp_lsatdis_init.F90
+++ b/physics/module_ugwp_lsatdis_init.F90
@@ -1,0 +1,52 @@
+!===============================
+!  Part -3  init  wave solvers
+!===============================
+
+  module ugwp_lsatdis_init 
+     implicit none
+     
+      integer  :: nwav, nazd
+      integer  :: nst
+      real     :: eff 
+      integer, parameter  :: incdim = 4
+      integer, parameter  :: iazdim = 4            
+!    
+     contains
+           
+     subroutine initsolv_lsatdis(me, master,  nwaves, nazdir, nstoch, effac, do_physb, kxw) 
+       
+     implicit none
+! 
+     integer  :: me, master
+     integer  :: nwaves, nazdir
+     integer  :: nstoch
+     real     :: effac  
+     logical  :: do_physb
+     real     :: kxw     
+!     
+!locals: define azimuths and Ch(nwaves) - domain when physics-based soureces
+!                                          are not actibve
+!
+     integer :: inc, jk, jl, iazi, i, j, k    
+            
+     if( nwaves == 0 .or. nstoch == 1 ) then
+!                                redefine from the default       
+       nwav = incdim
+       nazd = iazdim
+       nst  = 0
+       eff  = 1.0
+     else
+!                                from input_nml multi-wave spectra   
+       nwav = nwaves
+       nazd = nazdir
+       nst  = nstoch
+       eff  = effac  
+     endif        
+!
+!       
+       
+       
+     end subroutine initsolv_lsatdis
+!     
+  end module ugwp_lsatdis_init     
+!

--- a/physics/module_ugwp_okw_init.F90
+++ b/physics/module_ugwp_okw_init.F90
@@ -1,0 +1,57 @@
+      module ugwp_okw_init 
+!=========================================================================    
+      implicit none
+     
+      real    ::  eff_okw                     ! scale factors for conv GWs
+      integer ::  nwokw                       ! number of waves      
+      integer ::  nazokw                      ! number of azimuths
+      integer ::  nstokw                      ! flag for stochastic choice of launch level above Conv-cloud  
+!        
+      real, parameter    ::  okw_trig=0.       ! if ( abs(okwp) > okw_trig ) launch GW-packet
+      
+      
+      real, parameter    :: cmin =  2.5
+      real, parameter    :: cmax = 67.5  
+      real               :: dc
+      real, allocatable  :: ch_okwp(:),   spf_okwp(:) 
+      real, allocatable  :: xaz_okwp(:),   yaz_okwp(:)
+
+     contains
+!              
+      subroutine init_okw_gws(nwaves, nazdir, nstoch, effac, &
+                              lonr, kxw )
+			      
+     use ugwp_common,  only : pi2, arad
+     use ugwp_conv_init, only: init_nazdir
+ 
+      implicit none
+     
+      integer :: nwaves, nazdir, nstoch
+      integer :: lonr 
+      real    :: kxw,  effac , chk
+      
+      integer :: k
+              
+      nwokw  =  nwaves
+      nazokw =  nazdir
+      nstokw =  nstoch      
+      eff_okw  =  effac
+      
+       if (.not. allocated(ch_okwp))    allocate (ch_okwp(nwaves))
+       if (.not. allocated(spf_okwp))   allocate (spf_okwp(nwaves))
+       if (.not. allocated(xaz_okwp)) allocate (xaz_okwp(nazdir))
+       if (.not. allocated(yaz_okwp)) allocate (yaz_okwp(nazdir))      
+      dc = (cmax-cmin)/float(nwaves-1)
+      do k = 1,nwaves
+         chk =  cmin + (k-1)*dc
+         ch_okwp(k) = chk
+	 spf_okwp(k) = 1. 
+      enddo
+      
+      call init_nazdir(nazdir,  xaz_okwp,  yaz_okwp)           
+         
+      end subroutine init_okw_gws
+          
+      end module ugwp_okw_init     
+          
+!=============================== end of GW  sources    

--- a/physics/module_ugwp_oro_init.F90
+++ b/physics/module_ugwp_oro_init.F90
@@ -1,0 +1,127 @@
+! ========================================================================= 
+!
+!    ugwp_oro_init
+!    
+!=========================================================================     
+     module ugwp_oro_init 
+      
+     use ugwp_common, only : bnv2min, grav, grcp, fv, grav, cpd, grcp, pi  
+          
+     implicit none
+!  
+! constants and "crirtical" values to run oro-mtb_gw physics 
+!
+! choice of oro-scheme: strver = 'vay_2018' , 'gfs_2018', 'kdn_2005', 'smc_2000'
+!
+      character(len=8)  ::  strver  = 'gfs_2018' 
+      character(len=8)  ::  strbase = 'gfs_2018'          
+      real, parameter   ::  rimin=-10., ric=0.25
+
+!
+      real, parameter :: efmin=0.5,    efmax=10.0      
+      real, parameter :: hpmax=2400.0, hpmin=25.0
+      real, parameter :: sigma_std=1./100., gamm_std=1.0
+      
+      real, parameter :: frmax=10., frc =1.0, frmin =0.01
+!
+
+       real, parameter :: ce=0.8, ceofrc=ce/frc, cg=0.5
+       real, parameter :: gmax=1.0, veleps=1.0, factop=0.5
+! 
+       real, parameter :: rlolev=50000.0 
+!    
+       real,      parameter :: hncrit=9000.   ! max value in meters for elvmax
+       
+!  hncrit set to 8000m and sigfac added to enhance elvmax mtn hgt
+
+       real,      parameter :: sigfac=4.0     ! mb3a expt test for elvmax factor
+       real,      parameter :: hminmt=50.     ! min mtn height (*j*)
+       real,      parameter :: minwnd=1.0     ! min wind component (*j*)
+       real,      parameter :: dpmin=5000.0   ! minimum thickness of the reference layer in pa
+       
+       real,      parameter ::   kxoro=6.28e-3/200.    !                               
+       real,      parameter ::   coro = 0.0
+       integer,   parameter ::   nridge=2    
+          
+      real    ::  cdmb                      ! scale factors for mtb
+      real    ::  cleff                     ! scale factors for orogw
+      integer ::  nworo                     ! number of waves      
+      integer ::  nazoro                    ! number of azimuths
+      integer ::  nstoro                    ! flag for stochastic launch above SG-peak                 
+
+      integer, parameter ::  mdir = 8
+      real,    parameter ::  fdir=.5*mdir/pi
+
+      integer nwdir(mdir)
+      data nwdir/6,7,5,8,2,3,1,4/
+      save nwdir
+           
+     real,    parameter   ::   odmin  =0.1, odmax =10.0      
+!------------------------------------------------------------------------------     
+!    small-scale orography parameters  for TOFD of Beljaars et al., 2004, QJRMS
+!------------------------------------------------------------------------------
+
+     integer, parameter  ::   n_tofd=2                  ! depth of SSO for TOFD compared with Zpbl
+     real, parameter     ::  const_tofd =  0.0759       ! alpha*beta*Cmd*Ccorr*2.109 = 12.*1.*0.005*0.6*2.109 = 0.0759
+     real, parameter     ::     ze_tofd =1500.0         ! BJ's z-decay in meters
+     real, parameter     ::  a12_tofd =0.0002662*0.005363   ! BJ's k-spect const for sigf2 * a1*a2*exp(-[z/zdec]**1.5]
+     real, parameter     ::      ztop_tofd =10.*ze_tofd     ! no TOFD > this height too higher 15 km
+!------------------------------------------------------------------------------
+!     
+      real, parameter :: fcrit_sm  = 0.7, fcrit_sm2  = fcrit_sm * fcrit_sm 
+      real, parameter :: fcrit_gfs = 0.7  
+      real, parameter :: fcrit_mtb = 0.7            
+
+      real,  parameter :: lzmax  = 18.e3                      ! 18 km
+      real,  parameter :: mkzmin = 6.28/lzmax
+      real,  parameter :: mkz2min = mkzmin*mkzmin
+      real,  parameter :: zbr_pi  = 3./2.*4.*atan(1.0)        ! 3pi/2
+      real,  parameter :: zbr_ifs = 2.*atan(1.0)              ! pi/2
+      
+      contains
+!
+      subroutine init_oro_gws(nwaves, nazdir, nstoch, effac, &
+                              lonr, kxw, cdmbgwd )
+!     
+!
+      integer :: nwaves, nazdir, nstoch
+      integer :: lonr
+      real    :: cdmbgwd(2)   ! scaling factors for MTb (1) & (2) for cleff = cleff  * cdmbgwd(2)
+                              ! high res-n "larger" MTB and "less-active" cleff in GFS-2018   
+      real    :: cdmbX
+      real    :: kxw
+      real    :: effac        ! it is analog of cdmbgwd(2) for GWs, off for now
+!-----------------------------! GFS-setup for cdmb & cleff
+! cdmb =  4.0 * (192.0/IMX)  
+! cleff = 0.5E-5 / SQRT(IMX/192.0)  = 0.5E-5*SQRT(192./IMX)
+!    
+      real, parameter :: lonr_refmb =  4.0 * 192.0
+      real, parameter :: lonr_refgw =  192.0  
+      
+! copy  to "ugwp_oro_init"  =>  nwaves, nazdir, nstoch      
+      
+      nworo  =  nwaves
+      nazoro =  nazdir
+      nstoro =  nstoch
+      
+      cdmbX = lonr_refmb/float(lonr)
+      cdmb  = cdmbX     
+      if (cdmbgwd(1) >= 0.0) cdmb = cdmb * cdmbgwd(1)
+      
+       cleff = 0.5e-5 * sqrt(lonr_refgw/float(lonr))  !* effac 
+             
+!!!    cleff = kxw    * sqrt(lonr_refgw/float(lonr))  !* effac   
+    
+      if (cdmbgwd(2) >= 0.0) cleff = cleff  * cdmbgwd(2)	     
+! 
+!....................................................................
+! higher res => smaller h' ..&.. higher kx
+! flux_gwd ~ 'u'^2*kx/kz ~kxu/n ~1/dx *u/n    tau ~ h'*h'*kx*kx = const (h'-less kx-grow)
+!....................................................................
+! 
+!      print *, ' init_oro_gws 2-1cdmb',  cdmbgwd(2), cdmbgwd(1)
+      end subroutine init_oro_gws
+!
+    
+    end module ugwp_oro_init
+! ========================================================================= 

--- a/physics/module_ugwp_wmsdis_init.F90
+++ b/physics/module_ugwp_wmsdis_init.F90
@@ -1,0 +1,185 @@
+  module ugwp_wmsdis_init 
+ 
+    implicit none
+    
+      real,      parameter  :: maxdudt = 250.e-5	    
+            
+      real,      parameter  :: hpscale= 7000., rhp2   =  0.5/hpscale     
+      real,      parameter  :: omega2 = 2.*6.28/86400
+      real,      parameter  :: gptwo=2.0       
+        
+      real ,    parameter   :: dked_min =0.01
+      real ,    parameter   :: gssec = (6.28/30.)**2        ! max-value for bn2
+      real ,    parameter   :: bv2min = (6.28/60./120.)**2  ! min-value for bn2  7.6(-7)  2 hrs
+      real, parameter       :: minvel = 0.5     
+      
+! 
+! make parameter list that will be passed to SOLVER
+!
+!      
+        
+      real, parameter       :: v_kxw  = 6.28e-3/200.
+      real, parameter       :: v_kxw2 = v_kxw*v_kxw
+      real, parameter       :: tamp_mpa = 30.e-3
+      real, parameter       :: zfluxglob= 3.75e-3
+               
+      real ,     parameter  :: nslope=1                ! the GW sprctral slope at small-m     
+      integer, parameter    :: klaunch=55       ! 32 - ~ 1km ;55 - 5.5 km ; 52 4.7km ; 60-7km index for selecting launch level 
+      integer, parameter    :: ilaunch=klaunch                  
+      
+      integer  , parameter  :: iazidim=4       ! number of azimuths
+      integer  , parameter  :: incdim=25       !number of discrete cx - spectral elements in launch spectrum
+      real ,     parameter  :: ucrit2  =0.5   
+      
+      real ,     parameter  :: zcimin = ucrit2  
+      real ,     parameter  :: zcimax = 125.0
+      real ,     parameter  :: zgam =   0.25              
+      real ,     parameter  :: zms_l  = 2000.0        
+        
+      real                  :: gw_eff
+      
+!===========================================================================
+      integer  :: nwav, nazd, nst
+      real     :: eff  
+      
+      real                :: zaz_fct , zms 
+      real, allocatable   :: zci(:),  zci4(:), zci3(:),zci2(:), zdci(:) 
+      real, allocatable   :: zcosang(:), zsinang(:)      
+      contains
+!============================================================================
+     subroutine initsolv_wmsdis(me, master,  nwaves, nazdir, nstoch, effac, do_physb, kxw)
+     
+!        call initsolv_wmsdis(me, master, knob_ugwp_wvspec(2), knob_ugwp_azdir(2), &
+!         knob_ugwp_stoch(2), knob_ugwp_effac(2), do_physb_gwsrcs, kxw)
+!
+     use ugwp_common, only :   pi, pi2  
+     implicit none
+!     
+!input -control for solvers:
+!      nwaves, nazdir, nstoch, effac, do_physb, kxw
+!     
+!
+     integer  :: me, master
+     integer  :: nwaves, nazdir
+     integer  :: nstoch
+     real     :: effac  
+     logical  :: do_physb
+     real     :: kxw
+!     
+!locals     
+!
+      integer   :: inc, jk, jl, iazi  
+!        
+
+
+      real :: zang, zang1, znorm
+      real :: zx1, zx2, ztx, zdx, zxran, zxmin, zxmax, zx
+      real :: zpexp     
+       
+     if( nwaves == 0) then
+!
+!     redefine from the deafault
+!       
+       nwav = incdim
+       nazd = iazidim
+       nst  = 0
+       eff  = 1.0
+       gw_eff = eff
+     else
+!
+! from input.nml
+!     
+       nwav = nwaves
+       nazd = nazdir
+       nst  = nstoch
+       gw_eff  = effac  
+     endif 
+     
+      allocate ( zci(nwav),  zci4(nwav), zci3(nwav),zci2(nwav), zdci(nwav)  )   
+      allocate ( zcosang(nazd), zsinang(nazd) ) 
+            
+ 
+      
+      if (me == master) then
+         print *, 'ugwp_v0: init_gw_wmsdis_control '         
+         print *, 'ugwp_v0: WMSDIS launch layer ',      klaunch 
+         print *, 'ugwp_v0: WMSDID tot_mflux in mpa',   tamp_mpa*1000.
+       endif     
+          
+        
+        zpexp=gptwo/2.0                    ! gptwo=2 , zpexp = 1.
+                  	 	   
+!
+!      set up azimuth directions and some trig factors
+!
+!
+           zang=pi2/float(nazd)
+      
+! get normalization factor to ensure that the same amount of momentum
+! flux is directed (n,s,e,w) no mater how many azimuths are selected.
+!
+        znorm=0.0 
+        do iazi=1, nazd
+         zang1= (iazi-1)*zang
+         zcosang(iazi)=cos(zang1)
+         zsinang(iazi)=sin(zang1)
+         znorm=znorm+abs(zcosang(iazi))
+        enddo
+        zaz_fct= 1.0	
+        zaz_fct= 2./znorm            ! correction factot for azimuthal sums
+	 
+!       define coordinate transform for "Ch"   ....x = 1/c stretching transform
+!       -----------------------------------------------     
+! note that this is expresed in terms of the intrinsic phase speed
+! at launch ci=c-u_o so that the transformation is identical
+! see eq. 28-30 of scinocca 2003.   x = 1/c stretching transform
+!
+          zxmax=1.0 /zcimin
+          zxmin=1.0 /zcimax
+          zxran=zxmax-zxmin
+          zdx=zxran/real(nwav-1)                            ! dkz  
+!
+          zx1=zxran/(exp(zxran/zgam)-1.0 )                    !zgam =1./4.
+          zx2=zxmin-zx1
+  
+! 
+! computations for zci =1/zx
+!                                   if(lgacalc) zgam=(zxmax-zxmin)/log(zxmax/zxmin)
+!                                   zx1=zxran/(exp(zxran/zgam)-1.0_jprb)
+!                                   zx2=zxmin-zx1
+        zms=2.*pi/zms_l    
+        do inc=1, nwav
+          ztx=real(inc-1)*zdx+zxmin
+          zx = zx1*exp((ztx-zxmin)/zgam)+zx2                          !eq. 29 of scinocca 2003
+          zci(inc)=1.0 /zx                                            !eq. 28 of scinocca 2003
+        zdci(inc)=zci(inc)**2*(zx1/zgam)*exp((ztx-zxmin)/zgam)*zdx    !eq. 30 of scinocca 2003
+          zci4(inc)=(zms*zci(inc))**4	
+	  zci2(inc)=(zms*zci(inc))**2
+	  zci3(inc)=(zms*zci(inc))**3 
+        enddo
+!	
+!
+!  all done and print-out 
+!	
+!	
+	
+         if (me == master) then  
+         print *  
+         print *,  'ugwp_v0: zcimin=' , zcimin
+         print *,  'ugwp_v0: zcimax=' , zcimax
+         print *,  'ugwp_v0: cd_crit=',  zgam                        ! m/s precision for crit-level 
+         print *,  'ugwp_v0: launch-level',  ilaunch
+         print *, ' ugwp_v0 zms_l=', zms_l
+         print *, ' ugwp_vgw  nslope=', nslope
+
+         print *
+         endif      
+ 
+        
+     end subroutine initsolv_wmsdis
+!
+! make a list of  all-initilized parameters needed for "gw_solver_wmsdis"
+!     
+     
+  end module ugwp_wmsdis_init  
+!=========================================================================   

--- a/physics/mp_thompson.F90
+++ b/physics/mp_thompson.F90
@@ -124,7 +124,7 @@ module mp_thompson
                                ims=ims, ime=ime, jms=jms, jme=jme, kms=kms, kme=kme, &
                                its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte, &
                                mpicomm=mpicomm, mpirank=mpirank, mpiroot=mpiroot,    &
-                               threads=threads)
+                               threads=threads, errmsg=errmsg, errflg=errflg)
             if (errflg /= 0) return
          else if (is_aerosol_aware) then
             write(errmsg,fmt='(*(a))') 'Logic error in mp_thompson_init:',                    &
@@ -137,7 +137,7 @@ module mp_thompson
                                ims=ims, ime=ime, jms=jms, jme=jme, kms=kms, kme=kme, &
                                its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte, &
                                mpicomm=mpicomm, mpirank=mpirank, mpiroot=mpiroot,    &
-                               threads=threads)
+                               threads=threads, errmsg=errmsg, errflg=errflg)
             if (errflg /= 0) return
          end if
 

--- a/physics/samfdeepcnv.f
+++ b/physics/samfdeepcnv.f
@@ -159,6 +159,7 @@
       logical, intent(in)  :: do_ca
 
       integer, intent(inout)  :: kcnv(im)
+      ! DH* TODO - check dimensions of qtr, ntr+2 correct?  *DH
       real(kind=kind_phys), intent(inout) ::   qtr(ix,km,ntr+2),        &
      &   q1(ix,km), t1(ix,km),   u1(ix,km), v1(ix,km),                  &
      &   cnvw(ix,km),  cnvc(ix,km)

--- a/physics/samfshalcnv.f
+++ b/physics/samfshalcnv.f
@@ -116,6 +116,7 @@
      &   prslp(ix,km), garea(im), hpbl(im), dot(ix,km), phil(ix,km)
 !
       integer, intent(inout)  :: kcnv(im)
+      ! DH* TODO - check dimensions of qtr, ntr+2 correct?  *DH
       real(kind=kind_phys), intent(inout) ::   qtr(ix,km,ntr+2),        &
      &   q1(ix,km), t1(ix,km), u1(ix,km), v1(ix,km)
 !


### PR DESCRIPTION
The use of modules and subroutines was not very good in the original non-CCPP code. For example, a single .F90 file contained several modules and some modules were only written to define some constants. In this version, I just separated them into several individual .F90 without touching the code too much and each of them contains one module. This definitely needs improvement in future. 