### PR TITLE
Cleanup work for CCPP transition 2019/06/27 - 1

### DIFF
--- a/physics/GFS_DCNV_generic.F90
+++ b/physics/GFS_DCNV_generic.F90
@@ -155,7 +155,7 @@
 !! | cnvc            | convective_cloud_cover                                                                      | convective cloud cover                                               | frac          |    2 | real              | kind_phys | inout  | F        |
 !! | cnvw_phy_f3d    | convective_cloud_water_mixing_ratio_in_phy_f3d                                              | convective cloud water mixing ratio in the phy_f3d array             | kg kg-1       |    2 | real              | kind_phys | inout  | F        |
 !! | cnvc_phy_f3d    | convective_cloud_cover_in_phy_f3d                                                           | convective cloud cover in the phy_f3d array                          | frac          |    2 | real              | kind_phys | inout  | F        |
-!! | cape            | convective_available_potential_energy_for_coupling                                          | convective available potential energy for coupling DH* CHECK THIS DOESN'T MAKE SENSE!!! *DH | m2 s-2        |    1 | real    | kind_phys | inout   | F        |
+!! | cape            | convective_available_potential_energy_for_coupling                                          | convective available potential energy for coupling                   | m2 s-2        |    1 | real              | kind_phys | inout  | F        |
 !! | tconvtend       | tendency_of_air_temperature_due_to_deep_convection_for_coupling_on_physics_timestep         | tendency of air temperature due to deep convection                   | K             |    2 | real              | kind_phys | inout  | F        |
 !! | qconvtend       | tendency_of_water_vapor_specific_humidity_due_to_deep_convection_for_coupling_on_physics_timestep | tendency of specific humidity due to deep convection           | kg kg-1       |    2 | real              | kind_phys | inout  | F        |
 !! | uconvtend       | tendency_of_x_wind_due_to_deep_convection_for_coupling_on_physics_timestep                  | tendency_of_x_wind_due_to_deep_convection                            | m s-1         |    2 | real              | kind_phys | inout  | F        |
@@ -194,12 +194,12 @@
       ! dqdti, cnvqci, upd_mfi, dwn_mfi, det_mfi only allocated if ldiag3d == .true. or lgocart == .true.
       real(kind=kind_phys), dimension(:,:), intent(inout) :: dqdti, cnvqci, upd_mfi, dwn_mfi, det_mfi
       real(kind=kind_phys), dimension(im,levs), intent(inout) :: cnvw, cnvc
-      ! DH* The following arrays may not be allocated, depending on certain flags and microphysics schemes.
+      ! The following arrays may not be allocated, depending on certain flags and microphysics schemes.
       ! Since Intel 15 crashes when passing unallocated arrays to arrays defined with explicit shape,
       ! use assumed-shape arrays. Note that Intel 18 and GNU 6.2.0-8.1.0 tolerate explicit-shape arrays
       ! as long as these do not get used when not allocated (it is still invalid Fortran code, though).
       real(kind=kind_phys), dimension(:,:), intent(inout) :: cnvw_phy_f3d, cnvc_phy_f3d
-      ! *DH
+
       real(kind=kind_phys), dimension(im), intent(inout) :: cape
       real(kind=kind_phys), dimension(im,levs), intent(inout) :: tconvtend, qconvtend, uconvtend, vconvtend
 

--- a/physics/GFS_MP_generic.F90
+++ b/physics/GFS_MP_generic.F90
@@ -206,7 +206,8 @@
                                                                  srflag, cnvprcp, totprcp, totice, totsnw, totgrp, cnvprcpb, &
                                                                  totprcpb, toticeb, totsnwb, totgrpb, rain_cpl, rainc_cpl,   &
                                                                  snow_cpl, pwat
-      real(kind=kind_phys), dimension(im,levs), intent(inout) :: dt3dt, dq3dt
+      ! These arrays are only allocated if ldiag3d is .true.
+      real(kind=kind_phys), dimension(:,:),     intent(inout) :: dt3dt, dq3dt
 
       ! Stochastic physics / surface perturbations
       logical, intent(in) :: do_sppt
@@ -259,7 +260,7 @@
       ! put ice, snow, graupel on dynamics timestep. The way the code in
       ! GFS_physics_driver is written, Diag%{graupel,ice,snow} are on the
       ! physics timestep, while Diag%{rain,rainc} and all totprecip etc
-      ! are on the dynamics timestep. Totally confusing and wrong. *DH
+      ! are on the dynamics timestep. Confusing, but works if frain=1. *DH
       if (imp_physics == imp_physics_gfdl) then
         tprcp   = max(0., rain)               ! clu: rain -> tprcp
         !graupel = frain*graupel0

--- a/physics/GFS_PBL_generic.F90
+++ b/physics/GFS_PBL_generic.F90
@@ -320,14 +320,13 @@
 
       real(kind=kind_phys), dimension(im, levs, ntrac), intent(inout) :: dqdt
 
-      ! DH* The following arrays may not be allocated, depending on certain flags (cplflx, ...).
+      ! The following arrays may not be allocated, depending on certain flags (cplflx, ...).
       ! Since Intel 15 crashes when passing unallocated arrays to arrays defined with explicit shape,
       ! use assumed-shape arrays. Note that Intel 18 and GNU 6.2.0-8.1.0 tolerate explicit-shape arrays
       ! as long as these do not get used when not allocated.
       real(kind=kind_phys), dimension(:,:), intent(inout) :: dt3dt, du3dt_PBL, du3dt_OGWD, dv3dt_PBL, dv3dt_OGWD, dq3dt, dq3dt_ozone
       real(kind=kind_phys), dimension(:), intent(inout) :: dusfc_cpl, dvsfc_cpl, dtsfc_cpl, dqsfc_cpl, dusfci_cpl, dvsfci_cpl, &
         dtsfci_cpl, dqsfci_cpl, dusfc_diag, dvsfc_diag, dtsfc_diag, dqsfc_diag, dusfci_diag, dvsfci_diag, dtsfci_diag, dqsfci_diag
-      ! *DH
 
       character(len=*), intent(out) :: errmsg
       integer, intent(out) :: errflg

--- a/physics/GFS_suite_interstitial.F90
+++ b/physics/GFS_suite_interstitial.F90
@@ -262,7 +262,8 @@
 
       integer,              intent(inout), dimension(im) :: kinver
       real(kind=kind_phys), intent(inout), dimension(im) :: suntim, dlwsfc, ulwsfc, psmean, adjsfculw, ctei_rml, ctei_r
-      real(kind=kind_phys), intent(inout), dimension(im, levs) :: dt3dt_lw, dt3dt_sw, dt3dt_pbl, dt3dt_dcnv, dt3dt_scnv, dt3dt_mp
+      ! These arrays are only allocated if ldiag3d is .true.
+      real(kind=kind_phys), intent(inout), dimension(:,:) :: dt3dt_lw, dt3dt_sw, dt3dt_pbl, dt3dt_dcnv, dt3dt_scnv, dt3dt_mp
 
       character(len=*),     intent(out) :: errmsg
       integer,              intent(out) :: errflg

--- a/physics/cu_gf_driver.F90
+++ b/physics/cu_gf_driver.F90
@@ -315,7 +315,7 @@ contains
    dd_mf =0.
    dt_mf =0.
    tau_ecmwf(:)=0.
-!                                                                      
+!
        j=1
        ht(:)=phil(:,1)/g
        do i=its,ite

--- a/physics/gfdl_fv_sat_adj.F90
+++ b/physics/gfdl_fv_sat_adj.F90
@@ -53,7 +53,6 @@ module fv_sat_adj
 !   </tr>
 ! </table>
     ! DH* TODO - MAKE THIS INPUT ARGUMENTS *DH
-    !use constants_mod, only: rvgas, rdgas, grav, hlv, hlf, cp_air
     use physcons, only : rdgas => con_rd_dyn, &
                          rvgas => con_rv_dyn, &
                          grav => con_g_dyn,   &

--- a/physics/gwdps.f
+++ b/physics/gwdps.f
@@ -57,7 +57,8 @@
 
       logical, intent(in) :: lssav, ldiag3d
       real(kind=kind_phys), intent(in) :: dtdt(im,levs)
-      real(kind=kind_phys), intent(inout) :: dt3dt(im,levs)
+      ! dt3dt only allocated only if ldiag3d is .true.
+      real(kind=kind_phys), intent(inout) :: dt3dt(:,:)
       real(kind=kind_phys), intent(in) :: dtf
 
       character(len=*), intent(out) :: errmsg

--- a/physics/maximum_hourly_diagnostics.F90
+++ b/physics/maximum_hourly_diagnostics.F90
@@ -8,7 +8,7 @@ module maximum_hourly_diagnostics
 
    public maximum_hourly_diagnostics_init, maximum_hourly_diagnostics_run, maximum_hourly_diagnostics_finalize
 
-   ! DH* TODO - THIS CAME FROM PHYSCONS.F90 BUT IS IT BETTER PLACED IN HERE?
+   ! DH* TODO - cleanup use of constants
    real(kind=kind_phys), parameter ::PQ0=379.90516E0, A2A=17.2693882, A3=273.16, A4=35.86, RHmin=1.0E-6
    ! *DH
 

--- a/physics/module_mp_thompson.F90
+++ b/physics/module_mp_thompson.F90
@@ -1486,11 +1486,9 @@ MODULE module_mp_thompson
                           rainprod, evapprod, &
 #endif
                           kts, kte, dt, ii, jj)
-      ! DH*
 #ifdef MPI
       use mpi
 #endif
-      ! *DH
       implicit none
 
 !..Sub arguments

--- a/physics/mp_thompson_post.F90
+++ b/physics/mp_thompson_post.F90
@@ -21,20 +21,17 @@ contains
 !! | local_name      | standard_name                                         | long_name                                                | units      | rank | type      |    kind   | intent | optional |
 !! |-----------------|-------------------------------------------------------|----------------------------------------------------------|------------|------|-----------|-----------|--------|----------|
 !! | ncol            | horizontal_loop_extent                                | horizontal loop extent                                   | count      |    0 | integer   |           | in     | F        |
-!! | area            | cell_area                                             | area of the grid cell                                    | m2         |    1 | real      | kind_phys | in     | F        |
 !! | ttendlim        | limit_for_temperature_tendency_for_microphysics       | temperature tendency limiter per physics time step       | K s-1      |    0 | real      | kind_phys | in     | F        |
 !! | errmsg          | ccpp_error_message                                    | error message for error handling in CCPP                 | none       |    0 | character | len=*     | out    | F        |
 !! | errflg          | ccpp_error_flag                                       | error flag for error handling in CCPP                    | flag       |    0 | integer   |           | out    | F        |
 !!
 #endif
-   subroutine mp_thompson_post_init(ncol, area, ttendlim, errmsg, errflg)
+   subroutine mp_thompson_post_init(ncol, ttendlim, errmsg, errflg)
 
       implicit none
 
       ! Interface variables
       integer,         intent(in) :: ncol
-      ! DH* TODO: remove area and dx (also from metadata table)
-      real(kind_phys), dimension(1:ncol), intent(in) :: area
       real(kind_phys), intent(in) :: ttendlim
 
       ! CCPP error handling
@@ -42,7 +39,6 @@ contains
       integer,          intent(  out) :: errflg
 
       ! Local variables
-      !real(kind_phys), dimension(1:ncol) :: dx
       integer :: i
 
       ! Initialize the CCPP error handling variables
@@ -60,26 +56,7 @@ contains
 
       allocate(mp_tend_lim(1:ncol))
 
-      !! Cell size in m as square root of cell area
-      !dx = sqrt(area)
-
       do i=1,ncol
-         ! The column-dependent values that were set here previously
-         ! are replaced with a single value set in the namelist
-         ! input.nml.This value is independent of the grid spacing
-         ! (as opposed to setting it here on a per-column basis).
-         ! However, given that the timestep is the same for all grid
-         ! columns and determined by the smallest grid spacing in
-         ! the domain, it makes sense to use a single value.
-         !
-         ! The values previously used in RAP/HRRR were
-         !    mp_tend_lim(i) = 0.07    ! [K/s], 3-km HRRR value
-         ! and
-         !   mp_tend_lim(i) = 0.002   ! [K/s], 13-km RAP value
-         !
-         ! Our testing with FV3 has shown thus far that 0.002 is
-         ! too small for a 13km (C768) resolution and that 0.01
-         ! works better. This is work in progress ...
          mp_tend_lim(i) = ttendlim
       end do
 

--- a/physics/multi_gases.F90
+++ b/physics/multi_gases.F90
@@ -36,7 +36,7 @@ module ccpp_multi_gases_mod
 !   </tr>
 ! </table>
       use machine, only: kind_dyn
-      ! DH* TODO - MAKE THIS INPUT ARGUMENTS *DH
+      ! DH* TODO - MAKE THIS INPUT ARGUMENTS
       use physcons, only : rdgas => con_rd_dyn, &
                            cp_air => con_cp_dyn
       ! *DH

--- a/physics/physcons.F90
+++ b/physics/physcons.F90
@@ -56,7 +56,7 @@
   real(kind=kind_phys),parameter:: con_solr_old =1.3660e+3_kind_phys               !< solar constant (\f$W/m^{2}\f$)-Liu(2002)
   real(kind=kind_phys),parameter:: con_solr   =1.3608e+3_kind_phys                 !< solar constant (\f$W/m^{2}\f$)-nasa-sorce Tim(2008)
 ! real(kind=kind_phys),parameter:: con_solr   =1.36742732e+3_kind_phys             ! solar constant    (W/m2)-gfdl(1989) - OPR as of Jan 2006
-  ! Selected geophysics/astronomy constants with kind=kind_dyn DH* CHECK IF THIS BREAKS B4B AND IF SO REMOVE _kind_dyn
+  ! Selected geophysics/astronomy constants with kind=kind_dyn
   real(kind=kind_dyn), parameter:: con_g_dyn  =9.80665e+0_kind_dyn                 !< gravity (\f$m/s^{2}\f$)
 
 !> \name Thermodynamics constants
@@ -79,7 +79,7 @@
   real(kind=kind_phys),parameter:: con_jcal   =4.1855E+0_kind_phys                 !< joules per calorie
   real(kind=kind_phys),parameter:: con_rhw0   =1022.0_kind_phys                    !< sea water reference density (\f$kg/m^{3}\f$)
   real(kind=kind_phys),parameter:: con_epsq   =1.0E-12_kind_phys                   !< min q for computing precip type
-  ! Selected thermodynamics constants with kind=kind_dyn  DH* CHECK IF THIS BREAKS B4B AND IF SO REMOVE _kind_dyn
+  ! Selected thermodynamics constants with kind=kind_dyn
   real(kind=kind_dyn), parameter:: con_rd_dyn   =2.8705e+2_kind_dyn                !< gas constant air (\f$J/kg/K\f$)
   real(kind=kind_dyn), parameter:: con_rv_dyn   =4.6150e+2_kind_dyn                !< gas constant H2O (\f$J/kg/K\f$)
   real(kind=kind_dyn), parameter:: con_cp_dyn   =1.0046e+3_kind_dyn                !< spec heat air at p (\f$J/kg/K\f$)

--- a/physics/radcons.f90
+++ b/physics/radcons.f90
@@ -60,7 +60,6 @@
 !----------------------------
 ! Module variable definitions
 !----------------------------
-! DH* CHECK IF THIS IS NEEDED/TRUE?
 !CCPP: copy from GFS_driver.F90
   real(kind=kind_phys), parameter :: con_24  =   24.0_kind_phys
   real(kind=kind_phys), parameter :: con_hr  = 3600.0_kind_phys

--- a/physics/samfshalcnv.f
+++ b/physics/samfshalcnv.f
@@ -1869,13 +1869,12 @@ c
 
         real(kind=kind_phys), dimension(im), intent(inout) :: rainc,
      &    cnvprcp, cnvprcpb
-        ! DH* The following arrays may not be allocated, depending on certain flags and microphysics schemes.
+        ! The following arrays may not be allocated, depending on certain flags and microphysics schemes.
         ! Since Intel 15 crashes when passing unallocated arrays to arrays defined with explicit shape,
         ! use assumed-shape arrays. Note that Intel 18 and GNU 6.2.0-8.1.0 tolerate explicit-shape arrays
         ! as long as these do not get used when not allocated.
         real(kind=kind_phys), dimension(:,:), intent(inout) ::
      &    cnvw_phy_f3d, cnvc_phy_f3d
-        ! *DH
 
         character(len=*), intent(out) :: errmsg
         integer,          intent(out) :: errflg


### PR DESCRIPTION
- check several issues as described in the notes in the files, remove notes when check is ok
- remove or reword existing comments, add notes on future cleanup work
- remove commented code in mp_thompson_post
- remove hard-coded dimension extents for d?3dt fields to allow running the model without having to allocate the d?3dt fields when ldiag3d is false