### PR TITLE
Bugfix GF convection, Thompson cleanup 2019/07/09

### DIFF
--- a/physics/GFS_PBL_generic.F90
+++ b/physics/GFS_PBL_generic.F90
@@ -100,18 +100,19 @@
           enddo
         elseif (imp_physics == imp_physics_thompson) then
   ! Thompson
-          ! DH* Thompson ntrw and ntsw?
           if(ltaerosol) then
             do k=1,levs
               do i=1,im
-                vdftra(i,k,1) = qgrs(i,k,ntqv)
-                vdftra(i,k,2) = qgrs(i,k,ntcw)
-                vdftra(i,k,3) = qgrs(i,k,ntiw)
-                vdftra(i,k,4) = qgrs(i,k,ntlnc)
-                vdftra(i,k,5) = qgrs(i,k,ntinc)
-                vdftra(i,k,6) = qgrs(i,k,ntoz)
-                vdftra(i,k,7) = qgrs(i,k,ntwa)
-                vdftra(i,k,8) = qgrs(i,k,ntia)
+                vdftra(i,k,1)  = qgrs(i,k,ntqv)
+                vdftra(i,k,2)  = qgrs(i,k,ntcw)
+                vdftra(i,k,3)  = qgrs(i,k,ntiw)
+                vdftra(i,k,4)  = qgrs(i,k,ntrw)
+                vdftra(i,k,5)  = qgrs(i,k,ntsw)
+                vdftra(i,k,6)  = qgrs(i,k,ntlnc)
+                vdftra(i,k,7)  = qgrs(i,k,ntinc)
+                vdftra(i,k,8)  = qgrs(i,k,ntoz)
+                vdftra(i,k,9)  = qgrs(i,k,ntwa)
+                vdftra(i,k,10) = qgrs(i,k,ntia)
               enddo
             enddo
           else
@@ -120,8 +121,10 @@
                 vdftra(i,k,1) = qgrs(i,k,ntqv)
                 vdftra(i,k,2) = qgrs(i,k,ntcw)
                 vdftra(i,k,3) = qgrs(i,k,ntiw)
-                vdftra(i,k,4) = qgrs(i,k,ntinc)
-                vdftra(i,k,5) = qgrs(i,k,ntoz)
+                vdftra(i,k,4) = qgrs(i,k,ntrw)
+                vdftra(i,k,5) = qgrs(i,k,ntsw)
+                vdftra(i,k,6) = qgrs(i,k,ntinc)
+                vdftra(i,k,7) = qgrs(i,k,ntoz)
               enddo
             enddo
           endif
@@ -362,18 +365,19 @@
           enddo
         elseif (imp_physics == imp_physics_thompson) then
   ! Thompson
-          ! DH* - Thompson ntrw, ntsw?
           if(ltaerosol) then
             do k=1,levs
               do i=1,im
                 dqdt(i,k,ntqv)  = dvdftra(i,k,1)
                 dqdt(i,k,ntcw)  = dvdftra(i,k,2)
                 dqdt(i,k,ntiw)  = dvdftra(i,k,3)
-                dqdt(i,k,ntlnc) = dvdftra(i,k,4)
-                dqdt(i,k,ntinc) = dvdftra(i,k,5)
-                dqdt(i,k,ntoz)  = dvdftra(i,k,6)
-                dqdt(i,k,ntwa)  = dvdftra(i,k,7)
-                dqdt(i,k,ntia)  = dvdftra(i,k,8)
+                dqdt(i,k,ntrw)  = dvdftra(i,k,4)
+                dqdt(i,k,ntsw)  = dvdftra(i,k,5)
+                dqdt(i,k,ntlnc) = dvdftra(i,k,6)
+                dqdt(i,k,ntinc) = dvdftra(i,k,7)
+                dqdt(i,k,ntoz)  = dvdftra(i,k,8)
+                dqdt(i,k,ntwa)  = dvdftra(i,k,9)
+                dqdt(i,k,ntia)  = dvdftra(i,k,10)
               enddo
             enddo
           else
@@ -382,8 +386,10 @@
                 dqdt(i,k,ntqv)  = dvdftra(i,k,1)
                 dqdt(i,k,ntcw)  = dvdftra(i,k,2)
                 dqdt(i,k,ntiw)  = dvdftra(i,k,3)
-                dqdt(i,k,ntinc) = dvdftra(i,k,4)
-                dqdt(i,k,ntoz)  = dvdftra(i,k,5)
+                dqdt(i,k,ntrw)  = dvdftra(i,k,4)
+                dqdt(i,k,ntsw)  = dvdftra(i,k,5)
+                dqdt(i,k,ntinc) = dvdftra(i,k,6)
+                dqdt(i,k,ntoz)  = dvdftra(i,k,7)
               enddo
             enddo
           endif

--- a/physics/cu_gf_deep.F90
+++ b/physics/cu_gf_deep.F90
@@ -3227,9 +3227,9 @@ endif
         enddo
         do k=kts+1,ktf
           do i=its,itf
-           if(ierr(i).ne.0) exit
-           if(k.lt.kbcon(i)) exit
-           if(k.gt.ktop(i)) exit
+           if(ierr(i).ne.0) cycle
+           if(k.lt.kbcon(i)) cycle
+           if(k.gt.ktop(i)) cycle
            dz=z(i,k)-z(i,k-1)
            da=zu(i,k)*dz*(9.81/(1004.*( &
                   (t_cup(i,k)))))*dby(i,k-1)/ &
@@ -4379,8 +4379,8 @@ endif
         enddo
         do i=its,itf
           do k=kts,kbcon(i)
-            if(ierr(i).ne.0 ) exit
-!           if(k.gt.kbcon(i)) exit
+            if(ierr(i).ne.0 ) cycle
+!           if(k.gt.kbcon(i)) cycle
 
             dz = (z_cup (i,k+1)-z_cup (i,k))*g
             da = dz*(tn(i,k)*(1.+0.608*qo(i,k))-t(i,k)*(1.+0.608*q(i,k)))/dtime

--- a/physics/cu_ntiedtke.F90
+++ b/physics/cu_ntiedtke.F90
@@ -202,6 +202,10 @@ contains
       real(kind=kind_phys), dimension( ix , km ),     intent(inout) :: pu, pv, pt, pqv
       real(kind=kind_phys), dimension( ix , km ),     intent(in )   :: poz, prsl, pomg, pqvf, ptf
       real(kind=kind_phys), dimension( ix , km+1 ),   intent(in )   :: pzz, prsi
+      ! DH* TODO - check dimensions of clw, ktrac+2 seems to be smaller
+      ! than the actual dimensions (ok as long as only indices 1 and 2
+      ! are accessed here, and as long as these contain what is expected);
+      ! better to expand into the cloud-ice and cloud-water components *DH
       real(kind=kind_phys), dimension( ix , km, ktrac+2 ),    intent(inout ) ::  clw
 
       integer, dimension( lq ),   intent(out)  :: kbot, ktop, kcnv

--- a/physics/mp_thompson.F90
+++ b/physics/mp_thompson.F90
@@ -124,7 +124,7 @@ module mp_thompson
                                ims=ims, ime=ime, jms=jms, jme=jme, kms=kms, kme=kme, &
                                its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte, &
                                mpicomm=mpicomm, mpirank=mpirank, mpiroot=mpiroot,    &
-                               threads=threads)
+                               threads=threads, errmsg=errmsg, errflg=errflg)
             if (errflg /= 0) return
          else if (is_aerosol_aware) then
             write(errmsg,fmt='(*(a))') 'Logic error in mp_thompson_init:',                    &
@@ -137,7 +137,7 @@ module mp_thompson
                                ims=ims, ime=ime, jms=jms, jme=jme, kms=kms, kme=kme, &
                                its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte, &
                                mpicomm=mpicomm, mpirank=mpirank, mpiroot=mpiroot,    &
-                               threads=threads)
+                               threads=threads, errmsg=errmsg, errflg=errflg)
             if (errflg /= 0) return
          end if
 

--- a/physics/samfdeepcnv.f
+++ b/physics/samfdeepcnv.f
@@ -159,6 +159,7 @@
       logical, intent(in)  :: do_ca
 
       integer, intent(inout)  :: kcnv(im)
+      ! DH* TODO - check dimensions of qtr, ntr+2 correct?  *DH
       real(kind=kind_phys), intent(inout) ::   qtr(ix,km,ntr+2),        &
      &   q1(ix,km), t1(ix,km),   u1(ix,km), v1(ix,km),                  &
      &   cnvw(ix,km),  cnvc(ix,km)

--- a/physics/samfshalcnv.f
+++ b/physics/samfshalcnv.f
@@ -116,6 +116,7 @@
      &   prslp(ix,km), garea(im), hpbl(im), dot(ix,km), phil(ix,km)
 !
       integer, intent(inout)  :: kcnv(im)
+      ! DH* TODO - check dimensions of qtr, ntr+2 correct?  *DH
       real(kind=kind_phys), intent(inout) ::   qtr(ix,km,ntr+2),        &
      &   q1(ix,km), t1(ix,km), u1(ix,km), v1(ix,km)
 !


### PR DESCRIPTION
This PR and associated PRs listed below fix a bug in the GF convection scheme introduced in a previous code cleanup PR (https://github.com/NCAR/ccpp-physics/pull/251) and cleans up/improves code for the CCPP Thompson MP scheme.

- physics/GFS_PBL_generic.F90: add missing tracers for Thompson MP to tracer advection array for PBL schemes
- physics/cu_gf_deep.F90: bugfix, replace exit statements in do loop with cycle statements
- physics/cu_gf_driver.F90: cleanup, instead of passing in convective_transportable_tracers array, only pass in the components required
- physics/cu_ntiedtke.F90, physics/samfdeepcnv.f, physics/samfshalcnv.f: add notes to check dimensions of clw array
- physics/module_mp_thompson.F90, physics/mp_thompson.F90: cleanup, return with an error if CCN_ACTIVATE.BIN is not found, remove temporary stopping of model

**Testing:** logs will be posted below

**Associated PRs:**
https://github.com/NCAR/NEMSfv3gfs/pull/199
https://github.com/NCAR/FV3/pull/176
https://github.com/NCAR/ccpp-physics/pull/283