### PR TITLE
gsd/develop: add regression tests for Thompson only, GF only, MYNN only & cleanup

### DIFF
--- a/physics/docs/pdftxt/GSD_adv_suite.txt
+++ b/physics/docs/pdftxt/GSD_adv_suite.txt
@@ -144,7 +144,6 @@ The GSD RAP/HRRR physics suite uses the parameterizations in the following order
        ltaerosol      = .true.
        lradar         = .true.
        ttendlim       = -999.
-       make_number_concentrations = .true.
        pdfcld         = .false.
        fhswr          = 3600.
        fhlwr          = 3600.

--- a/physics/docs/pdftxt/suite_input.nml.txt
+++ b/physics/docs/pdftxt/suite_input.nml.txt
@@ -279,7 +279,6 @@ and how stochastic perturbations are used in the Noah Land Surface Model.
 <tr><td>iccn            <td>gfs_control_type          <td>flag for using IN and CCN forcing in MG2/3 microphysics      <td>.false.
 <tr><td>rhcmax          <td>gfs_control_type          <td>maximum critical relative humidity                           <td>0.9999999 
 <tr><td colspan="4"  align= center>\b Parameters \b Specific \b to \b GSD_v0 \b Suite 
-<tr><td>make_number_concentrations    <td>gfs_control_type   <td>flag to calculate initial number concentrations from mass concentrations if not in ICs/BCs    <td>.false.
 <tr><td>ltaerosol       <td>gfs_control_type          <td>logical flag for using aerosol climotology in Thompson MP scheme          <td>.false.
 <tr><td>lradar          <td>gfs_control_type          <td>logical flag for computing radar reflectivity in Thompson MP scheme       <td>.false.
 <tr><td>ttendlim        <td>gfs_control_type          <td>temperature tendency limiter per time step in K/s, set to < 0 to deactivate   <td>-999.0

--- a/physics/mp_thompson_pre.F90
+++ b/physics/mp_thompson_pre.F90
@@ -39,7 +39,6 @@ module mp_thompson_pre
 !! | qg              | graupel_mixing_ratio_updated_by_physics                               | graupel mixing ratio wrt dry+vapor (no condensates)      | kg kg-1    |    2 | real      | kind_phys | inout  | F        |
 !! | ni              | ice_number_concentration_updated_by_physics                           | ice number concentration                                 | kg-1       |    2 | real      | kind_phys | inout  | F        |
 !! | nr              | rain_number_concentration_updated_by_physics                          | rain number concentration                                | kg-1       |    2 | real      | kind_phys | inout  | F        |
-!! | make_number_concentrations | flag_for_initial_number_concentration_calculation          | flag for initial number concentration calculation        | flag       |    0 | logical   |           | in     | F        |
 !! | is_aerosol_aware| flag_for_aerosol_physics                                              | flag for aerosol-aware physics                           | flag       |    0 | logical   |           | in     | F        |
 !! | nc              | cloud_droplet_number_concentration_updated_by_physics                 | cloud droplet number concentration                       | kg-1       |    2 | real      | kind_phys | inout  | T        |
 !! | nwfa            | water_friendly_aerosol_number_concentration_updated_by_physics        | number concentration of water-friendly aerosols          | kg-1       |    2 | real      | kind_phys | inout  | T        |
@@ -60,7 +59,6 @@ module mp_thompson_pre
 #endif
       subroutine mp_thompson_pre_run(ncol, nlev, kdt, con_g, con_rd,    &
                                   spechum, qc, qr, qi, qs, qg, ni, nr,       &
-                                  make_number_concentrations,                &
                                   is_aerosol_aware, nc, nwfa, nifa, nwfa2d,  &
                                   nifa2d, tgrs, tgrs_save, prsl, phil, area, &
                                   mpirank, mpiroot, blkno, errmsg, errflg)
@@ -83,7 +81,6 @@ module mp_thompson_pre
          real(kind_phys),           intent(inout) :: qg(1:ncol,1:nlev)
          real(kind_phys),           intent(inout) :: ni(1:ncol,1:nlev)
          real(kind_phys),           intent(inout) :: nr(1:ncol,1:nlev)
-         logical,                   intent(in   ) :: make_number_concentrations
          ! Aerosols
          logical,                   intent(in   ) :: is_aerosol_aware
          real(kind_phys), optional, intent(inout) :: nc(1:ncol,1:nlev)
@@ -169,27 +166,17 @@ module mp_thompson_pre
          !  they also need to be switched back to mass/number per kg of air, because
          !  what is returned by the functions is in units of number per cubic meter.
 
-         if (make_number_concentrations) then
-             ! If qi is in boundary conditions but ni is not, calculate ni from qi, rho and tgrs
-             if (maxval(qi)>0.0 .and. maxval(ni)==0.0) then
-                 ni = make_IceNumber(qi*rho, tgrs) * orho
-             end if
-         else
-             ! If qi is in boundary conditions but ni is not, reset qi to zero
-             if (maxval(qi)>0.0 .and. maxval(ni)==0.0) qi = 0.0
+         ! If qi is in boundary conditions but ni is not, calculate ni from qi, rho and tgrs
+         if (maxval(qi)>0.0 .and. maxval(ni)==0.0) then
+             ni = make_IceNumber(qi*rho, tgrs) * orho
          end if
 
          ! If ni is in boundary conditions but qi is not, reset ni to zero
          if (maxval(ni)>0.0 .and. maxval(qi)==0.0) ni = 0.0
 
-         if (make_number_concentrations) then
-             ! If qr is in boundary conditions but nr is not, calculate nr from qr, rho and tgrs
-             if (maxval(qr)>0.0 .and. maxval(nr)==0.0) then
-                 nr = make_RainNumber(qr*rho, tgrs) * orho
-             end if
-         else
-             ! If qr is in boundary conditions but nr is not, reset qr to zero
-             if (maxval(qr)>0.0 .and. maxval(nr)==0.0) qr = 0.0
+         ! If qr is in boundary conditions but nr is not, calculate nr from qr, rho and tgrs
+         if (maxval(qr)>0.0 .and. maxval(nr)==0.0) then
+             nr = make_RainNumber(qr*rho, tgrs) * orho
          end if
 
          ! If nr is in boundary conditions but qr is not, reset nr to zero
@@ -298,14 +285,9 @@ module mp_thompson_pre
             endif
          endif
 
-         if (make_number_concentrations) then
-             ! If qc is in boundary conditions but nc is not, calculate nc from qc, rho and nwfa
-             if (maxval(qc)>0.0 .and. maxval(nc)==0.0) then
-                nc = make_DropletNumber(qc*rho, nwfa) * orho
-             end if
-         else
-             ! If qc is in boundary conditions but nc is not, reset qc to zero
-             if (maxval(qc)>0.0 .and. maxval(nc)==0.0) qc = 0.0
+         ! If qc is in boundary conditions but nc is not, calculate nc from qc, rho and nwfa
+         if (maxval(qc)>0.0 .and. maxval(nc)==0.0) then
+            nc = make_DropletNumber(qc*rho, nwfa) * orho
          end if
 
          ! If nc is in boundary conditions but qc is not, reset nc to zero


### PR DESCRIPTION
Associated PRs:

https://github.com/NCAR/NEMSfv3gfs/pull/206
https://github.com/NCAR/ccpp-physics/pull/285
https://github.com/NCAR/FV3/pull/179

See https://github.com/NCAR/NEMSfv3gfs/pull/206 for testing.

Changes in ccpp-physics:
- remove option to turn off make_number_concentrations, always this option if number concentrations are not in the initial conditions