### PR TITLE
HAFS physics changes for CCPP

### DIFF
--- a/physics/moninedmf.f
+++ b/physics/moninedmf.f
@@ -8,8 +8,28 @@
 
       contains
 
+!> \section arg_table_hedmf_init Argument Table
+!! | local_name     | standard_name                                                               | long_name                                             | units         | rank | type      |    kind   | intent | optional |
+!! |----------------|-----------------------------------------------------------------------------|-------------------------------------------------------|---------------|------|-----------|-----------|--------|----------|
+!! | moninq_fac     | atmosphere_diffusivity_coefficient_factor                                   | multiplicative constant for atmospheric diffusivities | none          |    0 | real      | kind_phys | in     | F        |
+!! | errmsg         | ccpp_error_message                                                          | error message for error handling in CCPP              | none          |    0 | character | len=*     | out    | F        |
+!! | errflg         | ccpp_error_flag                                                             | error flag for error handling in CCPP                 | flag          |    0 | integer   |           | out    | F        |
+!!
+      subroutine hedmf_init (moninq_fac,errmsg,errflg)
+         use machine, only : kind_phys
+         implicit none
+         real(kind=kind_phys), intent(in ) :: moninq_fac
+         character(len=*),     intent(out) :: errmsg
+         integer,              intent(out) :: errflg
+         ! Initialize CCPP error handling variables
+         errmsg = ''
+         errflg = 0
 
-      subroutine hedmf_init ()
+         if (moninq_fac == 0) then
+             errflg = 1
+             write(errmsg,'(*(a))') 'Logic error: moninq_fac == 0',
+     &                              ' is incompatible with hedmf'
+         end if
       end subroutine hedmf_init
 
       subroutine hedmf_finalize ()

--- a/physics/sfc_diff.f
+++ b/physics/sfc_diff.f
@@ -56,6 +56,9 @@
 !! | ztpert         | perturbation_of_heat_to_momentum_roughness_length_ratio                      | perturbation of heat to momentum roughness length ratio          | frac       |    1 | real      | kind_phys | in     | F        |
 !! | flag_iter      | flag_for_iteration                                                           | flag for iteration                                               | flag       |    1 | logical   |           | in     | F        |
 !! | redrag         | flag_for_reduced_drag_coefficient_over_sea                                   | flag for reduced drag coefficient over sea                       | flag       |    0 | logical   |           | in     | F        |
+!! | u10m           | x_wind_at_10m                                                                | 10 meter u wind speed                                            | m s-1      |    1 | real      | kind_phys | in     | F        |
+!! | v10m           | y_wind_at_10m                                                                | 10 meter v wind speed                                            | m s-1      |    1 | real      | kind_phys | in     | F        |
+!! | sfc_z0_type    | flag_for_surface_roughness_option_over_ocean                                 | surface roughness options over ocean                             | flag       |    0 | integer   |           | in     | F        |
 !! | wet            | flag_nonzero_wet_surface_fraction                                            | flag indicating presence of some ocean or lake surface area fraction | flag   |    1 | logical   |           | in     | F        |
 !! | dry            | flag_nonzero_land_surface_fraction                                           | flag indicating presence of some land surface area fraction      | flag       |    1 | logical   |           | in     | F        |
 !! | icy            | flag_nonzero_sea_ice_surface_fraction                                        | flag indicating presence of some sea ice surface area fraction   | flag       |    1 | logical   |           | in     | F        |
@@ -134,6 +137,7 @@
      &                    sigmaf,vegtype,shdmax,ivegsrc,                &  !intent(in)
      &                    z0pert,ztpert,                                &  ! mg, sfc-perts !intent(in)
      &                    flag_iter,redrag,                             &  !intent(in)
+     &                    u10m,v10m,sfc_z0_type,                        &  !hafs,z0 type !intent(in)
      &                    wet,dry,icy,                                  &  !intent(in)
      &                    tskin_ocn, tskin_lnd, tskin_ice,              &  !intent(in)
      &                    tsurf_ocn, tsurf_lnd, tsurf_ice,              &  !intent(in)
@@ -156,11 +160,14 @@
       implicit none
 !
       integer, intent(in) :: im, ivegsrc
+      integer, intent(in) :: sfc_z0_type ! option for calculating surface roughness length over ocean
+
       integer, dimension(im), intent(in) :: vegtype 
 
       logical, intent(in) :: redrag ! reduced drag coeff. flag for high wind over sea (j.han)
       logical, dimension(im), intent(in) :: flag_iter, wet, dry, icy ! added by s.lu
 
+      real(kind=kind_phys), dimension(im), intent(in)    :: u10m,v10m
       real(kind=kind_phys), intent(in) :: rvrdm1, eps, epsm1, grav
       real(kind=kind_phys), dimension(im), intent(in)    ::             &
      &                    ps,u1,v1,t1,q1,z1,prsl1,prslki,ddvel,         &
@@ -188,6 +195,8 @@
 !
 !     locals
 !
+      real(kind=kind_phys), dimension(im)                :: wind10m
+
       integer   i
 !
       real(kind=kind_phys) :: qs1,  rat, thv1, restar,
@@ -227,9 +236,16 @@
 !  ps is in pascals, wind is wind speed,
 !  surface roughness length is converted to m from cm
 !
+
+!       write(0,*)'in sfc_diff, sfc_z0_type=',sfc_z0_type
+
       do i=1,im
 
-        ztmax_ocn = 0.; ztmax_lnd = 0.; ztmax_ice = 0.
+        ztmax_ocn = 0.0 ; ztmax_lnd = 0.0 ; ztmax_ice = 0.0
+
+        wind10m(i) = max(sqrt( u10m(i)*u10m(i) + v10m(i)*v10m(i)),
+     &                 1.0)
+
         if(flag_iter(i)) then
           wind(i) = max(sqrt(u1(i)*u1(i) + v1(i)*v1(i))
      &                + max(0.0, min(ddvel(i), 30.0)), 1.0)
@@ -270,7 +286,18 @@
 
             rat    = min(7.0, 2.67 * sqrt(sqrt(restar)) - 2.57)
             ztmax_ocn  = z0max_ocn * exp(-rat)
+
+           if (sfc_z0_type == 6) then
+             call znot_t_v6(wind10m(i),ztmax_ocn)   ! 10-m wind,m/s, ztmax(m)
+           else if (sfc_z0_type == 7) then
+             call znot_t_v7(wind10m(i),ztmax_ocn)   ! 10-m wind,m/s, ztmax(m)
+           else if (sfc_z0_type .ne. 0) then
+             write(0,*)'no option for sfc_z0_type=',sfc_z0_type
+             stop
+           endif
+
           endif ! Open ocean
+
           if (dry(i) .or. icy(i)) then ! over land or sea ice
 !** xubin's new z0  over land and sea ice
             tem1 = 1.0 - shdmax(i)
@@ -396,6 +423,17 @@
             else
               z0rl_ocn(i) = 100.0 * max(min(z0_ocn,.1), 1.e-7)
             endif
+
+             if (sfc_z0_type == 6) then   ! wang
+               call znot_m_v6(wind10m(i),z0_ocn)   ! wind, m/s, z0, m
+               z0rl_ocn(i) = 100.0 * z0_ocn        ! cm
+             endif              !wang
+             if (sfc_z0_type == 7) then   ! wang
+               call znot_m_v7(wind10m(i),z0_ocn)   ! wind, m/s, z0, m
+               z0rl_ocn(i) = 100.0 * z0_ocn        ! cm
+             endif              !wang
+
+
           endif              ! end of if(open ocean)
         endif                ! end of if(flagiter) loop
       enddo
@@ -558,6 +596,303 @@
 !.................................
       end subroutine stability
 !---------------------------------
+
+
+!! add fitted z0,zt curves for hurricane application (used in HWRF/HMON)
+!! Weiguo Wang, 2019-0425
+
+       SUBROUTINE znot_m_v6(uref,znotm)
+       IMPLICIT NONE
+! Calculate areodynamical roughness over water with input 10-m wind
+! For low-to-moderate winds, try to match the Cd-U10 relationship from COARE V3.5 (Edson et al. 2013)
+! For high winds, try to fit available observational data
+!
+! Bin Liu, NOAA/NCEP/EMC 2017
+! 
+! uref(m/s)   :   wind speed at 10-m height
+! znotm(meter):   areodynamical roughness scale over water
+!
+
+       REAL, INTENT(IN) :: uref
+       REAL, INTENT(OUT):: znotm
+       REAL             :: p13, p12, p11, p10
+       REAL             :: p25, p24, p23, p22, p21, p20
+       REAL             :: p35, p34, p33, p32, p31, p30
+       REAL             :: p40
+
+       p13 = -1.296521881682694e-02
+       p12 =  2.855780863283819e-01
+       p11 = -1.597898515251717e+00
+       p10 = -8.396975715683501e+00
+
+       p25 =  3.790846746036765e-10
+       p24 =  3.281964357650687e-09
+       p23 =  1.962282433562894e-07
+       p22 = -1.240239171056262e-06
+       p21 =  1.739759082358234e-07
+       p20 =  2.147264020369413e-05
+
+       p35 =  1.840430200185075e-07
+       p34 = -2.793849676757154e-05
+       p33 =  1.735308193700643e-03
+       p32 = -6.139315534216305e-02
+       p31 =  1.255457892775006e+00
+       p30 = -1.663993561652530e+01
+
+       p40 =  4.579369142033410e-04
+
+       if (uref >= 0.0 .and.  uref <= 6.5 ) then
+        znotm = exp( p10 + p11*uref + p12*uref**2 + 
+     &          p13*uref**3)
+       elseif (uref > 6.5 .and. uref <= 15.7) then
+        znotm = p25*uref**5 + p24*uref**4 + p23*uref**3 + 
+     &          p22*uref**2 + p21*uref + p20
+       elseif (uref > 15.7 .and. uref <= 53.0) then
+        znotm = exp( p35*uref**5 + p34*uref**4 + 
+     &         p33*uref**3 + p32*uref**2 + p31*uref + p30 )
+       elseif ( uref > 53.0) then
+         znotm = p40
+       else
+        print*, 'Wrong input uref value:',uref
+       endif
+
+       END SUBROUTINE znot_m_v6
+
+       SUBROUTINE znot_t_v6(uref,znott)
+       IMPLICIT NONE
+! Calculate scalar roughness over water with input 10-m wind
+! For low-to-moderate winds, try to match the Ck-U10 relationship from COARE algorithm
+! For high winds, try to retain the Ck-U10 relationship of FY2015 HWRF
+!
+! Bin Liu, NOAA/NCEP/EMC 2017
+!
+! uref(m/s)   :   wind speed at 10-m height
+! znott(meter):   scalar roughness scale over water
+!
+
+       REAL, INTENT(IN) :: uref
+       REAL, INTENT(OUT):: znott
+
+       REAL             :: p00
+       REAL             :: p15, p14, p13, p12, p11, p10
+       REAL             :: p25, p24, p23, p22, p21, p20
+       REAL             :: p35, p34, p33, p32, p31, p30
+       REAL             :: p45, p44, p43, p42, p41, p40
+       REAL             :: p56, p55, p54, p53, p52, p51, p50
+       REAL             :: p60
+
+       p00 =  1.100000000000000e-04
+
+       p15 = -9.144581627678278e-10
+       p14 =  7.020346616456421e-08
+       p13 = -2.155602086883837e-06
+       p12 =  3.333848806567684e-05
+       p11 = -2.628501274963990e-04
+       p10 =  8.634221567969181e-04
+
+       p25 = -8.654513012535990e-12
+       p24 =  1.232380050058077e-09
+       p23 = -6.837922749505057e-08
+       p22 =  1.871407733439947e-06
+       p21 = -2.552246987137160e-05
+       p20 =  1.428968311457630e-04
+
+       p35 =  3.207515102100162e-12
+        p34 = -2.945761895342535e-10
+        p33 =  8.788972147364181e-09
+       p32 = -3.814457439412957e-08
+        p31 = -2.448983648874671e-06
+       p30 =  3.436721779020359e-05
+
+       p45 = -3.530687797132211e-11
+        p44 =  3.939867958963747e-09
+       p43 = -1.227668406985956e-08
+       p42 = -1.367469811838390e-05
+       p41 =  5.988240863928883e-04
+       p40 = -7.746288511324971e-03
+
+       p56 = -1.187982453329086e-13
+       p55 =  4.801984186231693e-11
+       p54 = -8.049200462388188e-09
+       p53 =  7.169872601310186e-07
+       p52 = -3.581694433758150e-05
+       p51 =  9.503919224192534e-04
+       p50 = -1.036679430885215e-02
+
+       p60 =  4.751256171799112e-05
+
+       if (uref >= 0.0 .and. uref < 5.9 ) then
+         znott = p00
+       elseif (uref >= 5.9 .and. uref <= 15.4) then
+         znott = p15*uref**5 + p14*uref**4 + p13*uref**3
+     &          + p12*uref**2 + p11*uref + p10
+       elseif (uref > 15.4 .and. uref <= 21.6) then
+         znott = p25*uref**5 + p24*uref**4 + p23*uref**3
+     &          + p22*uref**2 + p21*uref + p20
+       elseif (uref > 21.6 .and. uref <= 42.2) then
+         znott = p35*uref**5 + p34*uref**4 + p33*uref**3
+     &          + p32*uref**2 + p31*uref + p30
+       elseif ( uref > 42.2 .and. uref <= 53.3) then
+         znott = p45*uref**5 + p44*uref**4 + p43*uref**3
+     &          + p42*uref**2 + p41*uref + p40
+       elseif ( uref > 53.3 .and. uref <= 80.0) then
+         znott = p56*uref**6 + p55*uref**5 + p54*uref**4
+     &      + p53*uref**3 + p52*uref**2 + p51*uref + p50
+       elseif ( uref > 80.0) then
+         znott = p60
+       else
+         print*, 'Wrong input uref value:',uref
+        endif
+
+       END SUBROUTINE znot_t_v6
+
+
+       SUBROUTINE znot_m_v7(uref,znotm)
+        IMPLICIT NONE
+! Calculate areodynamical roughness over water with input 10-m wind
+! For low-to-moderate winds, try to match the Cd-U10 relationship from COARE V3.5 (Edson et al. 2013)
+! For high winds, try to fit available observational data
+! Comparing to znot_t_v6, slightly decrease Cd for higher wind speed
+!
+! Bin Liu, NOAA/NCEP/EMC 2018
+!
+! uref(m/s)   :   wind speed at 10-m height
+! znotm(meter):   areodynamical roughness scale over water
+!
+
+      REAL, INTENT(IN) :: uref
+      REAL, INTENT(OUT):: znotm
+      REAL             :: p13, p12, p11, p10
+      REAL             :: p25, p24, p23, p22, p21, p20
+      REAL             :: p35, p34, p33, p32, p31, p30
+      REAL             :: p40
+
+       p13 = -1.296521881682694e-02
+       p12 =  2.855780863283819e-01
+       p11 = -1.597898515251717e+00
+       p10 = -8.396975715683501e+00
+
+       p25 =  3.790846746036765e-10
+       p24 =  3.281964357650687e-09
+       p23 =  1.962282433562894e-07
+       p22 = -1.240239171056262e-06
+       p21 =  1.739759082358234e-07
+       p20 =  2.147264020369413e-05
+
+
+       p35 =  1.897534489606422e-07
+       p34 = -3.019495980684978e-05
+       p33 =  1.931392924987349e-03
+       p32 = -6.797293095862357e-02
+       p31 =  1.346757797103756e+00
+       p30 = -1.707846930193362e+01
+
+       p40 =  3.371427455376717e-04
+
+       if (uref >= 0.0 .and.  uref <= 6.5 ) then
+        znotm = exp( p10 + p11*uref + p12*uref**2 + p13*uref**3)
+       elseif (uref > 6.5 .and. uref <= 15.7) then
+        znotm = p25*uref**5 + p24*uref**4 + p23*uref**3 + 
+     &          p22*uref**2 + p21*uref + p20
+       elseif (uref > 15.7 .and. uref <= 53.0) then
+        znotm = exp( p35*uref**5 + p34*uref**4 + p33*uref**3 
+     &          + p32*uref**2 + p31*uref + p30 )
+       elseif ( uref > 53.0) then
+        znotm = p40
+       else
+        print*, 'Wrong input uref value:',uref
+       endif
+
+      END SUBROUTINE znot_m_v7
+      SUBROUTINE znot_t_v7(uref,znott)
+       IMPLICIT NONE
+! Calculate scalar roughness over water with input 10-m wind
+! For low-to-moderate winds, try to match the Ck-U10 relationship from COARE algorithm
+! For high winds, try to retain the Ck-U10 relationship of FY2015 HWRF
+! To be compatible with the slightly decreased Cd for higher wind speed
+!
+! Bin Liu, NOAA/NCEP/EMC 2018
+!
+! uref(m/s)   :   wind speed at 10-m height
+! znott(meter):   scalar roughness scale over water
+!
+
+        REAL, INTENT(IN) :: uref
+        REAL, INTENT(OUT):: znott
+
+        REAL             :: p00
+        REAL             :: p15, p14, p13, p12, p11, p10
+        REAL             :: p25, p24, p23, p22, p21, p20
+        REAL             :: p35, p34, p33, p32, p31, p30
+        REAL             :: p45, p44, p43, p42, p41, p40
+        REAL             :: p56, p55, p54, p53, p52, p51, p50
+        REAL             :: p60
+
+         p00 =  1.100000000000000e-04
+
+         p15 = -9.193764479895316e-10
+         p14 =  7.052217518653943e-08
+         p13 = -2.163419217747114e-06
+         p12 =  3.342963077911962e-05
+         p11 = -2.633566691328004e-04
+         p10 =  8.644979973037803e-04
+
+         p25 = -9.402722450219142e-12
+         p24 =  1.325396583616614e-09
+         p23 = -7.299148051141852e-08
+         p22 =  1.982901461144764e-06
+         p21 = -2.680293455916390e-05
+         p20 =  1.484341646128200e-04
+
+         p35 =  7.921446674311864e-12
+         p34 = -1.019028029546602e-09
+         p33 =  5.251986927351103e-08
+         p32 = -1.337841892062716e-06
+         p31 =  1.659454106237737e-05
+         p30 = -7.558911792344770e-05
+
+         p45 = -2.694370426850801e-10
+         p44 =  5.817362913967911e-08
+         p43 = -5.000813324746342e-06
+         p42 =  2.143803523428029e-04
+         p41 = -4.588070983722060e-03
+         p40 =  3.924356617245624e-02
+
+        p56 = -1.663918773476178e-13
+        p55 =  6.724854483077447e-11
+        p54 = -1.127030176632823e-08
+        p53 =  1.003683177025925e-06
+        p52 = -5.012618091180904e-05
+        p51 =  1.329762020689302e-03
+        p50 = -1.450062148367566e-02
+
+        p60 =  6.840803042788488e-05
+
+        if (uref >= 0.0 .and. uref < 5.9 ) then
+            znott = p00
+         elseif (uref >= 5.9 .and. uref <= 15.4) then
+           znott = p15*uref**5 + p14*uref**4 + p13*uref**3 + 
+     &             p12*uref**2 + p11*uref + p10
+         elseif (uref > 15.4 .and. uref <= 21.6) then
+           znott = p25*uref**5 + p24*uref**4 + p23*uref**3 + 
+     &             p22*uref**2 + p21*uref + p20
+         elseif (uref > 21.6 .and. uref <= 42.6) then
+           znott = p35*uref**5 + p34*uref**4 + p33*uref**3 + 
+     &             p32*uref**2 + p31*uref + p30
+         elseif ( uref > 42.6 .and. uref <= 53.0) then
+           znott = p45*uref**5 + p44*uref**4 + p43*uref**3 + 
+     &             p42*uref**2 + p41*uref + p40
+         elseif ( uref > 53.0 .and. uref <= 80.0) then
+           znott = p56*uref**6 + p55*uref**5 + p54*uref**4 + 
+     &             p53*uref**3 + p52*uref**2 + p51*uref + p50
+         elseif ( uref > 80.0) then
+           znott = p60
+        else
+           print*, 'Wrong input uref value:',uref
+         endif
+
+        END SUBROUTINE znot_t_v7
+
 
 !---------------------------------
       end module sfc_diff


### PR DESCRIPTION
Changes for the hurricane physics were recently made in the IPD version of GFS physics. This PR makes the corresponding changes in sfc_diff.f and adds a guard to prevent using the original moninedmf.f with the hurricane physics.

It is understood that the new moninedmf required to run the hurricane physics (moninedmf_hafs.f in IPD) should be combined with the existing moninedmf in CCPP to avoid the duplication of code. This will be addressed in a follow-up pull request when other schemes required for hurricane applications (e.g. Ferrier-Aligo microphysics) will be added.

This PR requires changes in the Vlab FV3 repository and must be merged at the same time (or afterwards), see issue https://vlab.ncep.noaa.gov/redmine/issues/66372.