### PR TITLE
remove loops over nblks in SCM-related GFS_phys_time_vary

### DIFF
--- a/physics/GFS_phys_time_vary.scm.F90
+++ b/physics/GFS_phys_time_vary.scm.F90
@@ -367,25 +367,19 @@
         sec_zero = nint(Model%fhzero*con_hr)
         if (sec_zero >= nint(max(Model%fhswr,Model%fhlwr))) then
           if (mod(Model%kdt,Model%nszero) == 1) then
-            do nb = 1,nblks
               call Diag%rad_zero  (Model)
               call Diag%phys_zero (Model)
         !!!!  THIS IS THE POINT AT WHICH DIAG%ZHOUR NEEDS TO BE UPDATED
-            enddo
           endif
         else
           if (mod(Model%kdt,Model%nszero) == 1) then
-            do nb = 1,nblks
               call Diag%phys_zero (Model)
         !!!!  THIS IS THE POINT AT WHICH DIAG%ZHOUR NEEDS TO BE UPDATED
-            enddo
           endif
           kdt_rad = nint(min(Model%fhswr,Model%fhlwr)/Model%dtp)
           if (mod(Model%kdt, kdt_rad) == 1) then
-            do nb = 1,nblks
               call Diag%rad_zero  (Model)
         !!!!  THIS IS THE POINT AT WHICH DIAG%ZHOUR NEEDS TO BE UPDATED
-            enddo
           endif
         endif
 


### PR DESCRIPTION
Loops over nblks are not needed (and result in compilation errors) for GFS_phys_time_vary.scm.F90.