### PR TITLE
Conditionally allocate Morrison-Gettelman arrays

### DIFF
--- a/physics/cs_conv.F90
+++ b/physics/cs_conv.F90
@@ -423,9 +423,13 @@ module cs_conv
    real(r8), intent(inout), dimension(IJSDIM,KMAX) :: ud_mf, dd_mf, dt_mf
    
    real(r8), intent(out)   :: rain1(IJSDIM)       ! lwe thickness of deep convective precipitation amount (m)
-   real(r8), intent(out), dimension(ijsdim,kmax) :: qlcn, qicn, w_upi,cnv_mfd,          &
+! GJF* These variables are conditionally allocated depending on whether the
+!     Morrison-Gettelman microphysics is used, so they must be declared 
+!     using assumed shape.
+   real(r8), intent(out), dimension(:,:) :: qlcn, qicn, w_upi,cnv_mfd,                  &
                                                     cnv_dqldt, clcn, cnv_fice,          &
                                                     cnv_ndrop, cnv_nice, cf_upi
+! *GJF
    integer, intent(inout) :: kcnv(im)             ! zero if no deep convection and 1 otherwise
    character(len=*), intent(out) :: errmsg
    integer,          intent(out) :: errflg

--- a/physics/m_micro.F90
+++ b/physics/m_micro.F90
@@ -297,10 +297,16 @@ end subroutine m_micro_init
      &                                       lwheat_i,swheat_i
        real (kind=kind_phys), dimension(ix,0:lm),intent(in):: prsi_i,   &
      &                                                        phii
-       real (kind=kind_phys), dimension(im,lm),intent(in)  ::           &
+! GJF* These variables are conditionally allocated depending on whether the
+!     Morrison-Gettelman microphysics is used, so they must be declared 
+!     using assumed shape.
+       real (kind=kind_phys), dimension(:,:),  intent(in)  ::           &
      &       CNV_DQLDT_i, CLCN_i,     QLCN_i, QICN_i,                   &
      &       CNV_MFD_i,               cf_upi, CNV_FICE_i, CNV_NDROP_i,  &
-     &       CNV_NICE_i,  w_upi, rhc_i, naai_i, npccn_i
+     &       CNV_NICE_i,  w_upi
+! *GJF
+       real (kind=kind_phys), dimension(im,lm),intent(in)  ::           &
+     &       rhc_i, naai_i, npccn_i
        real (kind=kind_phys), dimension(im,lm,ntrcaer),intent(in) ::    &
      &       aerfld_i
        real (kind=kind_phys),dimension(im),intent(in):: TAUGWX,         &
@@ -320,9 +326,13 @@ end subroutine m_micro_init
        integer, dimension(IM), intent(inout):: KCBL
        real (kind=kind_phys),dimension(ix,lm),intent(inout):: q_io, t_io,   &
      &                                             ncpl_io,ncpi_io,CLLS_io
-       real (kind=kind_phys),dimension(im,lm),intent(inout):: rnw_io,snw_io,&
+! GJF* These variables are conditionally allocated depending on whether the
+!     Morrison-Gettelman microphysics is used, so they must be declared 
+!     using assumed shape.
+       real (kind=kind_phys),dimension(:,:),intent(inout):: rnw_io,snw_io,&
      &                                             ncpr_io, ncps_io,        &
      &                                             qgl_io,  ncgl_io
+! *GJF
 !Moo   real (kind=kind_phys),dimension(im,lm),intent(inout):: CLLS_io
 
 

--- a/physics/samfdeepcnv.f
+++ b/physics/samfdeepcnv.f
@@ -168,10 +168,14 @@
       real(kind=kind_phys), intent(out) :: cldwrk(im),                  &
      &   rn(im),                                                        &
      &   ud_mf(im,km),dd_mf(im,km), dt_mf(im,km)
-
-      real(kind=kind_phys), dimension(im,km), intent(inout) ::          &
+      
+      ! GJF* These variables are conditionally allocated depending on whether the
+      !     Morrison-Gettelman microphysics is used, so they must be declared 
+      !     using assumed shape.
+      real(kind=kind_phys), dimension(:,:), intent(inout) ::          &
      &   qlcn, qicn, w_upi, cnv_mfd, cnv_dqldt, clcn                    &
      &,  cnv_fice, cnv_ndrop, cnv_nice, cf_upi
+      ! *GJF
       integer :: mp_phys, mp_phys_mg
 
       real(kind=kind_phys), intent(in) :: clam,    c0s,     c1,         &


### PR DESCRIPTION
Deep convection schemes use the Morrison-Gettelman arrays. Since they are conditionally allocated, make sure that the schemes that use them have assumed-shape dummy arguments.