### PR TITLE
Address issue #300

### DIFF
--- a/physics/GFS_surface_generic.F90
+++ b/physics/GFS_surface_generic.F90
@@ -272,7 +272,7 @@
 !! | xcosz          | instantaneous_cosine_of_zenith_angle                                                                                | cosine of zenith angle at current time                                              | none        |    1 | real       | kind_phys | in     | F        |
 !! | evbs           | soil_upward_latent_heat_flux                                                                                        | soil upward latent heat flux                                                        | W m-2       |    1 | real       | kind_phys | in     | F        |
 !! | evcw           | canopy_upward_latent_heat_flux                                                                                      | canopy upward latent heat flux                                                      | W m-2       |    1 | real       | kind_phys | in     | F        |
-!! | trans          | transpiration_flux                                                                                                  | total plant transpiration rate                                                      | kg m-2 s-1  |    1 | real       | kind_phys | in     | F        |
+!! | trans          | transpiration_flux                                                                                                  | total plant transpiration rate                                                      | W m-2       |    1 | real       | kind_phys | in     | F        |
 !! | sbsno          | snow_deposition_sublimation_upward_latent_heat_flux                                                                 | latent heat flux from snow depo/subl                                                | W m-2       |    1 | real       | kind_phys | in     | F        |
 !! | snowc          | surface_snow_area_fraction                                                                                          | surface snow area fraction                                                          | frac        |    1 | real       | kind_phys | in     | F        |
 !! | snohf          | snow_freezing_rain_upward_latent_heat_flux                                                                          | latent heat flux due to snow and frz rain                                           | W m-2       |    1 | real       | kind_phys | in     | F        |
@@ -322,8 +322,8 @@
 !! | ep             | cumulative_surface_upward_potential_latent_heat_flux_multiplied_by_timestep                                         | cumulative surface upward potential latent heat flux multiplied by timestep         | W m-2 s     |    1 | real       | kind_phys | inout  | F        |
 !! | runoff         | total_runoff                                                                                                        | total water runoff                                                                  | kg m-2      |    1 | real       | kind_phys | inout  | F        |
 !! | srunoff        | surface_runoff                                                                                                      | surface water runoff (from lsm)                                                     | kg m-2      |    1 | real       | kind_phys | inout  | F        |
-!! | runof          | surface_runoff_flux                                                                                                 | surface runoff flux                                                                 | g m-2 s-1   |    1 | real       | kind_phys | in     | F        |
-!! | drain          | subsurface_runoff_flux                                                                                              | subsurface runoff flux                                                              | g m-2 s-1   |    1 | real       | kind_phys | in     | F        |
+!! | runof          | surface_runoff_flux                                                                                                 | surface runoff flux                                                                 | kg m-2 s-1  |    1 | real       | kind_phys | in     | F        |
+!! | drain          | subsurface_runoff_flux                                                                                              | subsurface runoff flux                                                              | kg m-2 s-1  |    1 | real       | kind_phys | in     | F        |
 !! | errmsg         | ccpp_error_message                                                                                                  | error message for error handling in CCPP                                            | none        |    0 | character  | len=*     | out    | F        |
 !! | errflg         | ccpp_error_flag                                                                                                     | error flag for error handling in CCPP                                               | flag        |    0 | integer    |           | out    | F        |
 !!
@@ -365,7 +365,7 @@
         real(kind=kind_phys), parameter :: albdf   = 0.06d0
 
         integer :: i
-        real(kind=kind_phys) :: tem, xcosz_loc, ocalnirdf_cpl, ocalnirbm_cpl, ocalvisdf_cpl, ocalvisbm_cpl
+        real(kind=kind_phys) :: xcosz_loc, ocalnirdf_cpl, ocalnirbm_cpl, ocalvisdf_cpl, ocalvisbm_cpl
 
         ! Initialize CCPP error handling variables
         errmsg = ''
@@ -459,10 +459,9 @@
 !  --- ...  total runoff is composed of drainage into water table and
 !           runoff at the surface and is accumulated in unit of meters
         if (lssav) then
-          tem = dtf * 0.001
           do i=1,im
-            runoff(i)  = runoff(i)  + (drain(i)+runof(i)) * tem
-            srunoff(i) = srunoff(i) + runof(i) * tem
+            runoff(i)  = runoff(i)  + (drain(i)+runof(i)) * dtf
+            srunoff(i) = srunoff(i) + runof(i) * dtf
           enddo
         endif
 

--- a/physics/sfc_drv.f
+++ b/physics/sfc_drv.f
@@ -231,17 +231,17 @@
 !! | stc            | soil_temperature                                                             | soil temperature                                                | K             |    2 | real      | kind_phys | inout  | F        |
 !! | slc            | volume_fraction_of_unfrozen_soil_moisture                                    | volume fraction of unfrozen soil moisture                       | frac          |    2 | real      | kind_phys | inout  | F        |
 !! | canopy         | canopy_water_amount                                                          | canopy moisture content                                         | kg m-2        |    1 | real      | kind_phys | inout  | F        |
-!! | trans          | transpiration_flux                                                           | total plant transpiration rate                                  | kg m-2 s-1    |    1 | real      | kind_phys | inout  | F        |
+!! | trans          | transpiration_flux                                                           | total plant transpiration rate                                  | W m-2         |    1 | real      | kind_phys | inout  | F        |
 !! | tsurf          | surface_skin_temperature_after_iteration_over_land                           | surface skin temperature after iteration over land              | K             |    1 | real      | kind_phys | inout  | F        |
 !! | zorl           | surface_roughness_length_over_land_interstitial                              | surface roughness length over land  (temporary use as interstitial)  | cm       |    1 | real      | kind_phys | inout  | F        |
 !! | sncovr1        | surface_snow_area_fraction_over_land                                         | surface snow area fraction                                      | frac          |    1 | real      | kind_phys | inout  | F        |
 !! | qsurf          | surface_specific_humidity_over_land                                          | surface air saturation specific humidity over land              | kg kg-1       |    1 | real      | kind_phys | inout  | F        |
 !! | gflux          | upward_heat_flux_in_soil_over_land                                           | soil heat flux over land                                        | W m-2         |    1 | real      | kind_phys | inout  | F        |
-!! | drain          | subsurface_runoff_flux                                                       | subsurface runoff flux                                          | g m-2 s-1     |    1 | real      | kind_phys | inout  | F        |
+!! | drain          | subsurface_runoff_flux                                                       | subsurface runoff flux                                          | kg m-2 s-1    |    1 | real      | kind_phys | inout  | F        |
 !! | evap           | kinematic_surface_upward_latent_heat_flux_over_land                          | kinematic surface upward latent heat flux over land             | kg kg-1 m s-1 |    1 | real      | kind_phys | inout  | F        |
 !! | hflx           | kinematic_surface_upward_sensible_heat_flux_over_land                        | kinematic surface upward sensible heat flux over land           | K m s-1       |    1 | real      | kind_phys | inout  | F        |
 !! | ep             | surface_upward_potential_latent_heat_flux_over_land                          | surface upward potential latent heat flux over land             | W m-2         |    1 | real      | kind_phys | inout  | F        |
-!! | runoff         | surface_runoff_flux                                                          | surface runoff flux                                             | g m-2 s-1     |    1 | real      | kind_phys | inout  | F        |
+!! | runoff         | surface_runoff_flux                                                          | surface runoff flux                                             | kg m-2 s-1    |    1 | real      | kind_phys | inout  | F        |
 !! | cmm            | surface_drag_wind_speed_for_momentum_in_air_over_land                        | momentum exchange coefficient over land                         | m s-1         |    1 | real      | kind_phys | inout  | F        |
 !! | chh            | surface_drag_mass_flux_for_heat_and_moisture_in_air_over_land                | thermal exchange coefficient over land                          | kg m-2 s-1    |    1 | real      | kind_phys | inout  | F        |
 !! | evbs           | soil_upward_latent_heat_flux                                                 | soil upward latent heat flux                                    | W m-2         |    1 | real      | kind_phys | inout  | F        |
@@ -614,7 +614,7 @@
           trans(i) = ett
           sbsno(i) = esnow
           snowc(i) = sncovr
-          stm(i)   = soilm
+          stm(i)   = soilm * 1000.0 ! unit conversion (from m to kg m-2)
           snohf(i) = flx1 + flx2 + flx3
 
           smcwlt2(i) = smcwlt
@@ -630,7 +630,7 @@
           enddo
           wet1(i) = smsoil(1) / smcmax !Sarah Lu added 09/09/2010 (for GOCART)
 
-!  --- ...  unit conversion (from m s-1 to mm s-1)
+!  --- ...  unit conversion (from m s-1 to mm s-1 and kg m-2 s-1)
           runoff(i)  = runoff1 * 1000.0
           drain (i)  = runoff2 * 1000.0
 

--- a/physics/sfc_drv_ruc.F90
+++ b/physics/sfc_drv_ruc.F90
@@ -236,9 +236,9 @@ module lsm_ruc
 !! | evbs                 | soil_upward_latent_heat_flux                                                 | soil upward latent heat flux                                    | W m-2         |    1 | real      | kind_phys | out    | F        |
 !! | evcw                 | canopy_upward_latent_heat_flux                                               | canopy upward latent heat flux                                  | W m-2         |    1 | real      | kind_phys | out    | F        |
 !! | sbsno                | snow_deposition_sublimation_upward_latent_heat_flux                          | latent heat flux from snow depo/subl                            | W m-2         |    1 | real      | kind_phys | out    | F        |
-!! | trans                | transpiration_flux                                                           | total plant transpiration rate                                  | kg m-2 s-1    |    1 | real      | kind_phys | out    | F        |
-!! | runof                | surface_runoff_flux                                                          | surface runoff flux                                             | g m-2 s-1     |    1 | real      | kind_phys | out    | F        |
-!! | drain                | subsurface_runoff_flux                                                       | subsurface runoff flux                                          | g m-2 s-1     |    1 | real      | kind_phys | out    | F        |
+!! | trans                | transpiration_flux                                                           | total plant transpiration rate                                  | W m-2         |    1 | real      | kind_phys | out    | F        |
+!! | runof                | surface_runoff_flux                                                          | surface runoff flux                                             | kg m-2 s-1    |    1 | real      | kind_phys | out    | F        |
+!! | drain                | subsurface_runoff_flux                                                       | subsurface runoff flux                                          | kg m-2 s-1    |    1 | real      | kind_phys | out    | F        |
 !! | runoff               | total_runoff                                                                 | total water runoff                                              | kg m-2        |    1 | real      | kind_phys | inout  | F        |
 !! | srunoff              | surface_runoff                                                               | surface water runoff (from lsm)                                 | kg m-2        |    1 | real      | kind_phys | inout  | F        |
 !! | gflux                | upward_heat_flux_in_soil_over_land                                           | soil heat flux over land                                        | W m-2         |    1 | real      | kind_phys | out    | F        |
@@ -1032,12 +1032,12 @@ module lsm_ruc
         sfcdew(i)  = dew(i,j)
         qsurf(i)   = qsfc(i,j)
         sncovr1(i) = sncovr(i,j)
-        stm(i)     = soilm(i,j)
+        stm(i)     = soilm(i,j) * 1000.0 ! unit conversion (from m to kg m-2)
         tsurf(i)   = soilt(i,j)
         tice(i)    = tsurf(i)
-        !  --- ...  units [m/s] = [g m-2 s-1] 
-        runof (i)  = runoff1(i,j)
-        drain (i)  = runoff2(i,j)
+        
+        runof (i)  = runoff1(i,j) * 1000.0 ! unit conversion (from m s-1 to mm s-1 and kg m-2 s-1)
+        drain (i)  = runoff2(i,j) * 1000.0 ! unit conversion (from m s-1 to mm s-1 and kg m-2 s-1)
 
         wetness(i) = wet(i,j)
 
@@ -1048,8 +1048,8 @@ module lsm_ruc
         rhosnf(i) = rhosnfr(i,j)
 
         ! --- ... accumulated total runoff and surface runoff
-        runoff(i)  = runoff(i)  + (drain(i)+runof(i)) * delt * 0.001 ! kg m-2
-        srunoff(i) = srunoff(i) + runof(i) * delt * 0.001            ! kg m-2
+        runoff(i)  = runoff(i)  + (drain(i)+runof(i)) * delt          ! kg m-2
+        srunoff(i) = srunoff(i) + runof(i) * delt                     ! kg m-2
 
         ! --- ... accumulated frozen precipitation (accumulation in lsmruc)
         snowfallac(i) = snfallac(i,j) ! kg m-2


### PR DESCRIPTION
change units of runoff fluxes to kg m-2 s-1 in the metadata (and in the code for RUC LSM); change units of soil moisture content and runoff variables to kg m-2 (CCPP metadata had been in error and they only were in kg m-2 after a conversion in GFS_diagnostics.F90); should be merged with removal of conversion factor in GFS_diagnostics.F90 in FV3 repo