### PR TITLE
ccpp_prebuild: out-of-source builds for parallel cmake builds (target master)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,12 +123,25 @@ set(SCHEMES2 ${SCHEMES})
 #------------------------------------------------------------------------------
 if (${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-none")
-  SET_SOURCE_FILES_PROPERTIES(./physics/module_bfmicrophysics.f ./physics/sflx.f ./physics/sfc_diff.f ./physics/sfc_diag.f PROPERTIES COMPILE_FLAGS -fdefault-real-8)
-  SET_SOURCE_FILES_PROPERTIES(./physics/module_nst_model.f90 ./physics/calpreciptype.f90 PROPERTIES COMPILE_FLAGS "-fdefault-real-8 -ffree-form")
-  SET_SOURCE_FILES_PROPERTIES(./physics/mersenne_twister.f PROPERTIES COMPILE_FLAGS "-fdefault-real-8 -fno-range-check")
-  SET_SOURCE_FILES_PROPERTIES(./physics/module_nst_water_prop.f90 PROPERTIES COMPILE_FLAGS "-ffree-line-length-none -fdefault-real-8 -ffree-form")
-  SET_SOURCE_FILES_PROPERTIES(./physics/aer_cloud.F ./physics/wv_saturation.F ./physics/cldwat2m_micro.F ./physics/surface_perturbation.F90 PROPERTIES COMPILE_FLAGS "-fdefault-real-8 -fdefault-double-8")
-  SET_SOURCE_FILES_PROPERTIES(./physics/module_mp_thompson_make_number_concentrations.F90 PROPERTIES COMPILE_FLAGS "-fdefault-real-8 -fdefault-double-8")
+  SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/physics/module_bfmicrophysics.f
+                              ${CMAKE_CURRENT_SOURCE_DIR}/physics/sflx.f
+                              ${CMAKE_CURRENT_SOURCE_DIR}/physics/sfc_diff.f
+                              ${CMAKE_CURRENT_SOURCE_DIR}/physics/sfc_diag.f
+                              PROPERTIES COMPILE_FLAGS -fdefault-real-8)
+  SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/physics/module_nst_model.f90
+                              ${CMAKE_CURRENT_SOURCE_DIR}/physics/calpreciptype.f90
+                              PROPERTIES COMPILE_FLAGS "-fdefault-real-8 -ffree-form")
+  SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/physics/mersenne_twister.f
+                              PROPERTIES COMPILE_FLAGS "-fdefault-real-8 -fno-range-check")
+  SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/physics/module_nst_water_prop.f90
+                              PROPERTIES COMPILE_FLAGS "-ffree-line-length-none -fdefault-real-8 -ffree-form")
+  SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/physics/aer_cloud.F
+                              ${CMAKE_CURRENT_SOURCE_DIR}/physics/wv_saturation.F
+                              ${CMAKE_CURRENT_SOURCE_DIR}/physics/cldwat2m_micro.F
+                              ${CMAKE_CURRENT_SOURCE_DIR}/physics/surface_perturbation.F90
+                              PROPERTIES COMPILE_FLAGS "-fdefault-real-8 -fdefault-double-8")
+  SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/physics/module_mp_thompson_make_number_concentrations.F90
+                              PROPERTIES COMPILE_FLAGS "-fdefault-real-8 -fdefault-double-8")
 
   if (PROJECT STREQUAL "CCPP-FV3")
     # Set 32-bit floating point precision flags for certain files
@@ -140,10 +153,10 @@ if (${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
              CMAKE_Fortran_FLAGS_PREC32 "${CMAKE_Fortran_FLAGS_PREC32}")
       string(REPLACE "-fdefault-double-8" ""
              CMAKE_Fortran_FLAGS_PREC32 "${CMAKE_Fortran_FLAGS_PREC32}")
-      SET_PROPERTY(SOURCE ./physics/gfdl_fv_sat_adj.F90
+      SET_PROPERTY(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/physics/gfdl_fv_sat_adj.F90
                    APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_PREC32} ")
       # Add all of the above files to the list of schemes with special floating point precision flags
-      list(APPEND SCHEMES_SFX_PREC ./physics/gfdl_fv_sat_adj.F90)
+      list(APPEND SCHEMES_SFX_PREC ${CMAKE_CURRENT_SOURCE_DIR}/physics/gfdl_fv_sat_adj.F90)
     endif (DYN32)
 
     # Remove files with special floating point precision flags from list
@@ -159,28 +172,28 @@ if (${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
 elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
   # Adjust settings for bit-for-bit reproducibility of NEMSfv3gfs
   if (PROJECT STREQUAL "CCPP-FV3")
-    SET_SOURCE_FILES_PROPERTIES(./physics/module_bfmicrophysics.f
-                                ./physics/sflx.f
-                                ./physics/sfc_diff.f
-                                ./physics/sfc_diag.f
-                                ./physics/module_nst_model.f90
-                                ./physics/calpreciptype.f90
-                                ./physics/mersenne_twister.f
-                                ./physics/module_nst_water_prop.f90
-                                ./physics/aer_cloud.F
-                                ./physics/wv_saturation.F
-                                ./physics/cldwat2m_micro.F
-                                ./physics/surface_perturbation.F90
-                                ./physics/radiation_aerosols.f
-                                ./physics/cu_gf_deep.F90
-                                ./physics/cu_gf_sh.F90
-                                ./physics/module_bl_mynn.F90
-                                ./physics/module_MYNNPBL_wrapper.F90
-                                ./physics/module_sf_mynn.F90
-                                ./physics/module_MYNNSFC_wrapper.F90
-                                ./physics/module_MYNNrad_pre.F90
-                                ./physics/module_MYNNrad_post.F90
-                                ./physics/module_mp_thompson_make_number_concentrations.F90
+    SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/physics/module_bfmicrophysics.f
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/sflx.f
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/sfc_diff.f
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/sfc_diag.f
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/module_nst_model.f90
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/calpreciptype.f90
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/mersenne_twister.f
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/module_nst_water_prop.f90
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/aer_cloud.F
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/wv_saturation.F
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/cldwat2m_micro.F
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/surface_perturbation.F90
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/radiation_aerosols.f
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/cu_gf_deep.F90
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/cu_gf_sh.F90
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/module_bl_mynn.F90
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/module_MYNNPBL_wrapper.F90
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/module_sf_mynn.F90
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/module_MYNNSFC_wrapper.F90
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/module_MYNNrad_pre.F90
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/module_MYNNrad_post.F90
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/module_mp_thompson_make_number_concentrations.F90
                                 PROPERTIES COMPILE_FLAGS "-r8 -ftz")
 
     # Replace -xHost or -xCORE-AVX2 with -xCORE-AVX-I for certain files
@@ -194,10 +207,10 @@ elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
     string(REPLACE "-axSSE4.2,AVX,CORE-AVX2,CORE-AVX512" "-axSSE4.2,AVX,CORE-AVX-I"
            CMAKE_Fortran_FLAGS_LOPT1
            "${CMAKE_Fortran_FLAGS_LOPT1}")
-    SET_SOURCE_FILES_PROPERTIES(./physics/radiation_aerosols.f
+    SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/physics/radiation_aerosols.f
                                 PROPERTIES COMPILE_FLAGS "${CMAKE_Fortran_FLAGS_LOPT1}")
     # Add all of the above files to the list of schemes with special compiler flags
-    list(APPEND SCHEMES_SFX_OPT ./physics/radiation_aerosols.f)
+    list(APPEND SCHEMES_SFX_OPT ${CMAKE_CURRENT_SOURCE_DIR}/physics/radiation_aerosols.f)
 
     # Force consistent results of math calculations for MG microphysics;
     # in Debug/Bitforbit mode; without this flag, the results of the
@@ -258,10 +271,10 @@ elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
       set(CMAKE_Fortran_FLAGS_PREC32 ${CMAKE_Fortran_FLAGS_DEFAULT_PREC})
       string(REPLACE "-real-size 64" "-real-size 32"
              CMAKE_Fortran_FLAGS_PREC32 "${CMAKE_Fortran_FLAGS_PREC32}")
-      SET_PROPERTY(SOURCE ./physics/gfdl_fv_sat_adj.F90
+      SET_PROPERTY(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/physics/gfdl_fv_sat_adj.F90
                    APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_PREC32} ")
       # Add all of the above files to the list of schemes with special floating point precision flags
-      list(APPEND SCHEMES_SFX_PREC ./physics/gfdl_fv_sat_adj.F90)
+      list(APPEND SCHEMES_SFX_PREC ${CMAKE_CURRENT_SOURCE_DIR}/physics/gfdl_fv_sat_adj.F90)
     endif (DYN32)
 
     # Remove files with special floating point precision flags from list
@@ -274,19 +287,44 @@ elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
                  APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_DEFAULT_PREC} ")
 
   else (PROJECT STREQUAL "CCPP-FV3")
-    SET_SOURCE_FILES_PROPERTIES(./physics/module_bfmicrophysics.f ./physics/sflx.f ./physics/sfc_diff.f ./physics/sfc_diag.f PROPERTIES COMPILE_FLAGS -r8)
-    SET_SOURCE_FILES_PROPERTIES(./physics/module_nst_model.f90 ./physics/calpreciptype.f90 PROPERTIES COMPILE_FLAGS "-r8 -free")
-    SET_SOURCE_FILES_PROPERTIES(./physics/mersenne_twister.f PROPERTIES COMPILE_FLAGS "-r8 -ftz")
-    SET_SOURCE_FILES_PROPERTIES(./physics/module_nst_water_prop.f90 PROPERTIES COMPILE_FLAGS "-extend-source 132 -r8 -free")
-    SET_SOURCE_FILES_PROPERTIES(./physics/aer_cloud.F ./physics/wv_saturation.F ./physics/cldwat2m_micro.F ./physics/surface_perturbation.F90 PROPERTIES COMPILE_FLAGS "-r8")
+    SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/physics/module_bfmicrophysics.f
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/sflx.f
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/sfc_diff.f
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/sfc_diag.f
+                                PROPERTIES COMPILE_FLAGS -r8)
+    SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/physics/module_nst_model.f90
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/calpreciptype.f90
+                                PROPERTIES COMPILE_FLAGS "-r8 -free")
+    SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/physics/mersenne_twister.f
+                                PROPERTIES COMPILE_FLAGS "-r8 -ftz")
+    SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/physics/module_nst_water_prop.f90
+                                PROPERTIES COMPILE_FLAGS "-extend-source 132 -r8 -free")
+    SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/physics/aer_cloud.F
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/wv_saturation.F
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/cldwat2m_micro.F
+                                ${CMAKE_CURRENT_SOURCE_DIR}/physics/surface_perturbation.F90
+                                PROPERTIES COMPILE_FLAGS "-r8")
   endif (PROJECT STREQUAL "CCPP-FV3")
 elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI")
-  SET_SOURCE_FILES_PROPERTIES(./physics/module_bfmicrophysics.f ./physics/sflx.f ./physics/sfc_diff.f ./physics/sfc_diag.f PROPERTIES COMPILE_FLAGS -r8)
-  SET_SOURCE_FILES_PROPERTIES(./physics/module_nst_model.f90 ./physics/calpreciptype.f90 PROPERTIES COMPILE_FLAGS "-r8 -Mfree")
-  SET_SOURCE_FILES_PROPERTIES(./physics/mersenne_twister.f PROPERTIES COMPILE_FLAGS "-r8 -Mnofptrap")
-  SET_SOURCE_FILES_PROPERTIES(./physics/module_nst_water_prop.f90 PROPERTIES COMPILE_FLAGS "-r8 -Mfree")
-  SET_SOURCE_FILES_PROPERTIES(./physics/aer_cloud.F ./physics/wv_saturation.F ./physics/cldwat2m_micro.F ./physics/surface_perturbation.F90 PROPERTIES COMPILE_FLAGS "-r8")
-  SET_SOURCE_FILES_PROPERTIES(./physics/module_mp_thompson_make_number_concentrations.F90 PROPERTIES COMPILE_FLAGS "-r8")
+  SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/physics/module_bfmicrophysics.f
+                              ${CMAKE_CURRENT_SOURCE_DIR}/physics/sflx.f
+                              ${CMAKE_CURRENT_SOURCE_DIR}/physics/sfc_diff.f
+                              ${CMAKE_CURRENT_SOURCE_DIR}/physics/sfc_diag.f
+                              PROPERTIES COMPILE_FLAGS -r8)
+  SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/physics/module_nst_model.f90
+                              ${CMAKE_CURRENT_SOURCE_DIR}/physics/calpreciptype.f90
+                              PROPERTIES COMPILE_FLAGS "-r8 -Mfree")
+  SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/physics/mersenne_twister.f
+                              PROPERTIES COMPILE_FLAGS "-r8 -Mnofptrap")
+  SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/physics/module_nst_water_prop.f90
+                              PROPERTIES COMPILE_FLAGS "-r8 -Mfree")
+  SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/physics/aer_cloud.F
+                              ${CMAKE_CURRENT_SOURCE_DIR}/physics/wv_saturation.F
+                              ${CMAKE_CURRENT_SOURCE_DIR}/physics/cldwat2m_micro.F
+                              ${CMAKE_CURRENT_SOURCE_DIR}/physics/surface_perturbation.F90
+                              PROPERTIES COMPILE_FLAGS "-r8")
+  SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/physics/module_mp_thompson_make_number_concentrations.F90
+                              PROPERTIES COMPILE_FLAGS "-r8")
   if (PROJECT STREQUAL "CCPP-FV3")
     # Set 32-bit floating point precision flags for certain files
     # that are executed in the dynamics (fast physics part)
@@ -295,10 +333,10 @@ elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI")
       set(CMAKE_Fortran_FLAGS_PREC32 ${CMAKE_Fortran_FLAGS_DEFAULT_PREC})
       string(REPLACE "-r8" "-r4"
              CMAKE_Fortran_FLAGS_PREC32 "${CMAKE_Fortran_FLAGS_PREC32}")
-      SET_PROPERTY(SOURCE ./physics/gfdl_fv_sat_adj.F90
+      SET_PROPERTY(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/physics/gfdl_fv_sat_adj.F90
                    APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_PREC32} ")
       # Add all of the above files to the list of schemes with special floating point precision flags
-      list(APPEND SCHEMES_SFX_PREC ./physics/gfdl_fv_sat_adj.F90)
+      list(APPEND SCHEMES_SFX_PREC ${CMAKE_CURRENT_SOURCE_DIR}/physics/gfdl_fv_sat_adj.F90)
     endif (DYN32)
 
     # Remove files with special floating point precision flags from list

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,9 +97,23 @@ list(APPEND LIBS "ccpp")
 
 #------------------------------------------------------------------------------
 # Set the sources: physics schemes
-include(./CCPP_SCHEMES.cmake)
+set(SCHEMES $ENV{CCPP_SCHEMES})
+if(SCHEMES)
+  message(INFO "Got CCPP_SCHEMES from environment variable: ${SCHEMES}")
+else(SCHEMES)
+  include(./CCPP_SCHEMES.cmake)
+  message(INFO "Got SCHEMES from cmakefile include file: ${SCHEMES}")
+endif(SCHEMES)
+
 # Set the sources: physics scheme caps
-include(./CCPP_CAPS.cmake)
+set(CAPS $ENV{CCPP_CAPS})
+if(CAPS)
+  message(INFO "Got CAPS from environment variable: ${CAPS}")
+else(CAPS)
+  include(./CCPP_CAPS.cmake)
+  message(INFO "Got CAPS from cmakefile include file: ${CAPS}")
+endif(CAPS)
+
 # Create empty lists for schemes with special compiler optimization flags
 set(SCHEMES_SFX_OPT "")
 # Create empty lists for schemes with special floating point precision flags
@@ -334,7 +348,7 @@ if(STATIC)
   foreach(source_f90 ${CAPS})
       string(REGEX REPLACE ".F90" ".mod" tmp_module_f90 ${source_f90})
       string(TOLOWER ${tmp_module_f90} module_f90)
-      list(APPEND MODULES_F90 ${CMAKE_CURRENT_BINARY_DIR}/../${module_f90})
+      list(APPEND MODULES_F90 ${CMAKE_CURRENT_BINARY_DIR}/${module_f90})
   endforeach()
 else(STATIC)
   add_library(ccppphys SHARED ${SCHEMES} ${SCHEMES_SFX_OPT} ${CAPS})


### PR DESCRIPTION
Modifications of CMakeLists.txt to support out-of-source builds, required for parallel cmake builds in NEMSfv3gfs.

Backward compatible for in-source builds for both static and dynamic builds.