### PR TITLE
Remove TRANSITION mode, fix local kind definitions in MYJ SFC/PBL schemes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,52 +187,6 @@ elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
     # Add all of the above files to the list of schemes with special compiler flags
     list(APPEND SCHEMES_SFX_OPT ./physics/radiation_aerosols.f)
 
-    # Force consistent results of math calculations for MG microphysics;
-    # in Debug/Bitforbit mode; without this flag, the results of the
-    # intrinsic gamma function are different for the non-CCPP and CCPP
-    # version (on Theia with Intel 18). Note this is only required for
-    # the dynamic CCPP build, not for the static CCPP build.
-    if (TRANSITION)
-      # Replace -xHost or -xCORE-AVX2 with -xCORE-AVX-I, -no-prec-div with -prec-div, and
-      # -no-prec-sqrt with -prec-sqrt for certain files for bit-for-bit reproducibility
-      # with non-CCPP builds. These may go in the future once the CCPP solution is fully accepted.
-      set(CMAKE_Fortran_FLAGS_LOPT2 ${CMAKE_Fortran_FLAGS_OPT})
-      string(REPLACE "-no-prec-div" "-prec-div"
-             CMAKE_Fortran_FLAGS_LOPT2
-             "${CMAKE_Fortran_FLAGS_LOPT2}")
-      string(REPLACE "-no-prec-sqrt" "-prec-sqrt"
-             CMAKE_Fortran_FLAGS_LOPT2
-             "${CMAKE_Fortran_FLAGS_LOPT2}")
-      string(REPLACE "-xCORE-AVX2" "-xCORE-AVX-I"
-             CMAKE_Fortran_FLAGS_LOPT2
-             "${CMAKE_Fortran_FLAGS_LOPT2}")
-      string(REPLACE "-axSSE4.2,AVX,CORE-AVX2" "-axSSE4.2,AVX,CORE-AVX-I"
-             CMAKE_Fortran_FLAGS_LOPT2
-             "${CMAKE_Fortran_FLAGS_LOPT2}")
-      SET_SOURCE_FILES_PROPERTIES(./physics/micro_mg2_0.F90
-                                  ./physics/micro_mg3_0.F90
-                                  ./physics/aer_cloud.F
-                                  ./physics/cldmacro.F
-                                  ./physics/gfdl_fv_sat_adj.F90
-                                  ./physics/module_gfdl_cloud_microphys.F90
-                                  ./physics/sflx.f
-                                  ./physics/satmedmfvdif.F
-                                  ./physics/cs_conv.F90
-                                  ./physics/gcm_shoc.F90
-                                  PROPERTIES COMPILE_FLAGS "${CMAKE_Fortran_FLAGS_LOPT2}")
-      # Add all of the above files to the list of schemes with special compiler flags
-      list(APPEND SCHEMES_SFX_OPT ./physics/micro_mg2_0.F90
-                              ./physics/micro_mg3_0.F90
-                              ./physics/aer_cloud.F
-                              ./physics/cldmacro.F
-                              ./physics/module_gfdl_cloud_microphys.F90
-                              ./physics/sflx.f
-                              ./physics/satmedmfvdif.F
-                              ./physics/cs_conv.F90
-                              ./physics/gcm_shoc.F90
-                              ./physics/gfdl_fv_sat_adj.F90)
-    endif (TRANSITION)
-
     # Remove files with special compiler flags from list of files with standard compiler flags
     list(REMOVE_ITEM SCHEMES ${SCHEMES_SFX_OPT})
     # Assign standard compiler flags to all remaining schemes and caps

--- a/physics/gfdl_cloud_microphys.F90
+++ b/physics/gfdl_cloud_microphys.F90
@@ -170,9 +170,6 @@ contains
       real(kind=kind_phys), dimension(:,:), allocatable :: den
       real(kind=kind_phys) :: onebg
       real(kind=kind_phys) :: tem
-#ifdef TRANSITION
-      real(kind=kind_phys), volatile :: volatile_var1, volatile_var2
-#endif
 
       ! Initialize CCPP error handling variables
       errmsg = ''
@@ -260,18 +257,10 @@ contains
       ! calculate fraction of frozen precipitation using unscaled
       ! values of rain0, ice0, snow0, graupel0 (for bit-for-bit)
       do i=1,im
-#ifdef TRANSITION
-        volatile_var1 = rain0(i)+snow0(i)+ice0(i)+graupel0(i)
-        volatile_var2 = snow0(i)+ice0(i)+graupel0(i)
-        prcp0(i) = volatile_var1 * tem
-        if ( volatile_var1 * tem > rainmin ) then
-          sr(i) = volatile_var2 / volatile_var1
-#else
         prcp0(i) = (rain0(i)+snow0(i)+ice0(i)+graupel0(i)) * tem
         if ( prcp0(i) > rainmin ) then
           sr(i) = (snow0(i) + ice0(i)  + graupel0(i)) &
                       / (rain0(i) + snow0(i) + ice0(i) + graupel0(i))
-#endif
         else
           sr(i) = 0.0
         endif

--- a/physics/gfdl_fv_sat_adj.F90
+++ b/physics/gfdl_fv_sat_adj.F90
@@ -296,10 +296,6 @@ subroutine fv_sat_adj_run(mdt, zvir, is, ie, isd, ied, kmp, km, kmdelz, js, je, 
 
     ! Local variables
     real(kind=kind_dyn), dimension(is:ie,js:je) :: dpln
-#ifdef TRANSITION
-    ! For bit-for-bit reproducibility
-    real(kind=kind_dyn), volatile :: volatile_var
-#endif
     integer :: kdelz
     integer :: k, j, i
 
@@ -317,9 +313,6 @@ subroutine fv_sat_adj_run(mdt, zvir, is, ie, isd, ied, kmp, km, kmdelz, js, je, 
 !$OMP                 ql,qv,te0,fast_mp_consv,     &
 !$OMP                 hydrostatic,ng,zvir,pkz,     &
 !$OMP                 akap,te0_2d,ngas,qvi)        &
-#ifdef TRANSITION
-!$OMP          private(volatile_var)               &
-#endif
 !$OMP          private(k,j,i,kdelz,dpln)
 #endif
 
@@ -351,27 +344,12 @@ subroutine fv_sat_adj_run(mdt, zvir, is, ie, isd, ied, kmp, km, kmdelz, js, je, 
           do j=js,je
              do i=is,ie
 #ifdef MOIST_CAPPA
-#ifdef TRANSITION
-               volatile_var = log(rrg*delp(i,j,k)/delz(i,j,k)*pt(i,j,k))
-               pkz(i,j,k) = exp(cappa(i,j,k)*volatile_var)
-#else
                pkz(i,j,k) = exp(cappa(i,j,k)*log(rrg*delp(i,j,k)/delz(i,j,k)*pt(i,j,k)))
-#endif
-#else
-#ifdef TRANSITION
-#ifdef MULTI_GASES
-               volatile_var = log(rrg*delp(i,j,k)/delz(i,j,k)*pt(i,j,k))
-               pkz(i,j,k) = exp(akap*(virqd(q(i,j,k,1:num_gas))/vicpqd(q(i,j,k,1:num_gas))*volatile_var)
-#else
-               volatile_var = log(rrg*delp(i,j,k)/delz(i,j,k)*pt(i,j,k))
-               pkz(i,j,k) = exp(akap*volatile_var)
-#endif
 #else
 #ifdef MULTI_GASES
                pkz(i,j,k) = exp(akap*(virqd(q(i,j,k,1:num_gas))/vicpqd(q(i,j,k,1:num_gas))*log(rrg*delp(i,j,k)/delz(i,j,k)*pt(i,j,k)))
 #else
                pkz(i,j,k) = exp(akap*log(rrg*delp(i,j,k)/delz(i,j,k)*pt(i,j,k)))
-#endif
 #endif
 #endif
              enddo

--- a/physics/machine.F
+++ b/physics/machine.F
@@ -20,6 +20,7 @@
      &,                     kind_phys = 8     ,kind_taum=8              &
      &,                     kind_grid = 8                               &
      &,                     kind_REAL = 8                               &! used in cmp_comm
+     &,                     kind_LOGICAL = 4                            &
      &,                     kind_INTEGER = 4                             ! -,,-
 
 #else
@@ -34,6 +35,7 @@
      &,                     kind_phys = 4     ,kind_taum=4              &
      &,                     kind_grid = 4                               &
      &,                     kind_REAL = 4                               &! used in cmp_comm
+     &,                     kind_LOGICAL = 4                            &
      &,                     kind_INTEGER = 4                             ! -,,-
 
 #endif

--- a/physics/machine.meta
+++ b/physics/machine.meta
@@ -19,3 +19,15 @@
   units = none
   dimensions = ()
   type = integer
+[kind_LOGICAL]
+  standard_name = kind_LOGICAL
+  long_name = definition of kind_LOGICAL
+  units = none
+  dimensions = ()
+  type = integer
+[kind_INTEGER]
+  standard_name = kind_INTEGER
+  long_name = definition of kind_INTEGER
+  units = none
+  dimensions = ()
+  type = integer

--- a/physics/module_BL_MYJPBL.F90
+++ b/physics/module_BL_MYJPBL.F90
@@ -15,6 +15,10 @@
 !                                 ,G,P608,PI,PQ0,R_D,R_V,RHOWATER        &
 !                                 ,STBOLT,CAPPA
 
+      USE machine, only: kfpt => kind_phys,    &
+                         kint => kind_INTEGER, &
+                         klog => kind_LOGICAL
+
 !-----------------------------------------------------------------------
 !
       IMPLICIT NONE
@@ -36,12 +40,12 @@
 !       real   (kind=kdbl),parameter :: r8_in=x'fff7ffffffffffff'
 !       integer(kind=kint),parameter :: i4_in=-999  ! -huge(1)
 
-       integer,parameter:: &
-         klog=4 &                   ! logical variables
-        ,kint=4 &                   ! integer variables
-        !,kfpt=4 &                   ! floating point variables
-        ,kfpt=8 &                   ! floating point variables
-        ,kdbl=8                     ! double precision
+      ! integer,parameter:: &
+      !   klog=4 &                   ! logical variables
+      !  ,kint=4 &                   ! integer variables
+      !  !,kfpt=4 &                   ! floating point variables
+      !  ,kfpt=8 &                   ! floating point variables
+      !  ,kdbl=8                     ! double precision
 
       REAL(kind=kfpt),PARAMETER :: A2=17.2693882,A3=273.15,A4=35.86,CP=1004.6      &
                        ,ELIV=2.850e6,ELWV=2.501e6,R_V=461.6             &

--- a/physics/module_MYJPBL_wrapper.F90
+++ b/physics/module_MYJPBL_wrapper.F90
@@ -3,6 +3,9 @@
 
       MODULE myjpbl_wrapper
 
+      USE machine, only: kfpt => kind_phys, &
+                         kind_phys
+
       contains
 
       subroutine myjpbl_wrapper_init ()
@@ -13,11 +16,9 @@
 
 !!
 !> \brief This scheme (1) performs pre-myjpbl work, (2) runs the myjpbl, and (3) performs post-myjpbl work
-#if 0
 !! \section arg_table_myjpbl_wrapper_run Argument Table
 !! \htmlinclude myjpbl_wrapper_run.html
 !!
-#endif
 !###===================================================================
   SUBROUTINE myjpbl_wrapper_run(                    &
      &  restart,do_myjsfc,                           &
@@ -42,19 +43,18 @@
      &  me, lprnt, errmsg, errflg )
 
 !
-      use machine,      only : kind_phys
 
       use MODULE_BL_MYJPBL,      only: MYJPBL_INIT,MYJPBL
 
 !-------------------------------------------------------------------
       implicit none
 
-      integer,parameter:: &
-        klog=4 &                   ! logical variables
-       ,kint=4 &                   ! integer variables
-       !,kfpt=4 &                   ! floating point variables
-       ,kfpt=8 &                   ! floating point variables
-       ,kdbl=8                     ! double precision
+!      integer,parameter:: &
+!        klog=4 &                   ! logical variables
+!       ,kint=4 &                   ! integer variables
+!       !,kfpt=4 &                   ! floating point variables
+!       ,kfpt=8 &                   ! floating point variables
+!       ,kdbl=8                     ! double precision
 
 !-------------------------------------------------------------------
 !  ---  constant parameters:
@@ -121,7 +121,7 @@
       integer :: i_min, i_max, k_min, k_max
 
       logical :: lprnt1,lprnt2
-      integer (kind=kint) :: ict, ide, lm, me1
+      integer :: ict, ide, lm, me1
       real(kind=kfpt) :: dt_myj, tem, tem1, tem2, ptem
       integer,dimension(im) :: kpbl_myj
       real(kind=kfpt),dimension(1:levs-1):: epsl

--- a/physics/module_MYJSFC_wrapper.F90
+++ b/physics/module_MYJSFC_wrapper.F90
@@ -3,6 +3,9 @@
 
       MODULE myjsfc_wrapper
 
+      USE machine, only: kfpt => kind_phys, &
+                         kind_phys
+
       contains
 
       subroutine myjsfc_wrapper_init ()
@@ -47,19 +50,19 @@
      &  wind,      con_cp,    con_g,    con_rd,    &
      &  me, lprnt, errmsg, errflg )             ! intent(inout)
 !
-      use machine,        only : kind_phys
+
       use MODULE_SF_JSFC, only: JSFC_INIT,JSFC
 
 !-------------------------------------------------------------------
       implicit none
 !-------------------------------------------------------------------
 
-      integer,parameter:: &
-         klog=4 &                   ! logical variables
-        ,kint=4 &                   ! integer variables
-        !,kfpt=4 &                   ! floating point variables
-        ,kfpt=8 &                   ! floating point variables
-        ,kdbl=8                     ! double precision
+!      integer,parameter:: &
+!         klog=4 &                   ! logical variables
+!        ,kint=4 &                   ! integer variables
+!        !,kfpt=4 &                   ! floating point variables
+!        ,kfpt=8 &                   ! floating point variables
+!        ,kdbl=8                     ! double precision
 !
 !  ---  constant parameters:
 !      real(kind=kind_phys), parameter :: karman  = 0.4

--- a/physics/module_SF_JSFC.F90
+++ b/physics/module_SF_JSFC.F90
@@ -15,6 +15,9 @@
 !
 !-----------------------------------------------------------------------
 !
+
+      USE machine, only: kfpt => kind_phys
+
       IMPLICIT NONE
 !
 !-----------------------------------------------------------------------
@@ -35,12 +38,12 @@
 !       real   (kind=kdbl),parameter :: r8_in=x'fff7ffffffffffff'
 !       integer(kind=kint),parameter :: i4_in=-999  ! -huge(1)
 !
-       integer,parameter:: &
-         klog=4 &                   ! logical variables
-        ,kint=4 &                   ! integer variables
-        !,kfpt=4 &                   ! floating point variables
-        ,kfpt=8 &                   ! floating point variables
-        ,kdbl=8                     ! double precision
+      ! integer,parameter:: &
+      !   klog=4 &                   ! logical variables
+      !  ,kint=4 &                   ! integer variables
+      !  !,kfpt=4 &                   ! floating point variables
+      !  ,kfpt=8 &                   ! floating point variables
+      !  ,kdbl=8                     ! double precision
 !
       PRIVATE
 !


### PR DESCRIPTION
Changes:

- remove all code related to the deprecated TRANSITION mode for Theia+Intel15
- clean up the local kind definitions for new MYJ SFC/PBL schemes by importing them from machine.F (and adding them to this module if necessary)

For regression testing, see NCAR/NEMSfv3gfs#251