### PR TITLE
Update GFSv16 changes to new metadata format

### DIFF
--- a/physics/GFS_debug.F90
+++ b/physics/GFS_debug.F90
@@ -41,7 +41,23 @@
       end subroutine GFS_diagtoscreen_finalize
 
 !> \section arg_table_GFS_diagtoscreen_run Argument Table
-!! \htmlinclude GFS_diagtoscreen_run.html
+!! | local_name     | standard_name                                          | long_name                                               | units         | rank | type                  |    kind   | intent | optional |
+!! |----------------|--------------------------------------------------------|---------------------------------------------------------|---------------|------|-----------------------|-----------|--------|----------|
+!! | Model          | GFS_control_type_instance                              | instance of derived type GFS_control_type in FV3        | DDT           |    0 | GFS_control_type      |           | in     | F        |
+!! | Statein        | GFS_statein_type_instance                              | instance of derived type GFS_statein_type in FV3        | DDT           |    0 | GFS_statein_type      |           | in     | F        |
+!! | Stateout       | GFS_stateout_type_instance                             | instance of derived type GFS_stateout_type              | DDT           |    0 | GFS_stateout_type     |           | in     | F        |
+!! | Sfcprop        | GFS_sfcprop_type_instance                              | instance of type GFS_sfcprop_type in FV3                | DDT           |    0 | GFS_sfcprop_type      |           | in     | F        |
+!! | Coupling       | GFS_coupling_type_instance                             | instance of type GFS_coupling_type in FV3               | DDT           |    0 | GFS_coupling_type     |           | in     | F        |
+!! | Grid           | GFS_grid_type_instance                                 | instance of type GFS_grid_type in FV3                   | DDT           |    0 | GFS_grid_type         |           | in     | F        |
+!! | Tbd            | GFS_tbd_type_instance                                  | instance of type GFS_tbd_type in FV3                    | DDT           |    0 | GFS_tbd_type          |           | in     | F        |
+!! | Cldprop        | GFS_cldprop_type_instance                              | instance of type GFS_cldprop_type in FV3                | DDT           |    0 | GFS_cldprop_type      |           | in     | F        |
+!! | Radtend        | GFS_radtend_type_instance                              | instance of type GFS_radtend_type in FV3                | DDT           |    0 | GFS_radtend_type      |           | in     | F        |
+!! | Diag           | GFS_diag_type_instance                                 | instance of type GFS_diag_type in FV3                   | DDT           |    0 | GFS_diag_type         |           | in     | F        |
+!! | Interstitial   | GFS_interstitial_type_instance                         | instance of type GFS_interstitial_type in FV3           | DDT           |    0 | GFS_interstitial_type |           | in     | F        |
+!! | nthreads       | omp_threads                                            | number of OpenMP threads or fast physics schemes        | count         |    0 | integer               |           | in     | F        |
+!! | blkno          | ccpp_block_number                                      | number of block for explicit data blocking in CCPP      | index         |    0 | integer               |           | in     | F        |
+!! | errmsg         | ccpp_error_message                                     | error message for error handling in CCPP                | none          |    0 | character             | len=*     | out    | F        |
+!! | errflg         | ccpp_error_flag                                        | error flag for error handling in CCPP                   | flag          |    0 | integer               |           | out    | F        |
 !!
       subroutine GFS_diagtoscreen_run (Model, Statein, Stateout, Sfcprop, Coupling,     &
                                        Grid, Tbd, Cldprop, Radtend, Diag, Interstitial, &
@@ -130,7 +146,7 @@
                      call print_var(mpirank,omprank, blkno, 'Sfcprop%zorlo'    , Sfcprop%zorlo)
                      call print_var(mpirank,omprank, blkno, 'Sfcprop%zorll'    , Sfcprop%zorll)
                      call print_var(mpirank,omprank, blkno, 'Sfcprop%fice'     , Sfcprop%fice)
-                     call print_var(mpirank,omprank, blkno, 'Sfcprop%hprim'    , Sfcprop%hprim)
+!                    call print_var(mpirank,omprank, blkno, 'Sfcprop%hprim'    , Sfcprop%hprim)
                      call print_var(mpirank,omprank, blkno, 'Sfcprop%hprime'   , Sfcprop%hprime)
                      call print_var(mpirank,omprank, blkno, 'Sfcprop%sncovr'   , Sfcprop%sncovr)
                      call print_var(mpirank,omprank, blkno, 'Sfcprop%snoalb'   , Sfcprop%snoalb)
@@ -756,7 +772,23 @@
       end subroutine GFS_interstitialtoscreen_finalize
 
 !> \section arg_table_GFS_interstitialtoscreen_run Argument Table
-!! \htmlinclude GFS_interstitialtoscreen_run.html
+!! | local_name     | standard_name                                          | long_name                                               | units         | rank | type                  |    kind   | intent | optional |
+!! |----------------|--------------------------------------------------------|---------------------------------------------------------|---------------|------|-----------------------|-----------|--------|----------|
+!! | Model          | GFS_control_type_instance                              | instance of derived type GFS_control_type               | DDT           |    0 | GFS_control_type      |           | in     | F        |
+!! | Statein        | GFS_statein_type_instance                              | instance of derived type GFS_statein_type               | DDT           |    0 | GFS_statein_type      |           | in     | F        |
+!! | Stateout       | GFS_stateout_type_instance                             | instance of derived type GFS_stateout_type              | DDT           |    0 | GFS_stateout_type     |           | in     | F        |
+!! | Sfcprop        | GFS_sfcprop_type_instance                              | instance of derived type GFS_sfcprop_type               | DDT           |    0 | GFS_sfcprop_type      |           | in     | F        |
+!! | Coupling       | GFS_coupling_type_instance                             | instance of derived type GFS_coupling_type              | DDT           |    0 | GFS_coupling_type     |           | in     | F        |
+!! | Grid           | GFS_grid_type_instance                                 | instance of derived type GFS_grid_type                  | DDT           |    0 | GFS_grid_type         |           | in     | F        |
+!! | Tbd            | GFS_tbd_type_instance                                  | instance of derived type GFS_tbd_type                   | DDT           |    0 | GFS_tbd_type          |           | in     | F        |
+!! | Cldprop        | GFS_cldprop_type_instance                              | instance of derived type GFS_cldprop_type               | DDT           |    0 | GFS_cldprop_type      |           | in     | F        |
+!! | Radtend        | GFS_radtend_type_instance                              | instance of derived type GFS_radtend_type               | DDT           |    0 | GFS_radtend_type      |           | in     | F        |
+!! | Diag           | GFS_diag_type_instance                                 | instance of derived type GFS_diag_type                  | DDT           |    0 | GFS_diag_type         |           | in     | F        |
+!! | Interstitial   | GFS_interstitial_type_instance                         | instance of derived type GFS_interstitial_type          | DDT           |    0 | GFS_interstitial_type |           | in     | F        |
+!! | nthreads       | omp_threads                                            | number of OpenMP threads or fast physics schemes        | count         |    0 | integer               |           | in     | F        |
+!! | blkno          | ccpp_block_number                                      | number of block for explicit data blocking in CCPP      | index         |    0 | integer               |           | in     | F        |
+!! | errmsg         | ccpp_error_message                                     | error message for error handling in CCPP                | none          |    0 | character             | len=*     | out    | F        |
+!! | errflg         | ccpp_error_flag                                        | error flag for error handling in CCPP                   | flag          |    0 | integer               |           | out    | F        |
 !!
       subroutine GFS_interstitialtoscreen_run (Model, Statein, Stateout, Sfcprop, Coupling, &
                                            Grid, Tbd, Cldprop, Radtend, Diag, Interstitial, &
@@ -868,7 +900,12 @@
       end subroutine GFS_abort_finalize
 
 !> \section arg_table_GFS_abort_run Argument Table
-!! \htmlinclude GFS_abort_run.html
+!! | local_name     | standard_name                                          | long_name                                               | units         | rank | type                  |    kind   | intent | optional |
+!! |----------------|--------------------------------------------------------|---------------------------------------------------------|---------------|------|-----------------------|-----------|--------|----------|
+!! | Model          | GFS_control_type_instance                              | instance of derived type GFS_control_type               | DDT           |    0 | GFS_control_type      |           | in     | F        |
+!! | blkno          | ccpp_block_number                                      | number of block for explicit data blocking in CCPP      | index         |    0 | integer               |           | in     | F        |
+!! | errmsg         | ccpp_error_message                                     | error message for error handling in CCPP                | none          |    0 | character             | len=*     | out    | F        |
+!! | errflg         | ccpp_error_flag                                        | error flag for error handling in CCPP                   | flag          |    0 | integer               |           | out    | F        |
 !!
       subroutine GFS_abort_run (Model, blkno, errmsg, errflg)
 
@@ -896,107 +933,3 @@
       end subroutine GFS_abort_run
 
     end module GFS_abort
-
-    module GFS_checkland
-
-        private
- 
-        public GFS_checkland_init, GFS_checkland_run, GFS_checkland_finalize
-
-        contains
-
-        subroutine GFS_checkland_init ()
-        end subroutine GFS_checkland_init
-
-        subroutine GFS_checkland_finalize ()
-        end subroutine GFS_checkland_finalize
-
-!> \section arg_table_GFS_checkland_run Argument Table
-!! \htmlinclude GFS_checkland_run.html
-!!
-        subroutine GFS_checkland_run (me, master, blkno, im, kdt, iter, flag_iter, flag_guess, &
-                flag_init, flag_restart, frac_grid, isot, ivegsrc, stype, vtype, slope,        &
-                soiltyp, vegtype, slopetyp, dry, icy, wet, lake, ocean,                        &
-                oceanfrac, landfrac, lakefrac, slmsk, islmsk, errmsg, errflg )
-
-           use machine, only: kind_phys
-
-           implicit none
-
-           ! Interface variables
-           integer,          intent(in   ) :: me
-           integer,          intent(in   ) :: master
-           integer,          intent(in   ) :: blkno
-           integer,          intent(in   ) :: im
-           integer,          intent(in   ) :: kdt
-           integer,          intent(in   ) :: iter
-           logical,          intent(in   ) :: flag_iter(im)
-           logical,          intent(in   ) :: flag_guess(im)
-           logical,          intent(in   ) :: flag_init
-           logical,          intent(in   ) :: flag_restart
-           logical,          intent(in   ) :: frac_grid
-           integer,          intent(in   ) :: isot
-           integer,          intent(in   ) :: ivegsrc
-           real(kind_phys),  intent(in   ) :: stype(im)
-           real(kind_phys),  intent(in   ) :: vtype(im)
-           real(kind_phys),  intent(in   ) :: slope(im)
-           integer,          intent(in   ) :: soiltyp(im)
-           integer,          intent(in   ) :: vegtype(im)
-           integer,          intent(in   ) :: slopetyp(im)
-           logical,          intent(in   ) :: dry(im)
-           logical,          intent(in   ) :: icy(im)
-           logical,          intent(in   ) :: wet(im)
-           logical,          intent(in   ) :: lake(im)
-           logical,          intent(in   ) :: ocean(im)
-           real(kind_phys),  intent(in   ) :: oceanfrac(im)
-           real(kind_phys),  intent(in   ) :: landfrac(im)
-           real(kind_phys),  intent(in   ) :: lakefrac(im)
-           real(kind_phys),  intent(in   ) :: slmsk(im)
-           integer,          intent(in   ) :: islmsk(im)
-           character(len=*), intent(  out) :: errmsg
-           integer,          intent(  out) :: errflg
-
-           ! Local variables
-           integer :: i
-
-           errflg = 0
-           errmsg = ''
-
-           write(0,'(a,i5)')   'YYY: me           :', me
-           write(0,'(a,i5)')   'YYY: master       :', master
-           write(0,'(a,i5)')   'YYY: blkno        :', blkno
-           write(0,'(a,i5)')   'YYY: im           :', im
-           write(0,'(a,i5)')   'YYY: kdt          :', kdt
-           write(0,'(a,i5)')   'YYY: iter         :', iter
-           write(0,'(a,1x,l)') 'YYY: flag_init    :', flag_init
-           write(0,'(a,1x,l)') 'YYY: flag_restart :', flag_restart
-           write(0,'(a,1x,l)') 'YYY: frac_grid    :', frac_grid
-           write(0,'(a,i5)')   'YYY: isot         :', isot
-           write(0,'(a,i5)')   'YYY: ivegsrc      :', ivegsrc
-
-           do i=1,im
-             !if (vegtype(i)==15) then
-               write(0,'(a,2i5,1x,1x,l)') 'YYY: i, blk, flag_iter(i)  :', i, blkno, flag_iter(i)
-               write(0,'(a,2i5,1x,1x,l)') 'YYY: i, blk, flag_guess(i) :', i, blkno, flag_guess(i)
-               write(0,'(a,2i5,1x,e16.7)')'YYY: i, blk, stype(i)      :', i, blkno, stype(i)
-               write(0,'(a,2i5,1x,e16.7)')'YYY: i, blk, vtype(i)      :', i, blkno, vtype(i)
-               write(0,'(a,2i5,1x,e16.7)')'YYY: i, blk, slope(i)      :', i, blkno, slope(i)
-               write(0,'(a,2i5,1x,i5)')   'YYY: i, blk, soiltyp(i)    :', i, blkno, soiltyp(i)
-               write(0,'(a,2i5,1x,i5)')   'YYY: i, blk, vegtype(i)    :', i, blkno, vegtype(i)
-               write(0,'(a,2i5,1x,i5)')   'YYY: i, blk, slopetyp(i)   :', i, blkno, slopetyp(i)
-               write(0,'(a,2i5,1x,1x,l)') 'YYY: i, blk, dry(i)        :', i, blkno, dry(i)
-               write(0,'(a,2i5,1x,1x,l)') 'YYY: i, blk, icy(i)        :', i, blkno, icy(i)
-               write(0,'(a,2i5,1x,1x,l)') 'YYY: i, blk, wet(i)        :', i, blkno, wet(i)
-               write(0,'(a,2i5,1x,1x,l)') 'YYY: i, blk, lake(i)       :', i, blkno, lake(i)
-               write(0,'(a,2i5,1x,1x,l)') 'YYY: i, blk, ocean(i)      :', i, blkno, ocean(i)
-               write(0,'(a,2i5,1x,e16.7)')'YYY: i, blk, oceanfrac(i)  :', i, blkno, oceanfrac(i)
-               write(0,'(a,2i5,1x,e16.7)')'YYY: i, blk, landfrac(i)   :', i, blkno, landfrac(i)
-               write(0,'(a,2i5,1x,e16.7)')'YYY: i, blk, lakefrac(i)   :', i, blkno, lakefrac(i)
-               write(0,'(a,2i5,1x,e16.7)')'YYY: i, blk, slmsk(i)      :', i, blkno, slmsk(i)
-               write(0,'(a,2i5,1x,i5)')   'YYY: i, blk, islmsk(i)     :', i, blkno, islmsk(i)
-             !end if
-           end do
-
-        end subroutine GFS_checkland_run
-
-    end module GFS_checkland

--- a/physics/GFS_debug.F90
+++ b/physics/GFS_debug.F90
@@ -3,7 +3,7 @@
     module GFS_diagtoscreen
 
       private
- 
+
       public GFS_diagtoscreen_init, GFS_diagtoscreen_run, GFS_diagtoscreen_finalize
 
       public print_my_stuff, chksum_int, chksum_real
@@ -41,23 +41,7 @@
       end subroutine GFS_diagtoscreen_finalize
 
 !> \section arg_table_GFS_diagtoscreen_run Argument Table
-!! | local_name     | standard_name                                          | long_name                                               | units         | rank | type                  |    kind   | intent | optional |
-!! |----------------|--------------------------------------------------------|---------------------------------------------------------|---------------|------|-----------------------|-----------|--------|----------|
-!! | Model          | GFS_control_type_instance                              | instance of derived type GFS_control_type in FV3        | DDT           |    0 | GFS_control_type      |           | in     | F        |
-!! | Statein        | GFS_statein_type_instance                              | instance of derived type GFS_statein_type in FV3        | DDT           |    0 | GFS_statein_type      |           | in     | F        |
-!! | Stateout       | GFS_stateout_type_instance                             | instance of derived type GFS_stateout_type              | DDT           |    0 | GFS_stateout_type     |           | in     | F        |
-!! | Sfcprop        | GFS_sfcprop_type_instance                              | instance of type GFS_sfcprop_type in FV3                | DDT           |    0 | GFS_sfcprop_type      |           | in     | F        |
-!! | Coupling       | GFS_coupling_type_instance                             | instance of type GFS_coupling_type in FV3               | DDT           |    0 | GFS_coupling_type     |           | in     | F        |
-!! | Grid           | GFS_grid_type_instance                                 | instance of type GFS_grid_type in FV3                   | DDT           |    0 | GFS_grid_type         |           | in     | F        |
-!! | Tbd            | GFS_tbd_type_instance                                  | instance of type GFS_tbd_type in FV3                    | DDT           |    0 | GFS_tbd_type          |           | in     | F        |
-!! | Cldprop        | GFS_cldprop_type_instance                              | instance of type GFS_cldprop_type in FV3                | DDT           |    0 | GFS_cldprop_type      |           | in     | F        |
-!! | Radtend        | GFS_radtend_type_instance                              | instance of type GFS_radtend_type in FV3                | DDT           |    0 | GFS_radtend_type      |           | in     | F        |
-!! | Diag           | GFS_diag_type_instance                                 | instance of type GFS_diag_type in FV3                   | DDT           |    0 | GFS_diag_type         |           | in     | F        |
-!! | Interstitial   | GFS_interstitial_type_instance                         | instance of type GFS_interstitial_type in FV3           | DDT           |    0 | GFS_interstitial_type |           | in     | F        |
-!! | nthreads       | omp_threads                                            | number of OpenMP threads or fast physics schemes        | count         |    0 | integer               |           | in     | F        |
-!! | blkno          | ccpp_block_number                                      | number of block for explicit data blocking in CCPP      | index         |    0 | integer               |           | in     | F        |
-!! | errmsg         | ccpp_error_message                                     | error message for error handling in CCPP                | none          |    0 | character             | len=*     | out    | F        |
-!! | errflg         | ccpp_error_flag                                        | error flag for error handling in CCPP                   | flag          |    0 | integer               |           | out    | F        |
+!! \htmlinclude GFS_diagtoscreen_run.html
 !!
       subroutine GFS_diagtoscreen_run (Model, Statein, Stateout, Sfcprop, Coupling,     &
                                        Grid, Tbd, Cldprop, Radtend, Diag, Interstitial, &
@@ -633,7 +617,7 @@
           integer, intent(in) :: mpirank, omprank, blkno
           character(len=*), intent(in) :: name
           real(kind_phys), intent(in) :: var(:,:)
-          
+
           integer :: k, i
 
 #ifdef PRINT_SUM
@@ -760,7 +744,7 @@
     module GFS_interstitialtoscreen
 
       private
- 
+
       public GFS_interstitialtoscreen_init, GFS_interstitialtoscreen_run, GFS_interstitialtoscreen_finalize
 
       contains
@@ -772,23 +756,7 @@
       end subroutine GFS_interstitialtoscreen_finalize
 
 !> \section arg_table_GFS_interstitialtoscreen_run Argument Table
-!! | local_name     | standard_name                                          | long_name                                               | units         | rank | type                  |    kind   | intent | optional |
-!! |----------------|--------------------------------------------------------|---------------------------------------------------------|---------------|------|-----------------------|-----------|--------|----------|
-!! | Model          | GFS_control_type_instance                              | instance of derived type GFS_control_type               | DDT           |    0 | GFS_control_type      |           | in     | F        |
-!! | Statein        | GFS_statein_type_instance                              | instance of derived type GFS_statein_type               | DDT           |    0 | GFS_statein_type      |           | in     | F        |
-!! | Stateout       | GFS_stateout_type_instance                             | instance of derived type GFS_stateout_type              | DDT           |    0 | GFS_stateout_type     |           | in     | F        |
-!! | Sfcprop        | GFS_sfcprop_type_instance                              | instance of derived type GFS_sfcprop_type               | DDT           |    0 | GFS_sfcprop_type      |           | in     | F        |
-!! | Coupling       | GFS_coupling_type_instance                             | instance of derived type GFS_coupling_type              | DDT           |    0 | GFS_coupling_type     |           | in     | F        |
-!! | Grid           | GFS_grid_type_instance                                 | instance of derived type GFS_grid_type                  | DDT           |    0 | GFS_grid_type         |           | in     | F        |
-!! | Tbd            | GFS_tbd_type_instance                                  | instance of derived type GFS_tbd_type                   | DDT           |    0 | GFS_tbd_type          |           | in     | F        |
-!! | Cldprop        | GFS_cldprop_type_instance                              | instance of derived type GFS_cldprop_type               | DDT           |    0 | GFS_cldprop_type      |           | in     | F        |
-!! | Radtend        | GFS_radtend_type_instance                              | instance of derived type GFS_radtend_type               | DDT           |    0 | GFS_radtend_type      |           | in     | F        |
-!! | Diag           | GFS_diag_type_instance                                 | instance of derived type GFS_diag_type                  | DDT           |    0 | GFS_diag_type         |           | in     | F        |
-!! | Interstitial   | GFS_interstitial_type_instance                         | instance of derived type GFS_interstitial_type          | DDT           |    0 | GFS_interstitial_type |           | in     | F        |
-!! | nthreads       | omp_threads                                            | number of OpenMP threads or fast physics schemes        | count         |    0 | integer               |           | in     | F        |
-!! | blkno          | ccpp_block_number                                      | number of block for explicit data blocking in CCPP      | index         |    0 | integer               |           | in     | F        |
-!! | errmsg         | ccpp_error_message                                     | error message for error handling in CCPP                | none          |    0 | character             | len=*     | out    | F        |
-!! | errflg         | ccpp_error_flag                                        | error flag for error handling in CCPP                   | flag          |    0 | integer               |           | out    | F        |
+!! \htmlinclude GFS_interstitialtoscreen_run.html
 !!
       subroutine GFS_interstitialtoscreen_run (Model, Statein, Stateout, Sfcprop, Coupling, &
                                            Grid, Tbd, Cldprop, Radtend, Diag, Interstitial, &
@@ -888,7 +856,7 @@
     module GFS_abort
 
       private
- 
+
       public GFS_abort_init, GFS_abort_run, GFS_abort_finalize
 
       contains
@@ -900,12 +868,7 @@
       end subroutine GFS_abort_finalize
 
 !> \section arg_table_GFS_abort_run Argument Table
-!! | local_name     | standard_name                                          | long_name                                               | units         | rank | type                  |    kind   | intent | optional |
-!! |----------------|--------------------------------------------------------|---------------------------------------------------------|---------------|------|-----------------------|-----------|--------|----------|
-!! | Model          | GFS_control_type_instance                              | instance of derived type GFS_control_type               | DDT           |    0 | GFS_control_type      |           | in     | F        |
-!! | blkno          | ccpp_block_number                                      | number of block for explicit data blocking in CCPP      | index         |    0 | integer               |           | in     | F        |
-!! | errmsg         | ccpp_error_message                                     | error message for error handling in CCPP                | none          |    0 | character             | len=*     | out    | F        |
-!! | errflg         | ccpp_error_flag                                        | error flag for error handling in CCPP                   | flag          |    0 | integer               |           | out    | F        |
+!! \htmlinclude GFS_abort_run.html
 !!
       subroutine GFS_abort_run (Model, blkno, errmsg, errflg)
 
@@ -933,3 +896,107 @@
       end subroutine GFS_abort_run
 
     end module GFS_abort
+
+    module GFS_checkland
+
+        private
+
+        public GFS_checkland_init, GFS_checkland_run, GFS_checkland_finalize
+
+        contains
+
+        subroutine GFS_checkland_init ()
+        end subroutine GFS_checkland_init
+
+        subroutine GFS_checkland_finalize ()
+        end subroutine GFS_checkland_finalize
+
+!> \section arg_table_GFS_checkland_run Argument Table
+!! \htmlinclude GFS_checkland_run.html
+!!
+        subroutine GFS_checkland_run (me, master, blkno, im, kdt, iter, flag_iter, flag_guess, &
+                flag_init, flag_restart, frac_grid, isot, ivegsrc, stype, vtype, slope,        &
+                soiltyp, vegtype, slopetyp, dry, icy, wet, lake, ocean,                        &
+                oceanfrac, landfrac, lakefrac, slmsk, islmsk, errmsg, errflg )
+
+           use machine, only: kind_phys
+
+           implicit none
+
+           ! Interface variables
+           integer,          intent(in   ) :: me
+           integer,          intent(in   ) :: master
+           integer,          intent(in   ) :: blkno
+           integer,          intent(in   ) :: im
+           integer,          intent(in   ) :: kdt
+           integer,          intent(in   ) :: iter
+           logical,          intent(in   ) :: flag_iter(im)
+           logical,          intent(in   ) :: flag_guess(im)
+           logical,          intent(in   ) :: flag_init
+           logical,          intent(in   ) :: flag_restart
+           logical,          intent(in   ) :: frac_grid
+           integer,          intent(in   ) :: isot
+           integer,          intent(in   ) :: ivegsrc
+           real(kind_phys),  intent(in   ) :: stype(im)
+           real(kind_phys),  intent(in   ) :: vtype(im)
+           real(kind_phys),  intent(in   ) :: slope(im)
+           integer,          intent(in   ) :: soiltyp(im)
+           integer,          intent(in   ) :: vegtype(im)
+           integer,          intent(in   ) :: slopetyp(im)
+           logical,          intent(in   ) :: dry(im)
+           logical,          intent(in   ) :: icy(im)
+           logical,          intent(in   ) :: wet(im)
+           logical,          intent(in   ) :: lake(im)
+           logical,          intent(in   ) :: ocean(im)
+           real(kind_phys),  intent(in   ) :: oceanfrac(im)
+           real(kind_phys),  intent(in   ) :: landfrac(im)
+           real(kind_phys),  intent(in   ) :: lakefrac(im)
+           real(kind_phys),  intent(in   ) :: slmsk(im)
+           integer,          intent(in   ) :: islmsk(im)
+           character(len=*), intent(  out) :: errmsg
+           integer,          intent(  out) :: errflg
+
+           ! Local variables
+           integer :: i
+
+           errflg = 0
+           errmsg = ''
+
+           write(0,'(a,i5)')   'YYY: me           :', me
+           write(0,'(a,i5)')   'YYY: master       :', master
+           write(0,'(a,i5)')   'YYY: blkno        :', blkno
+           write(0,'(a,i5)')   'YYY: im           :', im
+           write(0,'(a,i5)')   'YYY: kdt          :', kdt
+           write(0,'(a,i5)')   'YYY: iter         :', iter
+           write(0,'(a,1x,l)') 'YYY: flag_init    :', flag_init
+           write(0,'(a,1x,l)') 'YYY: flag_restart :', flag_restart
+           write(0,'(a,1x,l)') 'YYY: frac_grid    :', frac_grid
+           write(0,'(a,i5)')   'YYY: isot         :', isot
+           write(0,'(a,i5)')   'YYY: ivegsrc      :', ivegsrc
+
+           do i=1,im
+             !if (vegtype(i)==15) then
+               write(0,'(a,2i5,1x,1x,l)') 'YYY: i, blk, flag_iter(i)  :', i, blkno, flag_iter(i)
+               write(0,'(a,2i5,1x,1x,l)') 'YYY: i, blk, flag_guess(i) :', i, blkno, flag_guess(i)
+               write(0,'(a,2i5,1x,e16.7)')'YYY: i, blk, stype(i)      :', i, blkno, stype(i)
+               write(0,'(a,2i5,1x,e16.7)')'YYY: i, blk, vtype(i)      :', i, blkno, vtype(i)
+               write(0,'(a,2i5,1x,e16.7)')'YYY: i, blk, slope(i)      :', i, blkno, slope(i)
+               write(0,'(a,2i5,1x,i5)')   'YYY: i, blk, soiltyp(i)    :', i, blkno, soiltyp(i)
+               write(0,'(a,2i5,1x,i5)')   'YYY: i, blk, vegtype(i)    :', i, blkno, vegtype(i)
+               write(0,'(a,2i5,1x,i5)')   'YYY: i, blk, slopetyp(i)   :', i, blkno, slopetyp(i)
+               write(0,'(a,2i5,1x,1x,l)') 'YYY: i, blk, dry(i)        :', i, blkno, dry(i)
+               write(0,'(a,2i5,1x,1x,l)') 'YYY: i, blk, icy(i)        :', i, blkno, icy(i)
+               write(0,'(a,2i5,1x,1x,l)') 'YYY: i, blk, wet(i)        :', i, blkno, wet(i)
+               write(0,'(a,2i5,1x,1x,l)') 'YYY: i, blk, lake(i)       :', i, blkno, lake(i)
+               write(0,'(a,2i5,1x,1x,l)') 'YYY: i, blk, ocean(i)      :', i, blkno, ocean(i)
+               write(0,'(a,2i5,1x,e16.7)')'YYY: i, blk, oceanfrac(i)  :', i, blkno, oceanfrac(i)
+               write(0,'(a,2i5,1x,e16.7)')'YYY: i, blk, landfrac(i)   :', i, blkno, landfrac(i)
+               write(0,'(a,2i5,1x,e16.7)')'YYY: i, blk, lakefrac(i)   :', i, blkno, lakefrac(i)
+               write(0,'(a,2i5,1x,e16.7)')'YYY: i, blk, slmsk(i)      :', i, blkno, slmsk(i)
+               write(0,'(a,2i5,1x,i5)')   'YYY: i, blk, islmsk(i)     :', i, blkno, islmsk(i)
+             !end if
+           end do
+
+        end subroutine GFS_checkland_run
+
+    end module GFS_checkland

--- a/physics/rrtmg_lw_pre.F90
+++ b/physics/rrtmg_lw_pre.F90
@@ -12,17 +12,7 @@
       end subroutine rrtmg_lw_pre_init 
 
 !> \section arg_table_rrtmg_lw_pre_run Argument Table
-!! | local_name     | standard_name                             | long_name                                                          | units    | rank |  type                 |   kind    | intent | optional |
-!! |----------------|-------------------------------------------|--------------------------------------------------------------------|----------|------|-----------------------|-----------|--------|----------|
-!! | Model          | GFS_control_type_instance                 | Fortran DDT containing FV3-GFS model control parameters            | DDT      |    0 | GFS_control_type      |           | in     | F        |
-!! | Grid           | GFS_grid_type_instance                    | Fortran DDT containing FV3-GFS grid and interpolation related data | DDT      |    0 | GFS_grid_type         |           | in     | F        |
-!! | Sfcprop        | GFS_sfcprop_type_instance                 | Fortran DDT containing FV3-GFS surface fields                      | DDT      |    0 | GFS_sfcprop_type      |           | in     | F        |
-!! | Radtend        | GFS_radtend_type_instance                 | Fortran DDT containing FV3-GFS radiation tendencies                | DDT      |    0 | GFS_radtend_type      |           | inout  | F        |
-!! | im             | horizontal_loop_extent                    | horizontal loop extent                                             | count    |    0 | integer               |           | in     | F        |
-!! | tsfg           | surface_ground_temperature_for_radiation  | surface ground temperature for radiation                           | K        |    1 | real                  | kind_phys | in     | F        |
-!! | tsfa           | surface_air_temperature_for_radiation     | lowest model layer air temperature for radiation                   | K        |    1 | real                  | kind_phys | in     | F        |
-!! | errmsg         | ccpp_error_message                        | error message for error handling in CCPP                           | none     |    0 | character             | len=*     | out    | F        |
-!! | errflg         | ccpp_error_flag                           | error flag for error handling in CCPP                              | flag     |    0 | integer               |           | out    | F        |
+!! \htmlinclude rrtmg_lw_pre_run.html
 !!
       subroutine rrtmg_lw_pre_run (Model, Grid, Sfcprop, Radtend, im, tsfg, tsfa, errmsg, errflg)
     

--- a/physics/rrtmg_lw_pre.F90
+++ b/physics/rrtmg_lw_pre.F90
@@ -12,7 +12,17 @@
       end subroutine rrtmg_lw_pre_init 
 
 !> \section arg_table_rrtmg_lw_pre_run Argument Table
-!! \htmlinclude rrtmg_lw_pre_run.html
+!! | local_name     | standard_name                             | long_name                                                          | units    | rank |  type                 |   kind    | intent | optional |
+!! |----------------|-------------------------------------------|--------------------------------------------------------------------|----------|------|-----------------------|-----------|--------|----------|
+!! | Model          | GFS_control_type_instance                 | Fortran DDT containing FV3-GFS model control parameters            | DDT      |    0 | GFS_control_type      |           | in     | F        |
+!! | Grid           | GFS_grid_type_instance                    | Fortran DDT containing FV3-GFS grid and interpolation related data | DDT      |    0 | GFS_grid_type         |           | in     | F        |
+!! | Sfcprop        | GFS_sfcprop_type_instance                 | Fortran DDT containing FV3-GFS surface fields                      | DDT      |    0 | GFS_sfcprop_type      |           | in     | F        |
+!! | Radtend        | GFS_radtend_type_instance                 | Fortran DDT containing FV3-GFS radiation tendencies                | DDT      |    0 | GFS_radtend_type      |           | inout  | F        |
+!! | im             | horizontal_loop_extent                    | horizontal loop extent                                             | count    |    0 | integer               |           | in     | F        |
+!! | tsfg           | surface_ground_temperature_for_radiation  | surface ground temperature for radiation                           | K        |    1 | real                  | kind_phys | in     | F        |
+!! | tsfa           | surface_air_temperature_for_radiation     | lowest model layer air temperature for radiation                   | K        |    1 | real                  | kind_phys | in     | F        |
+!! | errmsg         | ccpp_error_message                        | error message for error handling in CCPP                           | none     |    0 | character             | len=*     | out    | F        |
+!! | errflg         | ccpp_error_flag                           | error flag for error handling in CCPP                              | flag     |    0 | integer               |           | out    | F        |
 !!
       subroutine rrtmg_lw_pre_run (Model, Grid, Sfcprop, Radtend, im, tsfg, tsfa, errmsg, errflg)
     
@@ -43,7 +53,7 @@
 !! emissivity for LW radiation.
         call setemis (Grid%xlon, Grid%xlat, Sfcprop%slmsk,        &        !  ---  inputs
                      Sfcprop%snowd, Sfcprop%sncovr, Sfcprop%zorl, &
-                     tsfg, tsfa, Sfcprop%hprim, IM,               &
+                     tsfg, tsfa, Sfcprop%hprime(:,1), IM,         &
                       Radtend%semis)                              !  ---  outputs
       endif
 

--- a/physics/rrtmg_sw_pre.F90
+++ b/physics/rrtmg_sw_pre.F90
@@ -12,7 +12,24 @@
       end subroutine rrtmg_sw_pre_init
 
 !> \section arg_table_rrtmg_sw_pre_run Argument Table
-!! \htmlinclude rrtmg_sw_pre_run.html
+!! | local_name     | standard_name                             | long_name                                                          | units    | rank |  type            |   kind    | intent | optional |
+!! |----------------|-------------------------------------------|--------------------------------------------------------------------|----------|------|------------------|-----------|--------|----------|
+!! | Model          | GFS_control_type_instance                 | Fortran DDT containing FV3-GFS model control parameters            | DDT      |    0 | GFS_control_type |           | in     | F        |
+!! | Grid           | GFS_grid_type_instance                    | Fortran DDT containing FV3-GFS grid and interpolation related data | DDT      |    0 | GFS_grid_type    |           | in     | F        |
+!! | Sfcprop        | GFS_sfcprop_type_instance                 | Fortran DDT containing FV3-GFS surface fields                      | DDT      |    0 | GFS_sfcprop_type |           | in     | F        |
+!! | Radtend        | GFS_radtend_type_instance                 | Fortran DDT containing FV3-GFS radiation tendencies                | DDT      |    0 | GFS_radtend_type |           | inout  | F        |
+!! | im             | horizontal_loop_extent                    | horizontal loop extent                                             | count    |    0 | integer          |           | in     | F        |
+!! | nday           | daytime_points_dimension                  | daytime points dimension                                           | count    |    0 | integer          |           | out    | F        |
+!! | idxday         | daytime_points                            | daytime points                                                     | index    |    1 | integer          |           | out    | F        |
+!! | tsfg           | surface_ground_temperature_for_radiation  | surface ground temperature for radiation                           | K        |    1 | real             | kind_phys | in     | F        |
+!! | tsfa           | surface_air_temperature_for_radiation     | lowest model layer air temperature for radiation                   | K        |    1 | real             | kind_phys | in     | F        |
+!! | sfcalb1        | surface_albedo_due_to_near_IR_direct      | surface albedo due to near IR direct beam                          | frac     |    1 | real             | kind_phys | out    | F        |
+!! | sfcalb2        | surface_albedo_due_to_near_IR_diffused    | surface albedo due to near IR diffused beam                        | frac     |    1 | real             | kind_phys | out    | F        |
+!! | sfcalb3        | surface_albedo_due_to_UV_and_VIS_direct   | surface albedo due to UV+VIS direct beam                           | frac     |    1 | real             | kind_phys | out    | F        |
+!! | sfcalb4        | surface_albedo_due_to_UV_and_VIS_diffused | surface albedo due to UV+VIS diffused beam                         | frac     |    1 | real             | kind_phys | out    | F        |
+!! | alb1d          | surface_albedo_perturbation               | surface albedo perturbation                                        | frac     |    1 | real             | kind_phys | in     | F        |
+!! | errmsg         | ccpp_error_message                        | error message for error handling in CCPP                           | none     |    0 | character        | len=*     | out    | F        |
+!! | errflg         | ccpp_error_flag                           | error flag for error handling in CCPP                              | flag     |    0 | integer          |           | out    | F        |
 !!
       subroutine rrtmg_sw_pre_run (Model, Grid, Sfcprop, Radtend, im, &
         nday, idxday, tsfg, tsfa, sfcalb1, sfcalb2, sfcalb3, sfcalb4, &
@@ -66,13 +83,13 @@
 !>  - Call module_radiation_surface::setalb() to setup surface albedo.
 !!  for SW radiation.
 
-        call setalb (Sfcprop%slmsk, Sfcprop%snowd, Sfcprop%sncovr,&    !  ---  inputs:
-                     Sfcprop%snoalb, Sfcprop%zorl, Radtend%coszen,&
-                     tsfg, tsfa, Sfcprop%hprim, Sfcprop%alvsf,    &
-                     Sfcprop%alnsf, Sfcprop%alvwf, Sfcprop%alnwf, &
-                     Sfcprop%facsf, Sfcprop%facwf, Sfcprop%fice,  &
-                     Sfcprop%tisfc, IM,                           &
-                     alb1d, Model%pertalb,                        &    !  mg, sfc-perts
+        call setalb (Sfcprop%slmsk, Sfcprop%snowd, Sfcprop%sncovr,   &  !  ---  inputs:
+                     Sfcprop%snoalb, Sfcprop%zorl, Radtend%coszen,   &
+                     tsfg, tsfa, Sfcprop%hprime(:,1), Sfcprop%alvsf, &
+                     Sfcprop%alnsf, Sfcprop%alvwf, Sfcprop%alnwf,    &
+                     Sfcprop%facsf, Sfcprop%facwf, Sfcprop%fice,     &
+                     Sfcprop%tisfc, IM,                              &
+                     alb1d, Model%pertalb,                           &  !  mg, sfc-perts
                      sfcalb)                                           !  ---  outputs
 
 !> -# Approximate mean surface albedo from vis- and nir-  diffuse values.

--- a/physics/rrtmg_sw_pre.F90
+++ b/physics/rrtmg_sw_pre.F90
@@ -12,24 +12,7 @@
       end subroutine rrtmg_sw_pre_init
 
 !> \section arg_table_rrtmg_sw_pre_run Argument Table
-!! | local_name     | standard_name                             | long_name                                                          | units    | rank |  type            |   kind    | intent | optional |
-!! |----------------|-------------------------------------------|--------------------------------------------------------------------|----------|------|------------------|-----------|--------|----------|
-!! | Model          | GFS_control_type_instance                 | Fortran DDT containing FV3-GFS model control parameters            | DDT      |    0 | GFS_control_type |           | in     | F        |
-!! | Grid           | GFS_grid_type_instance                    | Fortran DDT containing FV3-GFS grid and interpolation related data | DDT      |    0 | GFS_grid_type    |           | in     | F        |
-!! | Sfcprop        | GFS_sfcprop_type_instance                 | Fortran DDT containing FV3-GFS surface fields                      | DDT      |    0 | GFS_sfcprop_type |           | in     | F        |
-!! | Radtend        | GFS_radtend_type_instance                 | Fortran DDT containing FV3-GFS radiation tendencies                | DDT      |    0 | GFS_radtend_type |           | inout  | F        |
-!! | im             | horizontal_loop_extent                    | horizontal loop extent                                             | count    |    0 | integer          |           | in     | F        |
-!! | nday           | daytime_points_dimension                  | daytime points dimension                                           | count    |    0 | integer          |           | out    | F        |
-!! | idxday         | daytime_points                            | daytime points                                                     | index    |    1 | integer          |           | out    | F        |
-!! | tsfg           | surface_ground_temperature_for_radiation  | surface ground temperature for radiation                           | K        |    1 | real             | kind_phys | in     | F        |
-!! | tsfa           | surface_air_temperature_for_radiation     | lowest model layer air temperature for radiation                   | K        |    1 | real             | kind_phys | in     | F        |
-!! | sfcalb1        | surface_albedo_due_to_near_IR_direct      | surface albedo due to near IR direct beam                          | frac     |    1 | real             | kind_phys | out    | F        |
-!! | sfcalb2        | surface_albedo_due_to_near_IR_diffused    | surface albedo due to near IR diffused beam                        | frac     |    1 | real             | kind_phys | out    | F        |
-!! | sfcalb3        | surface_albedo_due_to_UV_and_VIS_direct   | surface albedo due to UV+VIS direct beam                           | frac     |    1 | real             | kind_phys | out    | F        |
-!! | sfcalb4        | surface_albedo_due_to_UV_and_VIS_diffused | surface albedo due to UV+VIS diffused beam                         | frac     |    1 | real             | kind_phys | out    | F        |
-!! | alb1d          | surface_albedo_perturbation               | surface albedo perturbation                                        | frac     |    1 | real             | kind_phys | in     | F        |
-!! | errmsg         | ccpp_error_message                        | error message for error handling in CCPP                           | none     |    0 | character        | len=*     | out    | F        |
-!! | errflg         | ccpp_error_flag                           | error flag for error handling in CCPP                              | flag     |    0 | integer          |           | out    | F        |
+!! \htmlinclude rrtmg_sw_pre_run.html
 !!
       subroutine rrtmg_sw_pre_run (Model, Grid, Sfcprop, Radtend, im, &
         nday, idxday, tsfg, tsfa, sfcalb1, sfcalb2, sfcalb3, sfcalb4, &


### PR DESCRIPTION
This PR updates the changes in https://github.com/NCAR/ccpp-physics/pull/323 to the new metadata format. All Fortran code changes are related to using Sfcprop%hprime(:,1) instead of Sfcprop%hprim. For the three files affected, we are still passing the entire DDT Sfcprop into the schemes, hence no changes are required for the metadata itself. Thus, this PR only restores the
```
!! \htmlinclude GFS_diagtoscreen_run.html
```
lines that were removed by PR https://github.com/NCAR/ccpp-physics/pull/323.

This was tested to compile and run on macOS/GNU.

Merging this PR will automatically merge https://github.com/NCAR/ccpp-physics/pull/323.