### PR TITLE
Fix the unit bug for soil moisture mass in the whole soil domain in sfc_drv_ruc.F90

### DIFF
--- a/physics/sfc_drv_ruc.F90
+++ b/physics/sfc_drv_ruc.F90
@@ -897,7 +897,7 @@ module lsm_ruc
         sfcdew(i)  = dew(i,j)
         qsurf(i)   = qsfc(i,j)
         sncovr1(i) = sncovr(i,j)
-        stm(i)     = soilm(i,j) * 1000.0 ! unit conversion (from m to kg m-2)
+        stm(i)     = soilm(i,j) 
         tsurf(i)   = soilt(i,j)
         tice(i)    = tsurf(i)
         


### PR DESCRIPTION
This commit removes conversion of units from [m] to [mm] for soil moisture content in the whole soil column. The units of this variable has been already converted to [mm] inside RUC LSM (module_sf_ruclsm.F).