### PR TITLE
Added sea_land_ice_mask to sfc_drv_ruc.F90

### DIFF
--- a/physics/sfc_drv_ruc.F90
+++ b/physics/sfc_drv_ruc.F90
@@ -897,7 +897,7 @@ module lsm_ruc
         sfcdew(i)  = dew(i,j)
         qsurf(i)   = qsfc(i,j)
         sncovr1(i) = sncovr(i,j)
-        stm(i)     = soilm(i,j) * 1000.0 ! unit conversion (from m to kg m-2)
+        stm(i)     = soilm(i,j)
         tsurf(i)   = soilt(i,j)
         tice(i)    = tsurf(i)
         

--- a/physics/sfc_drv_ruc.F90
+++ b/physics/sfc_drv_ruc.F90
@@ -143,7 +143,7 @@ module lsm_ruc
      &       sfcemis, dlwflx, dswsfc, snet, delt, tg3, cm, ch,          &
      &       prsl1, zf, ddvel, shdmin, shdmax, alvwf, alnwf,            &
      &       snoalb, sfalb, flag_iter, flag_guess, isot, ivegsrc, fice, &
-     &       smc, stc, slc, lsm_ruc, lsm, land,                         &
+     &       smc, stc, slc, lsm_ruc, lsm, land, islimsk,                &
      &       imp_physics, imp_physics_gfdl, imp_physics_thompson,       &
      &       smcwlt2, smcref2, wspd, do_mynnsfclay,                     &
      &       con_cp, con_rv, con_rd, con_g, con_pi, con_hvap, con_fvirt,& !  constants
@@ -184,6 +184,7 @@ module lsm_ruc
                                             con_hvap, con_fvirt
 
       logical, dimension(im), intent(in) :: flag_iter, flag_guess, land
+      integer, dimension(im), intent(in) :: islimsk ! sea/land/ice mask (=0/1/2)
       logical,                intent(in) :: do_mynnsfclay
 
 !  ---  in/out:
@@ -384,7 +385,7 @@ module lsm_ruc
         !> - Set flag for land and ice points.
         !- 10may19 - ice points are turned off.
         flag(i) = land(i)
-        if (land(i) .and. (vegtype(i)==iswater .or. vegtype(i)==isice)) then
+        if (land(i) .and. (vegtype(i)==iswater .or. (vegtype(i)==isice.and.islimsk(i)==2))) then
             !write(errmsg,'(a,i0,a,i0)') 'Logic error in sfc_drv_ruc_run: for i=', i, &
             !           ', land(i) is true but vegtype(i) is water or ice: ', vegtype(i)
             !errflg = 1

--- a/physics/sfc_drv_ruc.meta
+++ b/physics/sfc_drv_ruc.meta
@@ -278,6 +278,14 @@
   type = logical
   intent = in
   optional = F
+[islimsk]
+  standard_name = sea_land_ice_mask
+  long_name = sea/land/ice mask (=0/1/2)
+  units = flag
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = in
+  optional = F
 [rainnc]
   standard_name = lwe_thickness_of_explicit_rainfall_amount_from_previous_timestep
   long_name = explicit rainfall from previous timestep


### PR DESCRIPTION
The sea_land_ice mask was added to the consistency check on the vegetation type for land points:       
 if (land(i) .and. (vegtype(i)==iswater .or. (**vegtype(i)==isice.and.islimsk(i)==2)**)) then
            !write(errmsg,'(a,i0,a,i0)') 'Logic error in sfc_drv_ruc_run: for i=', i, &
            !           ', land(i) is true but vegtype(i) is water or ice: ', vegtype(i)
            !errflg = 1
            !return
            if(flag_init .and. iter==1) then
              write(0,'(a,i0,a,i0)') 'Warning: in sfc_drv_ruc_run: for i=', i, &
                ', land(i) is true but vegtype(i) is water or ice: ', vegtype(i)
            end if
        end if

The vegetation type for ice (isice=15) could be for both land and sea ice points. Therefore, additional check is added to warn only on the sea ice points with land=.true. 
This change will preclude from multiple unnecessary warning prints.