### PR TITLE
Bug fix in the unit conversion from [mm] to [m] for liquid rain in Thompson MP.

### DIFF
--- a/physics/mp_thompson.F90
+++ b/physics/mp_thompson.F90
@@ -395,7 +395,7 @@ module mp_thompson
          graupel = max(0.0, delta_graupel_mp/1000.0_kind_phys)
          ice     = max(0.0, delta_ice_mp/1000.0_kind_phys)
          snow    = max(0.0, delta_snow_mp/1000.0_kind_phys)
-         rain    = max(0.0, delta_rain_mp - (delta_graupel_mp + delta_ice_mp + delta_snow_mp)/1000.0_kind_phys)
+         rain    = max(0.0, (delta_rain_mp - (delta_graupel_mp + delta_ice_mp + delta_snow_mp))/1000.0_kind_phys)
 
       end subroutine mp_thompson_run
 !>@}


### PR DESCRIPTION
This bug fix corrects the unit conversion for liquid precipitation in mp_thompson.F90. The liquid precipitation is later used in GFS_MP_generic.F90  to compute total precipitation needed for the estimation of fraction of frozen precipitation. Because of the error, the fraction of frozen precipitation was 1000 less, and therefore, practically all precipitation was treated my the LSMs as liquid. The bug was affecting the model performance with both Noah and RUC LSM. The bug fix was tested on C96 resolution and fixed the problem with snow accumulation on the surface.