### PR TITLE
Fraction of frozen precipitation with RUC LSM

### DIFF
--- a/physics/GFS_MP_generic.F90
+++ b/physics/GFS_MP_generic.F90
@@ -270,7 +270,7 @@
         enddo
       enddo
 
-      ! Conversion factor mm per physics timestep to m per day
+      ! Conversion factor from mm per day to m per physics timestep 
       tem = dtp * con_p001 / con_day
 
 !> - For GFDL and Thompson MP scheme, determine convective snow by surface temperature;
@@ -280,6 +280,8 @@
       if (imp_physics == imp_physics_gfdl .or. imp_physics == imp_physics_thompson) then
 ! determine convective rain/snow by surface temperature
 ! determine large-scale rain/snow by rain/snow coming out directly from MP
+       
+      if (lsm/=lsm_ruc) then
         do i = 1, im
           !tprcp(i)  = max(0.0, rain(i) )! clu: rain -> tprcp ! DH now lines 245-250
           srflag(i) = 0.                     ! clu: default srflag as 'rain' (i.e. 0)
@@ -300,6 +302,14 @@
             srflag(i) = (snow0(i)+ice0(i)+graupel0(i)+csnow)/total_precip
           endif
         enddo
+      else
+      ! only for RUC LSM
+        do i=1,im
+          srflag(i) = sr(i)
+        !if(sr(i) > 0.) print *,'RUC LSM uses SR from MP - srflag(i)',i,srflag(i)
+        enddo
+      endif ! lsm==lsm_ruc
+
       elseif( .not. cal_pre) then
         if (imp_physics == imp_physics_mg) then              ! MG microphysics
           do i=1,im

--- a/physics/mp_thompson.F90
+++ b/physics/mp_thompson.F90
@@ -395,7 +395,7 @@ module mp_thompson
          graupel = max(0.0, delta_graupel_mp/1000.0_kind_phys)
          ice     = max(0.0, delta_ice_mp/1000.0_kind_phys)
          snow    = max(0.0, delta_snow_mp/1000.0_kind_phys)
-         rain    = max(0.0, delta_rain_mp - (delta_graupel_mp + delta_ice_mp + delta_snow_mp)/1000.0_kind_phys)
+         rain    = max(0.0, (delta_rain_mp - (delta_graupel_mp + delta_ice_mp + delta_snow_mp))/1000.0_kind_phys)
 
       end subroutine mp_thompson_run
 !>@}


### PR DESCRIPTION
Use fraction of frozen precipitation computed in Thompson or GFDL microphysics to fill array SRFLAG. This change will affect only the combination of RUC LSM with Thompson or GFDL microphysics, and will not affect any physics combinations not using RUC LSM. The reason for this change is to exclude temperature-based treatment of convective precipitation from the computation of SRFLAG, as is implemented in the WRF-based RAP and HRRR.