### PR TITLE
This commit has a fix for a problem of cloud-radiation coupling with the use of MYNN PBL.

### DIFF
--- a/physics/module_MYNNrad_post.F90
+++ b/physics/module_MYNNrad_post.F90
@@ -22,6 +22,7 @@
 #endif
 SUBROUTINE mynnrad_post_run(               &
      &     ix,im,levs,                     &
+     &     flag_init,flag_restart,         &
      &     qc,qi,                          &
      &     qc_save, qi_save,               &
      &     errmsg, errflg                  )
@@ -34,6 +35,7 @@ SUBROUTINE mynnrad_post_run(               &
 !------------------------------------------------------------------- 
 
       integer, intent(in)  :: ix, im, levs
+      logical,          intent(in)  :: flag_init, flag_restart
       real(kind=kind_phys), dimension(im,levs), intent(out) :: qc, qi
       real(kind=kind_phys), dimension(im,levs), intent(in)  :: qc_save, qi_save
       character(len=*), intent(out) :: errmsg
@@ -47,6 +49,11 @@ SUBROUTINE mynnrad_post_run(               &
 
       !write(0,*)"=============================================="
       !write(0,*)"in mynn rad post"
+
+      if (flag_init .and. (.not. flag_restart)) then
+        !write (0,*) 'Skip MYNNrad_post flag_init = ', flag_init
+        return
+      endif
 
      ! Add subgrid cloud information:
         do k = 1, levs

--- a/physics/module_MYNNrad_post.meta
+++ b/physics/module_MYNNrad_post.meta
@@ -25,6 +25,22 @@
   type = integer
   intent = in
   optional = F
+[flag_init]
+  standard_name = flag_for_first_time_step
+  long_name = flag signaling first time step for time integration loop
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[flag_restart]
+  standard_name = flag_for_restart
+  long_name = flag for restart (warmstart) or coldstart
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
 [qc]
   standard_name = cloud_condensed_water_mixing_ratio
   long_name = moist (dry+vapor, no condensates) mixing ratio of cloud water (condensate)

--- a/physics/module_MYNNrad_pre.F90
+++ b/physics/module_MYNNrad_pre.F90
@@ -32,6 +32,7 @@
 !###===================================================================
 SUBROUTINE mynnrad_pre_run(                &
      &     ix,im,levs,                     &
+     &     flag_init,flag_restart,         &
      &     qc, qi, T3D,                    &
      &     qc_save, qi_save,               &
      &     qc_bl,cldfra_bl,                &
@@ -50,6 +51,7 @@ SUBROUTINE mynnrad_pre_run(                &
       ! Interface variables
       real (kind=kind_phys), parameter :: gfac=1.0e5/con_g
       integer, intent(in)  :: ix, im, levs
+      logical,          intent(in)  :: flag_init, flag_restart
       real(kind=kind_phys), dimension(im,levs), intent(inout) :: qc, qi
       real(kind=kind_phys), dimension(im,levs), intent(in)    :: T3D,delp
       real(kind=kind_phys), dimension(im,levs), intent(inout) :: &
@@ -71,13 +73,17 @@ SUBROUTINE mynnrad_pre_run(                &
       !write(0,*)"=============================================="
       !write(0,*)"in mynn rad pre"
 
+      if (flag_init .and. (.not. flag_restart)) then
+       !write (0,*) 'Skip MYNNrad_pre flag_init = ', flag_init
+        return
+      endif
      ! Add subgrid cloud information:
         do k = 1, levs
            do i = 1, im
 
               qc_save(i,k) = qc(i,k)
               qi_save(i,k) = qi(i,k)
-              clouds1(i,k)=CLDFRA_BL(i,k)
+              clouds1(i,k) = CLDFRA_BL(i,k)
 
               IF (qc(i,k) < 1.E-6 .AND. qi(i,k) < 1.E-8 .AND. CLDFRA_BL(i,k)>0.001) THEN
                 !Partition the BL clouds into water & ice according to a linear

--- a/physics/module_MYNNrad_pre.meta
+++ b/physics/module_MYNNrad_pre.meta
@@ -25,6 +25,22 @@
   type = integer
   intent = in
   optional = F
+[flag_init]
+  standard_name = flag_for_first_time_step
+  long_name = flag signaling first time step for time integration loop
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[flag_restart]
+  standard_name = flag_for_restart
+  long_name = flag for restart (warmstart) or coldstart
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
 [qc]
   standard_name = cloud_condensed_water_mixing_ratio
   long_name = moist (dry+vapor, no condensates) mixing ratio of cloud water (condensate)


### PR DESCRIPTION
The problem: the first call to the radiation happens before
the first call to MYNN PBL, therefore CLDFRA_BL=0 in the first call to mynnrad_pre,
and zero values are sent to array cldcov(:,:).
When cloud cover is zero, the RRTMG radiation thinks that there are no clouds at all.
The erroneous cloud-free LW and SW downward radiation fluxes affect the first
hour of itegration, and cause siginificant cooling in the ploar regions, and too warm
land surface temperature from cloud-free SW radiation.
The fix: the fist call to mynnrad_pre should be skipped, so that cloud cover - cldcov(:,:) - is not
overwritten by zero values of MYNN subgrid-clouds. In this case the initial cloud cover
is computed in progcld5 from initial cloud water mixing ratio,
relative humidity and specific humidity in the layer.
Starting with the second call to the rrtmg radiation, the MYNN subgrid clouds are used.
Attached are SW and LW downward fluxes before fix (left) and after fix (right)
![Screen Shot 2019-11-01 at 11 16 09 AM](https://user-images.githubusercontent.com/38667904/68042703-27d55900-fc99-11e9-897f-2c4230ccf107.png)
![Screen Shot 2019-11-01 at 11 16 29 AM](https://user-images.githubusercontent.com/38667904/68042712-2f94fd80-fc99-11e9-873a-1c2de8b287be.png)
