### PR TITLE
dtc/develop: prevent mismatch of namelist and suite definition file settings for ozone physics

### DIFF
--- a/physics/cires_ugwp.F90
+++ b/physics/cires_ugwp.F90
@@ -37,8 +37,8 @@ contains
 !!
 ! -----------------------------------------------------------------------
 !
-    subroutine cires_ugwp_init (me, master, nlunit, logunit, fn_nml2, &
-                lonr, latr, levs, ak, bk, dtp, cdmbgwd, cgwf,         &
+    subroutine cires_ugwp_init (me, master, nlunit, input_nml_file, logunit, &
+                fn_nml2, lonr, latr, levs, ak, bk, dtp, cdmbgwd, cgwf,       &
                 pa_rf_in, tau_rf_in, con_p0, do_ugwp, errmsg, errflg)
 
 !----  initialization of cires_ugwp
@@ -47,6 +47,7 @@ contains
     integer,              intent (in) :: me
     integer,              intent (in) :: master
     integer,              intent (in) :: nlunit
+    character(len=*),     intent (in) :: input_nml_file(:)
     integer,              intent (in) :: logunit
     integer,              intent (in) :: lonr
     integer,              intent (in) :: levs
@@ -76,8 +77,8 @@ contains
     if (is_initialized) return
 
     if (do_ugwp .or. cdmbgwd(3) > 0.0) then
-      call cires_ugwp_mod_init (me, master, nlunit, logunit, fn_nml2,  &
-                                lonr, latr, levs, ak, bk, con_p0, dtp, &
+      call cires_ugwp_mod_init (me, master, nlunit, input_nml_file, logunit, &
+                                fn_nml2, lonr, latr, levs, ak, bk, con_p0, dtp, &
                                 cdmbgwd(1:2), cgwf, pa_rf_in, tau_rf_in)
     else
       write(errmsg,'(*(a))') "Logic error: cires_ugwp_init called but do_ugwp is false and cdmbgwd(3) <= 0"

--- a/physics/cires_ugwp.meta
+++ b/physics/cires_ugwp.meta
@@ -25,6 +25,15 @@
   type = integer
   intent = in
   optional = F
+[input_nml_file]
+  standard_name = namelist_filename_for_internal_file_reads
+  long_name = character string to store full namelist contents
+  units = none
+  dimensions = (number_of_lines_of_namelist_filename_for_internal_file_reads)
+  type = character
+  kind = len=*
+  intent = in
+  optional = F
 [logunit]
   standard_name = iounit_log
   long_name = fortran unit number for writing logfile

--- a/physics/cires_ugwp_module.F90
+++ b/physics/cires_ugwp_module.F90
@@ -106,12 +106,10 @@ module  cires_ugwp_module
 ! init  of cires_ugwp   (_init)  called from GFS_driver.F90
 !
 ! -----------------------------------------------------------------------
-   subroutine cires_ugwp_mod_init (me, master, nlunit, logunit, fn_nml2, &
-              lonr, latr, levs, ak, bk, pref, dtp, cdmvgwd, cgwf,    &
+   subroutine cires_ugwp_mod_init (me, master, nlunit, input_nml_file, logunit, &
+              fn_nml, lonr, latr, levs, ak, bk, pref, dtp, cdmvgwd, cgwf,    &
               pa_rf_in, tau_rf_in)
-!
-!  input_nml_file ='input.nml'=fn_nml
-!
+
     use  ugwp_oro_init,     only :  init_oro_gws
     use  ugwp_conv_init,    only :  init_conv_gws
     use  ugwp_fjet_init,    only :  init_fjet_gws
@@ -120,31 +118,33 @@ module  cires_ugwp_module
     use  ugwp_lsatdis_init, only :  initsolv_lsatdis
     implicit none
 
-    integer, intent (in) :: me
-    integer, intent (in) :: master
-    integer, intent (in) :: nlunit
-    integer, intent (in) :: logunit
-    integer, intent (in) :: lonr
-    integer, intent (in) :: levs
-    integer, intent (in) :: latr
-    real,    intent (in) :: ak(levs+1), bk(levs+1), pref
-    real,    intent (in) :: dtp
-    real,    intent (in) :: cdmvgwd(2), cgwf(2)             ! "scaling" controls for "old" GFS-GW schemes
-    real,    intent (in) :: pa_rf_in, tau_rf_in
- 
-    character(len=64), intent (in) :: fn_nml2
-    character(len=64), parameter   :: fn_nml='input.nml'
+    integer,              intent (in) :: me
+    integer,              intent (in) :: master
+    integer,              intent (in) :: nlunit
+    character (len = *),  intent (in) :: input_nml_file(:)
+    integer,              intent (in) :: logunit
+    character(len=64),    intent (in) :: fn_nml
+    integer,              intent (in) :: lonr
+    integer,              intent (in) :: levs
+    integer,              intent (in) :: latr
+    real,                 intent (in) :: ak(levs+1), bk(levs+1), pref
+    real,                 intent (in) :: dtp
+    real,                 intent (in) :: cdmvgwd(2), cgwf(2)             ! "scaling" controls for "old" GFS-GW schemes
+    real,                 intent (in) :: pa_rf_in, tau_rf_in
 
-!    character,  intent (in) :: input_nml_file
 !    integer, parameter :: logunit =  6
     integer :: ios
     logical :: exists
     real    :: dxsg
     integer :: k
-!
+
+#ifdef INTERNAL_FILE_NML
+    read (input_nml_file, nml = cires_ugwp_nml)
+#else
     if (me == master) print *, trim (fn_nml), ' GW-namelist file '
+    
     inquire (file =trim (fn_nml) , exist = exists)
-!
+
     if (.not. exists) then
        if (me == master) &
         write (6, *) 'separate ugwp :: namelist file: ', trim (fn_nml), ' does not exist'
@@ -154,6 +154,10 @@ module  cires_ugwp_module
     rewind (nlunit)
     read   (nlunit, nml = cires_ugwp_nml)
     close  (nlunit)
+#endif
+
+    
+    
 !
     ilaunch = launch_level
     pa_rf   = pa_rf_in

--- a/physics/ozphys.f
+++ b/physics/ozphys.f
@@ -10,8 +10,25 @@
 ! \brief Brief description of the subroutine
 !
 !> \section arg_table_ozphys_init Argument Table
+!! \htmlinclude ozphys_init.html
 !!
-      subroutine ozphys_init()
+      subroutine ozphys_init(oz_phys, errmsg, errflg)
+
+      implicit none
+      logical,          intent(in)  :: oz_phys
+      character(len=*), intent(out) :: errmsg
+      integer,          intent(out) :: errflg
+
+      ! Initialize CCPP error handling variables
+      errmsg = ''
+      errflg = 0
+
+      if (.not.oz_phys) then
+        write (errmsg,'(*(a))') 'Logic error: oz_phys == .false.'
+        errflg = 1
+        return
+      endif
+
       end subroutine ozphys_init
 
 ! \brief Brief description of the subroutine

--- a/physics/ozphys.meta
+++ b/physics/ozphys.meta
@@ -1,6 +1,31 @@
 [ccpp-arg-table]
   name = ozphys_init
   type = scheme
+[oz_phys]
+  standard_name = flag_for_ozone_physics
+  long_name = flag for old (2006) ozone physics
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+  optional = F
+[errflg]
+  standard_name = ccpp_error_flag
+  long_name = error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+  optional = F
 
 ########################################################################
 [ccpp-arg-table]

--- a/physics/ozphys_2015.f
+++ b/physics/ozphys_2015.f
@@ -8,8 +8,25 @@
       contains
 
 !> \section arg_table_ozphys_2015_init Argument Table
+!! \htmlinclude ozphys_2015_init.html
 !!
-      subroutine ozphys_2015_init()
+      subroutine ozphys_2015_init(oz_phys_2015, errmsg, errflg)
+
+      implicit none
+      logical,          intent(in)  :: oz_phys_2015
+      character(len=*), intent(out) :: errmsg
+      integer,          intent(out) :: errflg
+
+      ! Initialize CCPP error handling variables
+      errmsg = ''
+      errflg = 0
+
+      if (.not.oz_phys_2015) then
+        write (errmsg,'(*(a))') 'Logic error: oz_phys_2015 == .false.'
+        errflg = 1
+        return
+      endif
+
       end subroutine ozphys_2015_init
 
 ! \brief Brief description of the subroutine

--- a/physics/ozphys_2015.meta
+++ b/physics/ozphys_2015.meta
@@ -1,6 +1,31 @@
 [ccpp-arg-table]
   name = ozphys_2015_init
   type = scheme
+[oz_phys_2015]
+  standard_name = flag_for_2015_ozone_physics
+  long_name = flag for new (2015) ozone physics
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+  optional = F
+[errflg]
+  standard_name = ccpp_error_flag
+  long_name = error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+  optional = F
 
 ########################################################################
 [ccpp-arg-table]


### PR DESCRIPTION
**TODO: target dtc/develop**

This PR adds guards to the init routines of the old and new ozone physics that prevent mismatches of the namelist options oz_phys/oz_phys_2015 and the entry in the suite definition file.

This PR includes the CIRES UGWP namelist fix from @grantfirl (https://github.com/NCAR/ccpp-physics/pull/343).

Associated PRs:

https://github.com/NCAR/gmtb-scm/pull/136
**MISSING PR for ufs-weather-model**
