### PR TITLE
GFS_surface_composites.F90: apply missing change for fv3atm PR8

### DIFF
--- a/physics/GFS_surface_composites.F90
+++ b/physics/GFS_surface_composites.F90
@@ -123,7 +123,7 @@ contains
             if (cice(i) < one) then
               wet(i) = .true.
   !           tsfco(i) = tgice
-              tsfco(i) = max(tisfc(i), tgice)
+              if (.not. cplflx) tsfco(i) = max(tisfc(i), tgice)
   !           tsfco(i) = max((tsfc(i) - cice(i)*tisfc(i)) &
   !                                     / (one - cice(i)), tgice)
             endif


### PR DESCRIPTION
This PR applies a change to GFS_surface_composites.F90 that was made in IPD physics in https://github.com/NOAA-EMC/fv3atm/pull/8 and that has not been made for CCPP physics yet.

This PR should be tested and merged with the next commit to fv3atm (https://github.com/NOAA-EMC/fv3atm).