### PR TITLE
Added the capability to use climatological LAI in RUC LSM

### DIFF
--- a/physics/module_sf_ruclsm.F90
+++ b/physics/module_sf_ruclsm.F90
@@ -67,7 +67,7 @@ CONTAINS
                    Z3D,P8W,T3D,QV3D,QC3D,RHO3D,                  &
                    GLW,GSW,EMISS,CHKLOWQ, CHS,                   &
                    FLQC,FLHC,MAVAIL,CANWAT,VEGFRA,ALB,ZNT,       &
-                   Z0,SNOALB,ALBBCK,                             & !Z0,SNOALB,ALBBCK,LAI, &
+                   Z0,SNOALB,ALBBCK,LAI,                         & 
                    landusef, nlcat,                              & ! mosaic_lu, mosaic_soil, &
                    soilctop, nscat,                              &
                    QSFC,QSG,QVG,QCG,DEW,SOILT1,TSNAV,            &
@@ -218,6 +218,7 @@ CONTAINS
                                                          CANWAT, & ! new
                                                          SNOALB, &
                                                             ALB, &
+                                                            LAI, &
                                                           EMISS, &
                                                          MAVAIL, & 
                                                          SFCEXC, &
@@ -269,7 +270,6 @@ CONTAINS
                                                              PC, &
                                                       SFCRUNOFF, &
                                                        UDRUNOFF, &
-                                                            LAI, &
                                                          EMISSL, &
                                                            ZNTL, &
                                                         LMAVAIL, &

--- a/physics/sfc_drv_ruc.meta
+++ b/physics/sfc_drv_ruc.meta
@@ -198,6 +198,12 @@
   type = integer
   intent = in
   optional = F
+[rdlai]
+  standard_name = flag_for_reading_leaf_area_index_from_input
+  long_name = flag for reading leaf area index from initial conditions for RUC LSM
+  units = flag
+  dimensions = ()
+  type = logical
 [zs]
   standard_name = depth_of_soil_levels_for_land_surface_model
   long_name = depth of soil levels for land surface model
@@ -555,6 +561,14 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
+[laixy]
+  standard_name = leaf_area_index
+  long_name = leaf area index
+  units = none
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
   optional = F
 [sfalb]
   standard_name = surface_diffused_shortwave_albedo


### PR DESCRIPTION
This PR goes together with the PR https://github.com/NCAR/FV3/pull/220 in the FV3's gsd/develop branch.
It gives RUC LSM the capability to initialize Leaf Area Index (LAI) from the climatological data in INPUT/sfc_data.nc. This capability is controlled by the namelist parameter rdlai. No change in performance if rdlai=.false., but if rdlai=.true. the climatological LAI data will be used inside RUC LSM.
The code has been tested and works as intended both with rdlai=.false. and rdlai=.true.