### PR TITLE
Cleanup radiation tendencies (standard names)

### DIFF
--- a/physics/GFS_PBL_generic.meta
+++ b/physics/GFS_PBL_generic.meta
@@ -747,7 +747,7 @@
   intent = in
   optional = F
 [htrsw]
-  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_timestep
+  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_time_step
   long_name = total sky sw heating rate
   units = K s-1
   dimensions = (horizontal_dimension,vertical_dimension)
@@ -756,7 +756,7 @@
   intent = in
   optional = F
 [htrlw]
-  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_timestep
+  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_time_step
   long_name = total sky lw heating rate
   units = K s-1
   dimensions = (horizontal_dimension,vertical_dimension)

--- a/physics/GFS_suite_interstitial.meta
+++ b/physics/GFS_suite_interstitial.meta
@@ -443,7 +443,7 @@
   intent = in
   optional = F
 [htrsw]
-  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_timestep
+  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_time_step
   long_name = total sky sw heating rate
   units = K s-1
   dimensions = (horizontal_dimension,vertical_dimension)
@@ -452,7 +452,7 @@
   intent = in
   optional = F
 [htrlw]
-  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_timestep
+  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_time_step
   long_name = total sky lw heating rate
   units = K s-1
   dimensions = (horizontal_dimension,vertical_dimension)

--- a/physics/dcyc2.meta
+++ b/physics/dcyc2.meta
@@ -183,7 +183,7 @@
   intent = in
   optional = F
 [swh]
-  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_timestep
+  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_time_step
   long_name = total sky shortwave heating rate on radiation time step
   units = K s-1
   dimensions = (horizontal_dimension,vertical_dimension)
@@ -192,7 +192,7 @@
   intent = in
   optional = F
 [swhc]
-  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_on_radiation_timestep
+  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_on_radiation_time_step
   long_name = clear sky shortwave heating rate on radiation time step
   units = K s-1
   dimensions = (horizontal_dimension,vertical_dimension)
@@ -201,7 +201,7 @@
   intent = in
   optional = F
 [hlw]
-  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_timestep
+  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_time_step
   long_name = total sky longwave heating rate on radiation time step
   units = K s-1
   dimensions = (horizontal_dimension,vertical_dimension)
@@ -210,7 +210,7 @@
   intent = in
   optional = F
 [hlwc]
-  standard_name = tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_on_radiation_timestep
+  standard_name = tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_on_radiation_time_step
   long_name = clear sky longwave heating rate on radiation time step
   units = K s-1
   dimensions = (horizontal_dimension,vertical_dimension)

--- a/physics/m_micro.meta
+++ b/physics/m_micro.meta
@@ -424,7 +424,7 @@
   intent = in
   optional = F
 [lwheat_i]
-  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_timestep
+  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_time_step
   long_name = total sky lw heating rate
   units = K s-1
   dimensions = (horizontal_dimension,vertical_dimension)
@@ -433,7 +433,7 @@
   intent = in
   optional = F
 [swheat_i]
-  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_timestep
+  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_time_step
   long_name = total sky sw heating rate
   units = K s-1
   dimensions = (horizontal_dimension,vertical_dimension)

--- a/physics/module_MYNNPBL_wrapper.meta
+++ b/physics/module_MYNNPBL_wrapper.meta
@@ -729,7 +729,7 @@
   intent = inout
   optional = F
 [htrsw]
-  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_timestep
+  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_time_step
   long_name = total sky sw heating rate
   units = K s-1
   dimensions = (horizontal_dimension,vertical_dimension)
@@ -738,7 +738,7 @@
   intent = in
   optional = F
 [htrlw]
-  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_timestep
+  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_time_step
   long_name = total sky lw heating rate
   units = K s-1
   dimensions = (horizontal_dimension,vertical_dimension)

--- a/physics/moninedmf.meta
+++ b/physics/moninedmf.meta
@@ -145,7 +145,7 @@
   intent = in
   optional = F
 [swh]
-  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_timestep
+  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_time_step
   long_name = total sky shortwave heating rate
   units = K s-1
   dimensions = (horizontal_dimension,vertical_dimension)
@@ -154,7 +154,7 @@
   intent = in
   optional = F
 [hlw]
-  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_timestep
+  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_time_step
   long_name = total sky longwave heating rate
   units = K s-1
   dimensions = (horizontal_dimension,vertical_dimension)

--- a/physics/moninedmf_hafs.meta
+++ b/physics/moninedmf_hafs.meta
@@ -145,7 +145,7 @@
   intent = in
   optional = F
 [swh]
-  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_timestep
+  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_time_step
   long_name = total sky shortwave heating rate
   units = K s-1
   dimensions = (horizontal_dimension,vertical_dimension)
@@ -154,7 +154,7 @@
   intent = in
   optional = F
 [hlw]
-  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_timestep
+  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_time_step
   long_name = total sky longwave heating rate
   units = K s-1
   dimensions = (horizontal_dimension,vertical_dimension)

--- a/physics/radlw_main.meta
+++ b/physics/radlw_main.meta
@@ -257,7 +257,7 @@
   intent = in
   optional = F
 [hlwc]
-  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_time_step
+  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_time_step_and_radiation_levels
   long_name = longwave total sky heating rate
   units = K s-1
   dimensions = (horizontal_dimension,adjusted_vertical_layer_dimension_for_radiation)
@@ -291,7 +291,7 @@
   intent = inout
   optional = F
 [hlw0]
-  standard_name = tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_on_radiation_time_step
+  standard_name = tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_on_radiation_time_step_and_radiation_levels
   long_name = longwave clear sky heating rate
   units = K s-1
   dimensions = (horizontal_dimension,adjusted_vertical_layer_dimension_for_radiation)

--- a/physics/radsw_main.meta
+++ b/physics/radsw_main.meta
@@ -318,7 +318,7 @@
   intent = in
   optional = F
 [hswc]
-  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_time_step
+  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_time_step_and_radiation_levels
   long_name = shortwave total sky heating rate
   units = K s-1
   dimensions = (horizontal_dimension,adjusted_vertical_layer_dimension_for_radiation)
@@ -352,7 +352,7 @@
   intent = inout
   optional = F
 [hsw0]
-  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_on_radiation_time_step
+  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_on_radiation_time_step_and_radiation_levels
   long_name = shortwave clear sky heating rate
   units = K s-1
   dimensions = (horizontal_dimension,adjusted_vertical_layer_dimension_for_radiation)

--- a/physics/rrtmg_lw_post.meta
+++ b/physics/rrtmg_lw_post.meta
@@ -80,7 +80,7 @@
   intent = in
   optional = F
 [htlwc]
-  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_time_step
+  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_time_step_and_radiation_levels
   long_name = total sky heating rate due to longwave radiation
   units = K s-1
   dimensions = (horizontal_dimension,adjusted_vertical_layer_dimension_for_radiation)
@@ -89,7 +89,7 @@
   intent = in
   optional = F
 [htlw0]
-  standard_name = tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_on_radiation_time_step
+  standard_name = tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_on_radiation_time_step_and_radiation_levels
   long_name = clear sky heating rate due to longwave radiation
   units = K s-1
   dimensions = (horizontal_dimension,adjusted_vertical_layer_dimension_for_radiation)

--- a/physics/rrtmg_sw_post.meta
+++ b/physics/rrtmg_sw_post.meta
@@ -87,7 +87,7 @@
   intent = in
   optional = F
 [htswc]
-  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_time_step
+  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_time_step_and_radiation_levels
   long_name = total sky heating rate due to shortwave radiation
   units = K s-1
   dimensions = (horizontal_dimension,adjusted_vertical_layer_dimension_for_radiation)
@@ -96,7 +96,7 @@
   intent = in
   optional = F
 [htsw0]
-  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_on_radiation_time_step
+  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_on_radiation_time_step_and_radiation_levels
   long_name = clear sky heating rates due to shortwave radiation
   units = K s-1
   dimensions = (horizontal_dimension,adjusted_vertical_layer_dimension_for_radiation)

--- a/physics/satmedmfvdif.meta
+++ b/physics/satmedmfvdif.meta
@@ -249,7 +249,7 @@
   intent = in
   optional = F
 [swh]
-  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_timestep
+  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_time_step
   long_name = total sky shortwave heating rate
   units = K s-1
   dimensions = (horizontal_dimension,vertical_dimension)
@@ -258,7 +258,7 @@
   intent = in
   optional = F
 [hlw]
-  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_timestep
+  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_time_step
   long_name = total sky longwave heating rate
   units = K s-1
   dimensions = (horizontal_dimension,vertical_dimension)

--- a/physics/satmedmfvdifq.meta
+++ b/physics/satmedmfvdifq.meta
@@ -249,7 +249,7 @@
   intent = in
   optional = F
 [swh]
-  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_timestep
+  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_time_step
   long_name = total sky shortwave heating rate
   units = K s-1
   dimensions = (horizontal_dimension,vertical_dimension)
@@ -258,7 +258,7 @@
   intent = in
   optional = F
 [hlw]
-  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_timestep
+  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_time_step
   long_name = total sky longwave heating rate
   units = K s-1
   dimensions = (horizontal_dimension,vertical_dimension)

--- a/physics/ysuvdif.meta
+++ b/physics/ysuvdif.meta
@@ -125,7 +125,7 @@
   intent = inout
   optional = F
 [swh]
-  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_timestep
+  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_time_step
   long_name = total sky shortwave heating rate
   units = K s-1
   dimensions = (horizontal_dimension,vertical_dimension)
@@ -134,7 +134,7 @@
   intent = in
   optional = F
 [hlw]
-  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_timestep
+  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_time_step
   long_name = total sky longwave heating rate
   units = K s-1
   dimensions = (horizontal_dimension,vertical_dimension)


### PR DESCRIPTION
This PR addresses issue https://github.com/NCAR/ccpp-physics/issues/179. It only deals with the clean up of the standard names as described in the issue, it does not remove the LTP (extra layers for radiation) logic.

Associated PRs:

https://github.com/NCAR/ccpp-physics/pull/422
https://github.com/NCAR/fv3atm/pull/34
https://github.com/NCAR/ufs-weather-model/pull/32

For regression testing information, see https://github.com/NCAR/ufs-weather-model/pull/32.