### PR TITLE
Cleanup SCM build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,13 +33,6 @@ set(AUTHORS  "Grant J. Firl" "Dom Heinzeller")
 # Enable Fortran
 enable_language(Fortran)
 
-if (PROJECT STREQUAL "CCPP-SCM")
-  #------------------------------------------------------------------------------
-  # CMake Modules
-  # Set the CMake module path
-  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../framework/cmake")
-endif (PROJECT STREQUAL "CCPP-SCM")
-
 #------------------------------------------------------------------------------
 # Set OpenMP flags for C/C++/Fortran
 if (OPENMP)
@@ -345,13 +338,7 @@ elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "PGI")
   set_property(SOURCE ${CAPS} APPEND_STRING PROPERTY COMPILE_FLAGS " -Mnobounds ")
 endif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
 
-if (PROJECT STREQUAL "CCPP-SCM")
-    message(FATAL_ERROR "SHOULDN'T BE HERE!!!")
-  INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR}/ccpp/framework/src)
-endif (PROJECT STREQUAL "CCPP-SCM")
-
 #------------------------------------------------------------------------------
-
 if(STATIC)
   add_library(ccppphys STATIC ${SCHEMES} ${SCHEMES_SFX_OPT} ${CAPS})
   # Generate list of Fortran modules from defined sources


### PR DESCRIPTION
Remove unneeded build code for SCM, including an unintentionally left `message(FATAL_ERROR ...)` exception

After merging this PR, the submodule pointer in UFS' fv3atm should be updated, too (no testing required, all code changes are inside `if (PROJECT STREQUAL "CCPP-SCM")` blocks.

Tested together with https://github.com/NCAR/gmtb-scm/pull/179; this ccpp-physics PR https://github.com/NCAR/ccpp-physics/pull/426 must be merged first, and the submodule pointer must be updated in the gmtb-scm PR https://github.com/NCAR/gmtb-scm/pull/179.