### PR TITLE
dtc/hwrf-physics: combined version of HAFS/GFS moninedmf scheme (hybrid EDMF PBL)

### DIFF
--- a/physics/moninedmf.f
+++ b/physics/moninedmf.f
@@ -775,7 +775,7 @@ c
           do k = 1, kmpbl ! kmpbl is like a max possible pbl height
             if (zi(i,k) .le. 500. .and. zi(i,k+1) .gt. 500.) then ! find level bracketing 500 m
               spdk2 = SQRT(u1(i,k)*u1(i,k)+v1(i,k)*v1(i,k)) ! wspd near 500 m
-              wspm(i,1) = spdkw/0.6  ! now the Km limit for 500 m.  just store in K=1
+              wspm(i,1) = spdk2/0.6  ! now the Km limit for 500 m.  just store in K=1
               wspm(i,2) = float(k)  ! height of level at gridpoint i. store in K=2
             endif
           enddo !k

--- a/physics/moninedmf.meta
+++ b/physics/moninedmf.meta
@@ -542,42 +542,6 @@
   kind = kind_phys
   intent = in
   optional = F
-[grav]
-  standard_name = gravitational_acceleration
-  long_name = gravitational acceleration
-  units = m s-2
-  dimensions = ()
-  type = real
-  kind = kind_phys
-  intent = in
-  optional = F
-[cp]
-  standard_name = specific_heat_of_dry_air_at_constant_pressure
-  long_name = specific heat of dry air at constant pressure
-  units = J kg-1 K-1
-  dimensions = ()
-  type = real
-  kind = kind_phys
-  intent = in
-  optional = F
-[hvap]
-  standard_name = latent_heat_of_vaporization_of_water_at_0C
-  long_name = latent heat of evaporation/sublimation
-  units = J kg-1
-  dimensions = ()
-  type = real
-  kind = kind_phys
-  intent = in
-  optional = F
-[fv]
-  standard_name = ratio_of_vapor_to_dry_air_gas_constants_minus_one
-  long_name = (rv/rd) - 1 (rv = ideal gas constant for water vapor)
-  units = none
-  dimensions = ()
-  type = real
-  kind = kind_phys
-  intent = in
-  optional = F
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP

--- a/physics/moninedmf.meta
+++ b/physics/moninedmf.meta
@@ -507,7 +507,7 @@
   type = logical
   intent = in
   optional = F
-[islmsk]
+[islimsk]
   standard_name = sea_land_ice_mask
   long_name = sea/land/ice mask (=0/1/2)
   units = flag

--- a/physics/moninedmf.meta
+++ b/physics/moninedmf.meta
@@ -499,6 +499,49 @@
   kind = kind_phys
   intent = in
   optional = F
+[hurr_pbl]
+  standard_name = flag_hurricane_PBL
+  long_name = flag for hurricane-specific options in PBL scheme
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[islmsk]
+  standard_name = sea_land_ice_mask
+  long_name = sea/land/ice mask (=0/1/2)
+  units = flag
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = in
+  optional = F
+[var_ric]
+  standard_name = flag_variable_bulk_richardson_number
+  long_name = flag for calculating variable bulk richardson number for hurricane PBL
+  units = flag
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[coef_ric_l]
+  standard_name = coefficient_for_variable_bulk_richardson_number_over_land
+  long_name = coefficient for calculating variable bulk richardson number for hurricane PBL over land
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[coef_ric_s]
+  standard_name = coefficient_for_variable_bulk_richardson_number_over_ocean
+  long_name = coefficient for calculating variable bulk richardson number for hurricane PBL over ocean
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP

--- a/physics/moninedmf.meta
+++ b/physics/moninedmf.meta
@@ -542,6 +542,42 @@
   kind = kind_phys
   intent = in
   optional = F
+[grav]
+  standard_name = gravitational_acceleration
+  long_name = gravitational acceleration
+  units = m s-2
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[cp]
+  standard_name = specific_heat_of_dry_air_at_constant_pressure
+  long_name = specific heat of dry air at constant pressure
+  units = J kg-1 K-1
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[hvap]
+  standard_name = latent_heat_of_vaporization_of_water_at_0C
+  long_name = latent heat of evaporation/sublimation
+  units = J kg-1
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[fv]
+  standard_name = ratio_of_vapor_to_dry_air_gas_constants_minus_one
+  long_name = (rv/rd) - 1 (rv = ideal gas constant for water vapor)
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP


### PR DESCRIPTION
- based on https://github.com/NCAR/ccpp-physics/pull/395 but for branch dtc/hwrf-physics
- cherry-picked the following commits:
```
    git cherry-pick 942889ab0acace519254712cb4e14b6aaf3e0415
    git cherry-pick 500d53a21027f362a9c12c10767f0b4f8cf3361c
    git cherry-pick b0f04b210bd588673182023ea36b56ee94642c3e
    git cherry-pick e895c62cf49b908927678d72c1ad21ad828e3587
```
- apply changes for `moninedmf.{f,meta}` hidden in update of code from dtc/develop (0ae7516)

Associated PRs:

https://github.com/NCAR/ccpp-physics/pull/428
https://github.com/NCAR/fv3atm/pull/37
https://github.com/NCAR/ufs-weather-model/pull/35

For regression testing information, see https://github.com/NCAR/ufs-weather-model/pull/35
