### PR TITLE
Adding a separate array to store internal ice temperature

### DIFF
--- a/physics/GFS_PBL_generic.F90
+++ b/physics/GFS_PBL_generic.F90
@@ -287,7 +287,7 @@
         dqsfc_cpl, dusfci_cpl, dvsfci_cpl, dtsfci_cpl, dqsfci_cpl, dusfc_diag, dvsfc_diag, dtsfc_diag, dqsfc_diag,             &
         dusfci_diag, dvsfci_diag, dtsfci_diag, dqsfci_diag, dt3dt, du3dt_PBL, du3dt_OGWD, dv3dt_PBL, dv3dt_OGWD, dq3dt,        &
         dq3dt_ozone, rd, cp,fvirt, hvap, t1, q1, prsl, hflx, ushfsfci, oceanfrac, fice, dusfc_cice, dvsfc_cice, dtsfc_cice,    &
-        dqsfc_cice, wet, dry, icy, wind, stress_ocn, hflx_ocn, evap_ocn, ugrs1, vgrs1, dkt_cpl, dkt, errmsg, errflg)
+        dqsfc_cice, wet, dry, icy, wind, stress_wat, hflx_wat, evap_wat, ugrs1, vgrs1, dkt_cpl, dkt, errmsg, errflg)
 
       use machine,                only : kind_phys
       use GFS_PBL_generic_common, only : set_aerosol_tracer_index
@@ -307,7 +307,7 @@
       real(kind=kind_phys), dimension(:), intent(in) :: t1, q1, hflx, oceanfrac, fice
       real(kind=kind_phys), dimension(:,:), intent(in) :: prsl
       real(kind=kind_phys), dimension(:), intent(in) :: dusfc_cice, dvsfc_cice, dtsfc_cice, dqsfc_cice, &
-          wind, stress_ocn, hflx_ocn, evap_ocn, ugrs1, vgrs1
+          wind, stress_wat, hflx_wat, evap_wat, ugrs1, vgrs1
       real(kind=kind_phys), dimension(im, levs, nvdiff), intent(in) :: dvdftra
       real(kind=kind_phys), dimension(im), intent(in) :: dusfc1, dvsfc1, dtsfc1, dqsfc1, xmu
       real(kind=kind_phys), dimension(im, levs), intent(in) :: dudt, dvdt, dtdt, htrsw, htrlw
@@ -511,15 +511,15 @@
               tem1 = max(q1(i), 1.e-8)
               rho = prsl(i,1) / (rd*t1(i)*(one+fvirt*tem1))
               if (wind(i) > zero) then
-                tem = - rho * stress_ocn(i) / wind(i)
+                tem = - rho * stress_wat(i) / wind(i)
                 dusfci_cpl(i) = tem * ugrs1(i)   ! U-momentum flux
                 dvsfci_cpl(i) = tem * vgrs1(i)   ! V-momentum flux
               else
                 dusfci_cpl(i) = zero
                 dvsfci_cpl(i) = zero
               endif
-              dtsfci_cpl(i) = cp   * rho * hflx_ocn(i) ! sensible heat flux over open ocean
-              dqsfci_cpl(i) = hvap * rho * evap_ocn(i) ! latent heat flux over open ocean
+              dtsfci_cpl(i) = cp   * rho * hflx_wat(i) ! sensible heat flux over open ocean
+              dqsfci_cpl(i) = hvap * rho * evap_wat(i) ! latent heat flux over open ocean
             else                                       ! use results from PBL scheme for 100% open ocean
               dusfci_cpl(i) = dusfc1(i)
               dvsfci_cpl(i) = dvsfc1(i)

--- a/physics/GFS_PBL_generic.meta
+++ b/physics/GFS_PBL_generic.meta
@@ -1157,7 +1157,7 @@
   kind = kind_phys
   intent = in
   optional = F
-[stress_ocn]
+[stress_wat]
   standard_name = surface_wind_stress_over_ocean
   long_name = surface wind stress over ocean
   units = m2 s-2
@@ -1166,7 +1166,7 @@
   kind = kind_phys
   intent = in
   optional = F
-[hflx_ocn]
+[hflx_wat]
   standard_name = kinematic_surface_upward_sensible_heat_flux_over_ocean
   long_name = kinematic surface upward sensible heat flux over ocean
   units = K m s-1
@@ -1175,7 +1175,7 @@
   kind = kind_phys
   intent = in
   optional = F
-[evap_ocn]
+[evap_wat]
   standard_name = kinematic_surface_upward_latent_heat_flux_over_ocean
   long_name = kinematic surface upward latent heat flux over ocean
   units = kg kg-1 m s-1

--- a/physics/GFS_suite_interstitial.F90
+++ b/physics/GFS_suite_interstitial.F90
@@ -160,7 +160,7 @@
     subroutine GFS_suite_interstitial_2_run (im, levs, lssav, ldiag3d, lsidea, cplflx, flag_cice, shal_cnv, old_monin, mstrat,       &
       do_shoc, frac_grid, imfshalcnv, dtf, xcosz, adjsfcdsw, adjsfcdlw, cice, pgr, ulwsfc_cice, lwhd, htrsw, htrlw, xmu, ctei_rm,    &
       work1, work2, prsi, tgrs, prsl, qgrs_water_vapor, qgrs_cloud_water, cp, hvap, prslk, suntim, adjsfculw, adjsfculw_lnd,         &
-      adjsfculw_ice, adjsfculw_ocn, dlwsfc, ulwsfc, psmean, dt3dt_lw, dt3dt_sw, dt3dt_pbl, dt3dt_dcnv, dt3dt_scnv, dt3dt_mp,         &
+      adjsfculw_ice, adjsfculw_wat, dlwsfc, ulwsfc, psmean, dt3dt_lw, dt3dt_sw, dt3dt_pbl, dt3dt_dcnv, dt3dt_scnv, dt3dt_mp,         &
       ctei_rml, ctei_r, kinver, dry, icy, wet, frland, huge, errmsg, errflg)
 
       implicit none
@@ -181,7 +181,7 @@
 
       integer,              intent(inout), dimension(im) :: kinver
       real(kind=kind_phys), intent(inout), dimension(im) :: suntim, dlwsfc, ulwsfc, psmean, ctei_rml, ctei_r
-      real(kind=kind_phys), intent(in   ), dimension(im) :: adjsfculw_lnd, adjsfculw_ice, adjsfculw_ocn
+      real(kind=kind_phys), intent(in   ), dimension(im) :: adjsfculw_lnd, adjsfculw_ice, adjsfculw_wat
       real(kind=kind_phys), intent(  out), dimension(im) :: adjsfculw
 
       ! These arrays are only allocated if ldiag3d is .true.
@@ -232,11 +232,11 @@
             if (flag_cice(i)) then
               adjsfculw(i) = adjsfculw_lnd(i) * frland(i)               &
                            + ulwsfc_cice(i)   * tem                     &
-                           + adjsfculw_ocn(i) * (one - frland(i) - tem)
+                           + adjsfculw_wat(i) * (one - frland(i) - tem)
             else
               adjsfculw(i) = adjsfculw_lnd(i) * frland(i)               &
                            + adjsfculw_ice(i) * tem                     &
-                           + adjsfculw_ocn(i) * (one - frland(i) - tem)
+                           + adjsfculw_wat(i) * (one - frland(i) - tem)
             endif
           enddo
         else
@@ -246,20 +246,20 @@
             elseif (icy(i)) then                 ! ice (and water)
               tem = one - cice(i)
               if (flag_cice(i)) then
-                if (wet(i) .and. adjsfculw_ocn(i) /= huge) then
-                  adjsfculw(i) = ulwsfc_cice(i)*cice(i) + adjsfculw_ocn(i)*tem
+                if (wet(i) .and. adjsfculw_wat(i) /= huge) then
+                  adjsfculw(i) = ulwsfc_cice(i)*cice(i) + adjsfculw_wat(i)*tem
                 else
                   adjsfculw(i) = ulwsfc_cice(i)
                 endif
               else
-                if (wet(i) .and. adjsfculw_ocn(i) /= huge) then
-                  adjsfculw(i) = adjsfculw_ice(i)*cice(i) + adjsfculw_ocn(i)*tem
+                if (wet(i) .and. adjsfculw_wat(i) /= huge) then
+                  adjsfculw(i) = adjsfculw_ice(i)*cice(i) + adjsfculw_wat(i)*tem
                 else
                   adjsfculw(i) = adjsfculw_ice(i)
                 endif
               endif
             else                                 ! all water
-              adjsfculw(i) = adjsfculw_ocn(i)
+              adjsfculw(i) = adjsfculw_wat(i)
             endif
           enddo
         endif

--- a/physics/GFS_suite_interstitial.meta
+++ b/physics/GFS_suite_interstitial.meta
@@ -604,7 +604,7 @@
   kind = kind_phys
   intent = in
   optional = F
-[adjsfculw_ocn]
+[adjsfculw_wat]
   standard_name = surface_upwelling_longwave_flux_over_ocean_interstitial
   long_name = surface upwelling longwave flux at current time over ocean (temporary use as interstitial)
   units = W m-2

--- a/physics/GFS_surface_composites.F90
+++ b/physics/GFS_surface_composites.F90
@@ -26,12 +26,12 @@ contains
 !!
    subroutine GFS_surface_composites_pre_run (im, frac_grid, flag_cice, cplflx, cplwav2atm,                     &
                                  landfrac, lakefrac, oceanfrac,                                                 &
-                                 frland, dry, icy, lake, ocean, wet, cice, cimin, zorl, zorlo, zorll, zorl_ocn, &
-                                 zorl_lnd, zorl_ice, snowd, snowd_ocn, snowd_lnd, snowd_ice, tprcp, tprcp_ocn,  &
-                                 tprcp_lnd, tprcp_ice, uustar, uustar_lnd, uustar_ice, weasd, weasd_ocn,        &
-                                 weasd_lnd, weasd_ice, ep1d_ice, tsfc, tsfco, tsfcl, tsfc_ocn, tsfc_lnd,        &
-                                 tsfc_ice, tisfc, tice, tsurf, tsurf_ocn, tsurf_lnd, tsurf_ice, gflx_ice,       &
-                                 tgice, islmsk, semis_rad, semis_ocn, semis_lnd, semis_ice,                     &
+                                 frland, dry, icy, lake, ocean, wet, cice, cimin, zorl, zorlo, zorll, zorl_wat, &
+                                 zorl_lnd, zorl_ice, snowd, snowd_wat, snowd_lnd, snowd_ice, tprcp, tprcp_wat,  &
+                                 tprcp_lnd, tprcp_ice, uustar, uustar_lnd, uustar_ice, weasd, weasd_wat,        &
+                                 weasd_lnd, weasd_ice, ep1d_ice, tsfc, tsfco, tsfcl, tsfc_wat, tsfc_lnd,        &
+                                 tsfc_ice, tisfc, tice, tsurf, tsurf_wat, tsurf_lnd, tsurf_ice, gflx_ice,       &
+                                 tgice, islmsk, semis_rad, semis_wat, semis_lnd, semis_ice,                     &
                                  min_lakeice, min_seaice, errmsg, errflg)
 
       implicit none
@@ -48,14 +48,14 @@ contains
       real(kind=kind_phys), dimension(im), intent(in   ) :: zorl, snowd, tprcp, uustar, weasd
 
       real(kind=kind_phys), dimension(im), intent(inout) :: zorlo, zorll, tsfc, tsfco, tsfcl, tisfc, tsurf
-      real(kind=kind_phys), dimension(im), intent(inout) :: snowd_ocn, snowd_lnd, snowd_ice, tprcp_ocn, &
-        tprcp_lnd, tprcp_ice, zorl_ocn, zorl_lnd, zorl_ice, tsfc_ocn, tsfc_lnd, tsfc_ice, tsurf_ocn,    &
-        tsurf_lnd, tsurf_ice, uustar_lnd, uustar_ice, weasd_ocn, weasd_lnd, weasd_ice, ep1d_ice, gflx_ice
+      real(kind=kind_phys), dimension(im), intent(inout) :: snowd_wat, snowd_lnd, snowd_ice, tprcp_wat, &
+        tprcp_lnd, tprcp_ice, zorl_wat, zorl_lnd, zorl_ice, tsfc_wat, tsfc_lnd, tsfc_ice, tsurf_wat,    &
+        tsurf_lnd, tsurf_ice, uustar_lnd, uustar_ice, weasd_wat, weasd_lnd, weasd_ice, ep1d_ice, gflx_ice
       real(kind=kind_phys), dimension(im), intent(  out) :: tice
       real(kind=kind_phys),                intent(in   ) :: tgice
       integer,              dimension(im), intent(in   ) :: islmsk
       real(kind=kind_phys), dimension(im), intent(in   ) :: semis_rad
-      real(kind=kind_phys), dimension(im), intent(inout) :: semis_ocn, semis_lnd, semis_ice
+      real(kind=kind_phys), dimension(im), intent(inout) :: semis_wat, semis_lnd, semis_ice
       real(kind=kind_phys),                intent(in   ) :: min_lakeice, min_seaice
 
       ! CCPP error handling
@@ -138,18 +138,18 @@ contains
       endif
 
       do i=1,im
-        tprcp_ocn(i) = tprcp(i)
+        tprcp_wat(i) = tprcp(i)
         tprcp_lnd(i) = tprcp(i)
         tprcp_ice(i) = tprcp(i)
         if (wet(i)) then                   ! Water
-            zorl_ocn(i) = zorlo(i)
-            tsfc_ocn(i) = tsfco(i)
-           tsurf_ocn(i) = tsfco(i)
-!          weasd_ocn(i) = weasd(i)
-!          snowd_ocn(i) = snowd(i)
-           weasd_ocn(i) = zero
-           snowd_ocn(i) = zero
-           semis_ocn(i) = 0.984d0
+            zorl_wat(i) = zorlo(i)
+            tsfc_wat(i) = tsfco(i)
+           tsurf_wat(i) = tsfco(i)
+!          weasd_wat(i) = weasd(i)
+!          snowd_wat(i) = snowd(i)
+           weasd_wat(i) = zero
+           snowd_wat(i) = zero
+           semis_wat(i) = 0.984d0
         endif
         if (dry(i)) then                   ! Land
           uustar_lnd(i) = uustar(i)
@@ -204,8 +204,8 @@ contains
 !> \section arg_table_GFS_surface_composites_inter_run Argument Table
 !! \htmlinclude GFS_surface_composites_inter_run.html
 !!
-   subroutine GFS_surface_composites_inter_run (im, dry, icy, wet, semis_ocn, semis_lnd, semis_ice, adjsfcdlw, &
-                                                gabsbdlw_lnd, gabsbdlw_ice, gabsbdlw_ocn,                      &
+   subroutine GFS_surface_composites_inter_run (im, dry, icy, wet, semis_wat, semis_lnd, semis_ice, adjsfcdlw, &
+                                                gabsbdlw_lnd, gabsbdlw_ice, gabsbdlw_wat,                      &
                                                 adjsfcusw, adjsfcdsw, adjsfcnsw, errmsg, errflg)
 
       implicit none
@@ -213,9 +213,9 @@ contains
       ! Interface variables
       integer,                             intent(in   ) :: im
       logical,              dimension(im), intent(in   ) :: dry, icy, wet
-      real(kind=kind_phys), dimension(im), intent(in   ) :: semis_ocn, semis_lnd, semis_ice, adjsfcdlw, &
+      real(kind=kind_phys), dimension(im), intent(in   ) :: semis_wat, semis_lnd, semis_ice, adjsfcdlw, &
                                                             adjsfcdsw, adjsfcnsw
-      real(kind=kind_phys), dimension(im), intent(inout) :: gabsbdlw_lnd, gabsbdlw_ice, gabsbdlw_ocn
+      real(kind=kind_phys), dimension(im), intent(inout) :: gabsbdlw_lnd, gabsbdlw_ice, gabsbdlw_wat
       real(kind=kind_phys), dimension(im), intent(out)   :: adjsfcusw
 
       ! CCPP error handling
@@ -250,7 +250,7 @@ contains
       do i=1,im
         if (dry(i)) gabsbdlw_lnd(i) = semis_lnd(i) * adjsfcdlw(i)
         if (icy(i)) gabsbdlw_ice(i) = semis_ice(i) * adjsfcdlw(i)
-        if (wet(i)) gabsbdlw_ocn(i) = semis_ocn(i) * adjsfcdlw(i)
+        if (wet(i)) gabsbdlw_wat(i) = semis_wat(i) * adjsfcdlw(i)
         adjsfcusw(i) = adjsfcdsw(i) - adjsfcnsw(i)
       enddo
 
@@ -286,14 +286,14 @@ contains
 #endif
    subroutine GFS_surface_composites_post_run (                                                                                   &
       im, cplflx, cplwav2atm, frac_grid, flag_cice, islmsk, dry, wet, icy, landfrac, lakefrac, oceanfrac,                          &
-      zorl, zorlo, zorll, zorl_ocn, zorl_lnd, zorl_ice,                                                                           &
-      cd, cd_ocn, cd_lnd, cd_ice, cdq, cdq_ocn, cdq_lnd, cdq_ice, rb, rb_ocn, rb_lnd, rb_ice, stress, stress_ocn, stress_lnd,     &
-      stress_ice, ffmm, ffmm_ocn, ffmm_lnd, ffmm_ice, ffhh, ffhh_ocn, ffhh_lnd, ffhh_ice, uustar, uustar_ocn, uustar_lnd,         &
-      uustar_ice, fm10, fm10_ocn, fm10_lnd, fm10_ice, fh2, fh2_ocn, fh2_lnd, fh2_ice, tsurf, tsurf_ocn, tsurf_lnd, tsurf_ice,     &
-      cmm, cmm_ocn, cmm_lnd, cmm_ice, chh, chh_ocn, chh_lnd, chh_ice, gflx, gflx_ocn, gflx_lnd, gflx_ice, ep1d, ep1d_ocn,         &
-      ep1d_lnd, ep1d_ice, weasd, weasd_ocn, weasd_lnd, weasd_ice, snowd, snowd_ocn, snowd_lnd, snowd_ice, tprcp, tprcp_ocn,       &
-      tprcp_lnd, tprcp_ice, evap, evap_ocn, evap_lnd, evap_ice, hflx, hflx_ocn, hflx_lnd, hflx_ice, qss, qss_ocn, qss_lnd,        &
-      qss_ice, tsfc, tsfco, tsfcl, tsfc_ocn, tsfc_lnd, tsfc_ice, tisfc, tice, hice, cice, errmsg, errflg)
+      zorl, zorlo, zorll, zorl_wat, zorl_lnd, zorl_ice,                                                                           &
+      cd, cd_wat, cd_lnd, cd_ice, cdq, cdq_wat, cdq_lnd, cdq_ice, rb, rb_wat, rb_lnd, rb_ice, stress, stress_wat, stress_lnd,     &
+      stress_ice, ffmm, ffmm_wat, ffmm_lnd, ffmm_ice, ffhh, ffhh_wat, ffhh_lnd, ffhh_ice, uustar, uustar_wat, uustar_lnd,         &
+      uustar_ice, fm10, fm10_wat, fm10_lnd, fm10_ice, fh2, fh2_wat, fh2_lnd, fh2_ice, tsurf, tsurf_wat, tsurf_lnd, tsurf_ice,     &
+      cmm, cmm_wat, cmm_lnd, cmm_ice, chh, chh_wat, chh_lnd, chh_ice, gflx, gflx_wat, gflx_lnd, gflx_ice, ep1d, ep1d_wat,         &
+      ep1d_lnd, ep1d_ice, weasd, weasd_wat, weasd_lnd, weasd_ice, snowd, snowd_wat, snowd_lnd, snowd_ice, tprcp, tprcp_wat,       &
+      tprcp_lnd, tprcp_ice, evap, evap_wat, evap_lnd, evap_ice, hflx, hflx_wat, hflx_lnd, hflx_ice, qss, qss_wat, qss_lnd,        &
+      qss_ice, tsfc, tsfco, tsfcl, tsfc_wat, tsfc_lnd, tsfc_ice, tisfc, tice, hice, cice, errmsg, errflg)
 
       implicit none
 
@@ -302,12 +302,12 @@ contains
       logical, dimension(im),               intent(in) :: flag_cice, dry, wet, icy
       integer, dimension(im),               intent(in) :: islmsk
       real(kind=kind_phys), dimension(im),  intent(in) :: landfrac, lakefrac, oceanfrac,                                        &
-        zorl_ocn, zorl_lnd, zorl_ice, cd_ocn, cd_lnd, cd_ice, cdq_ocn, cdq_lnd, cdq_ice, rb_ocn, rb_lnd, rb_ice, stress_ocn,    &
-        stress_lnd, stress_ice, ffmm_ocn, ffmm_lnd, ffmm_ice, ffhh_ocn, ffhh_lnd, ffhh_ice, uustar_ocn, uustar_lnd, uustar_ice, &
-        fm10_ocn, fm10_lnd, fm10_ice, fh2_ocn, fh2_lnd, fh2_ice, tsurf_ocn, tsurf_lnd, tsurf_ice, cmm_ocn, cmm_lnd, cmm_ice,    &
-        chh_ocn, chh_lnd, chh_ice, gflx_ocn, gflx_lnd, gflx_ice, ep1d_ocn, ep1d_lnd, ep1d_ice, weasd_ocn, weasd_lnd, weasd_ice, &
-        snowd_ocn, snowd_lnd, snowd_ice,tprcp_ocn, tprcp_lnd, tprcp_ice, evap_ocn, evap_lnd, evap_ice, hflx_ocn, hflx_lnd,      &
-        hflx_ice, qss_ocn, qss_lnd, qss_ice, tsfc_ocn, tsfc_lnd, tsfc_ice
+        zorl_wat, zorl_lnd, zorl_ice, cd_wat, cd_lnd, cd_ice, cdq_wat, cdq_lnd, cdq_ice, rb_wat, rb_lnd, rb_ice, stress_wat,    &
+        stress_lnd, stress_ice, ffmm_wat, ffmm_lnd, ffmm_ice, ffhh_wat, ffhh_lnd, ffhh_ice, uustar_wat, uustar_lnd, uustar_ice, &
+        fm10_wat, fm10_lnd, fm10_ice, fh2_wat, fh2_lnd, fh2_ice, tsurf_wat, tsurf_lnd, tsurf_ice, cmm_wat, cmm_lnd, cmm_ice,    &
+        chh_wat, chh_lnd, chh_ice, gflx_wat, gflx_lnd, gflx_ice, ep1d_wat, ep1d_lnd, ep1d_ice, weasd_wat, weasd_lnd, weasd_ice, &
+        snowd_wat, snowd_lnd, snowd_ice,tprcp_wat, tprcp_lnd, tprcp_ice, evap_wat, evap_lnd, evap_ice, hflx_wat, hflx_lnd,      &
+        hflx_ice, qss_wat, qss_lnd, qss_ice, tsfc_wat, tsfc_lnd, tsfc_ice
 
       real(kind=kind_phys), dimension(im),  intent(inout) :: zorl, zorlo, zorll, cd, cdq, rb, stress, ffmm, ffhh, uustar, fm10, &
         fh2, tsurf, cmm, chh, gflx, ep1d, weasd, snowd, tprcp, evap, hflx, qss, tsfc, tsfco, tsfcl, tisfc
@@ -337,27 +337,27 @@ contains
           txi = cice(i)*(one - txl) ! txi = ice fraction wrt whole cell
           txo = max(zero, one - txl - txi)
 
-          zorl(i)   = txl*zorl_lnd(i)   + txi*zorl_ice(i)   + txo*zorl_ocn(i)
-          cd(i)     = txl*cd_lnd(i)     + txi*cd_ice(i)     + txo*cd_ocn(i)
-          cdq(i)    = txl*cdq_lnd(i)    + txi*cdq_ice(i)    + txo*cdq_ocn(i)
-          rb(i)     = txl*rb_lnd(i)     + txi*rb_ice(i)     + txo*rb_ocn(i)
-          stress(i) = txl*stress_lnd(i) + txi*stress_ice(i) + txo*stress_ocn(i)
-          ffmm(i)   = txl*ffmm_lnd(i)   + txi*ffmm_ice(i)   + txo*ffmm_ocn(i)
-          ffhh(i)   = txl*ffhh_lnd(i)   + txi*ffhh_ice(i)   + txo*ffhh_ocn(i)
-          uustar(i) = txl*uustar_lnd(i) + txi*uustar_ice(i) + txo*uustar_ocn(i)
-          fm10(i)   = txl*fm10_lnd(i)   + txi*fm10_ice(i)   + txo*fm10_ocn(i)
-          fh2(i)    = txl*fh2_lnd(i)    + txi*fh2_ice(i)    + txo*fh2_ocn(i)
-         !tsurf(i)  = txl*tsurf_lnd(i)  + txi*tice(i)      + txo*tsurf_ocn(i)
-         !tsurf(i)  = txl*tsurf_lnd(i)  + txi*tsurf_ice(i)  + txo*tsurf_ocn(i) ! not used again! Moorthi
-          cmm(i)    = txl*cmm_lnd(i)    + txi*cmm_ice(i)    + txo*cmm_ocn(i)
-          chh(i)    = txl*chh_lnd(i)    + txi*chh_ice(i)    + txo*chh_ocn(i)
-         !gflx(i)   = txl*gflx_lnd(i)   + txi*gflx_ice(i)   + txo*gflx_ocn(i)
-          ep1d(i)   = txl*ep1d_lnd(i)   + txi*ep1d_ice(i)   + txo*ep1d_ocn(i)
-         !weasd(i)  = txl*weasd_lnd(i)  + txi*weasd_ice(i)  + txo*weasd_ocn(i)
-         !snowd(i)  = txl*snowd_lnd(i)  + txi*snowd_ice(i)  + txo*snowd_ocn(i)
+          zorl(i)   = txl*zorl_lnd(i)   + txi*zorl_ice(i)   + txo*zorl_wat(i)
+          cd(i)     = txl*cd_lnd(i)     + txi*cd_ice(i)     + txo*cd_wat(i)
+          cdq(i)    = txl*cdq_lnd(i)    + txi*cdq_ice(i)    + txo*cdq_wat(i)
+          rb(i)     = txl*rb_lnd(i)     + txi*rb_ice(i)     + txo*rb_wat(i)
+          stress(i) = txl*stress_lnd(i) + txi*stress_ice(i) + txo*stress_wat(i)
+          ffmm(i)   = txl*ffmm_lnd(i)   + txi*ffmm_ice(i)   + txo*ffmm_wat(i)
+          ffhh(i)   = txl*ffhh_lnd(i)   + txi*ffhh_ice(i)   + txo*ffhh_wat(i)
+          uustar(i) = txl*uustar_lnd(i) + txi*uustar_ice(i) + txo*uustar_wat(i)
+          fm10(i)   = txl*fm10_lnd(i)   + txi*fm10_ice(i)   + txo*fm10_wat(i)
+          fh2(i)    = txl*fh2_lnd(i)    + txi*fh2_ice(i)    + txo*fh2_wat(i)
+         !tsurf(i)  = txl*tsurf_lnd(i)  + txi*tice(i)      + txo*tsurf_wat(i)
+         !tsurf(i)  = txl*tsurf_lnd(i)  + txi*tsurf_ice(i)  + txo*tsurf_wat(i) ! not used again! Moorthi
+          cmm(i)    = txl*cmm_lnd(i)    + txi*cmm_ice(i)    + txo*cmm_wat(i)
+          chh(i)    = txl*chh_lnd(i)    + txi*chh_ice(i)    + txo*chh_wat(i)
+         !gflx(i)   = txl*gflx_lnd(i)   + txi*gflx_ice(i)   + txo*gflx_wat(i)
+          ep1d(i)   = txl*ep1d_lnd(i)   + txi*ep1d_ice(i)   + txo*ep1d_wat(i)
+         !weasd(i)  = txl*weasd_lnd(i)  + txi*weasd_ice(i)  + txo*weasd_wat(i)
+         !snowd(i)  = txl*snowd_lnd(i)  + txi*snowd_ice(i)  + txo*snowd_wat(i)
           weasd(i)  = txl*weasd_lnd(i)  + txi*weasd_ice(i)
           snowd(i)  = txl*snowd_lnd(i)  + txi*snowd_ice(i)
-         !tprcp(i)  = txl*tprcp_lnd(i)  + txi*tprcp_ice(i)  + txo*tprcp_ocn(i)
+         !tprcp(i)  = txl*tprcp_lnd(i)  + txi*tprcp_ice(i)  + txo*tprcp_wat(i)
 
           if (.not. flag_cice(i) .and. islmsk(i) == 2) then
             tem     = one - txl
@@ -366,24 +366,24 @@ contains
             qss(i)  = txl*qss_lnd(i)    + tem*qss_ice(i)
             gflx(i) = txl*gflx_lnd(i)   + tem*gflx_ice(i)
           else
-            evap(i) = txl*evap_lnd(i)   + txi*evap_ice(i)   + txo*evap_ocn(i)
-            hflx(i) = txl*hflx_lnd(i)   + txi*hflx_ice(i)   + txo*hflx_ocn(i)
-            qss(i)  = txl*qss_lnd(i)    + txi*qss_ice(i)    + txo*qss_ocn(i)
-            gflx(i) = txl*gflx_lnd(i)   + txi*gflx_ice(i)   + txo*gflx_ocn(i)
+            evap(i) = txl*evap_lnd(i)   + txi*evap_ice(i)   + txo*evap_wat(i)
+            hflx(i) = txl*hflx_lnd(i)   + txi*hflx_ice(i)   + txo*hflx_wat(i)
+            qss(i)  = txl*qss_lnd(i)    + txi*qss_ice(i)    + txo*qss_wat(i)
+            gflx(i) = txl*gflx_lnd(i)   + txi*gflx_ice(i)   + txo*gflx_wat(i)
           endif
-          tsfc(i)   = txl*tsfc_lnd(i)   + txi*tice(i)       + txo*tsfc_ocn(i)
+          tsfc(i)   = txl*tsfc_lnd(i)   + txi*tice(i)       + txo*tsfc_wat(i)
 
           zorll(i) = zorl_lnd(i)
-          zorlo(i) = zorl_ocn(i)
+          zorlo(i) = zorl_wat(i)
   
           if (dry(i)) tsfcl(i) = tsfc_lnd(i)      ! over land
-          if (wet(i)) tsfco(i) = tsfc_ocn(i)      ! over lake or ocean when uncoupled
+          if (wet(i)) tsfco(i) = tsfc_wat(i)      ! over lake or ocean when uncoupled
                                                   ! for coupled model ocean will replace this
 !         if (icy(i)) tisfc(i) = tsfc_ice(i)      ! over ice when uncoupled
 !         if (icy(i)) tisfc(i) = tice(i)          ! over ice when uncoupled
 
 !         if (wet(i) .and. .not. cplflx) then
-!           tsfco(i) = tsfc_ocn(i)                ! over lake or ocean when uncoupled
+!           tsfco(i) = tsfc_wat(i)                ! over lake or ocean when uncoupled
 !           tisfc(i) = tsfc_ice(i)                ! over ice when uncoupled
 !         endif
 
@@ -429,29 +429,29 @@ contains
             !cice(i)   = zero
             !tisfc(i)  = tsfc(i)
           elseif (islmsk(i) == 0) then
-            zorl(i)   = zorl_ocn(i)
-            cd(i)     = cd_ocn(i)
-            cdq(i)    = cdq_ocn(i)
-            rb(i)     = rb_ocn(i)
-            stress(i) = stress_ocn(i)
-            ffmm(i)   = ffmm_ocn(i)
-            ffhh(i)   = ffhh_ocn(i)
-            uustar(i) = uustar_ocn(i)
-            fm10(i)   = fm10_ocn(i)
-            fh2(i)    = fh2_ocn(i)
-           !tsurf(i)  = tsurf_ocn(i)
-            tsfco(i)  = tsfc_ocn(i) ! over lake (and ocean when uncoupled)
-            cmm(i)    = cmm_ocn(i)
-            chh(i)    = chh_ocn(i)
-            gflx(i)   = gflx_ocn(i)
-            ep1d(i)   = ep1d_ocn(i)
-            weasd(i)  = weasd_ocn(i)
-            snowd(i)  = snowd_ocn(i)
-           !tprcp(i)  = tprcp_ocn(i)
-            evap(i)   = evap_ocn(i)
-            hflx(i)   = hflx_ocn(i)
-            qss(i)    = qss_ocn(i)
-            tsfc(i)   = tsfc_ocn(i)
+            zorl(i)   = zorl_wat(i)
+            cd(i)     = cd_wat(i)
+            cdq(i)    = cdq_wat(i)
+            rb(i)     = rb_wat(i)
+            stress(i) = stress_wat(i)
+            ffmm(i)   = ffmm_wat(i)
+            ffhh(i)   = ffhh_wat(i)
+            uustar(i) = uustar_wat(i)
+            fm10(i)   = fm10_wat(i)
+            fh2(i)    = fh2_wat(i)
+           !tsurf(i)  = tsurf_wat(i)
+            tsfco(i)  = tsfc_wat(i) ! over lake (and ocean when uncoupled)
+            cmm(i)    = cmm_wat(i)
+            chh(i)    = chh_wat(i)
+            gflx(i)   = gflx_wat(i)
+            ep1d(i)   = ep1d_wat(i)
+            weasd(i)  = weasd_wat(i)
+            snowd(i)  = snowd_wat(i)
+           !tprcp(i)  = tprcp_wat(i)
+            evap(i)   = evap_wat(i)
+            hflx(i)   = hflx_wat(i)
+            qss(i)    = qss_wat(i)
+            tsfc(i)   = tsfc_wat(i)
             !hice(i)   = zero
             !cice(i)   = zero
             !tisfc(i)  = tsfc(i)
@@ -460,7 +460,7 @@ contains
             cd(i)     = cd_ice(i)
             cdq(i)    = cdq_ice(i)
             rb(i)     = rb_ice(i)
-            stress(i) = cice(i)*stress_ice(i) + (one-cice(i))*stress_ocn(i)
+            stress(i) = cice(i)*stress_ice(i) + (one-cice(i))*stress_wat(i)
             ffmm(i)   = ffmm_ice(i)
             ffhh(i)   = ffhh_ice(i)
             uustar(i) = uustar_ice(i)
@@ -476,7 +476,7 @@ contains
             ep1d(i)   = ep1d_ice(i)
             weasd(i)  = weasd_ice(i)
             snowd(i)  = snowd_ice(i)
-           !tprcp(i)  = cice(i)*tprcp_ice(i) + (one-cice(i))*tprcp_ocn(i)
+           !tprcp(i)  = cice(i)*tprcp_ice(i) + (one-cice(i))*tprcp_wat(i)
             qss(i)    = qss_ice(i)
             evap(i)   = evap_ice(i)
             hflx(i)   = hflx_ice(i)
@@ -485,14 +485,14 @@ contains
           endif
 
           zorll(i) = zorl_lnd(i)
-          zorlo(i) = zorl_ocn(i)
+          zorlo(i) = zorl_wat(i)
 
           if (flag_cice(i) .and. wet(i)) then ! this was already done for lake ice in sfc_sice
             txi = cice(i)
             txo = one - txi
-            evap(i) = txi * evap_ice(i) + txo * evap_ocn(i)
-            hflx(i) = txi * hflx_ice(i) + txo * hflx_ocn(i)
-            tsfc(i) = txi * tsfc_ice(i) + txo * tsfc_ocn(i)
+            evap(i) = txi * evap_ice(i) + txo * evap_wat(i)
+            hflx(i) = txi * hflx_ice(i) + txo * hflx_wat(i)
+            tsfc(i) = txi * tsfc_ice(i) + txo * tsfc_wat(i)
           else
             if (islmsk(i) == 2) then
               tisfc(i) = tice(i)

--- a/physics/GFS_surface_composites.F90
+++ b/physics/GFS_surface_composites.F90
@@ -285,7 +285,7 @@ contains
 !!
 #endif
    subroutine GFS_surface_composites_post_run (                                                                                   &
-      im, cplflx, cplwav2atm, frac_grid, flag_cice, islmsk, dry, wet, icy, landfrac, lakefrac, oceanfrac,                          &
+      im, kice, km, cplflx, cplwav2atm, frac_grid, flag_cice, islmsk, dry, wet, icy, landfrac, lakefrac, oceanfrac,               &
       zorl, zorlo, zorll, zorl_wat, zorl_lnd, zorl_ice,                                                                           &
       cd, cd_wat, cd_lnd, cd_ice, cdq, cdq_wat, cdq_lnd, cdq_ice, rb, rb_wat, rb_lnd, rb_ice, stress, stress_wat, stress_lnd,     &
       stress_ice, ffmm, ffmm_wat, ffmm_lnd, ffmm_ice, ffhh, ffhh_wat, ffhh_lnd, ffhh_ice, uustar, uustar_wat, uustar_lnd,         &
@@ -293,11 +293,11 @@ contains
       cmm, cmm_wat, cmm_lnd, cmm_ice, chh, chh_wat, chh_lnd, chh_ice, gflx, gflx_wat, gflx_lnd, gflx_ice, ep1d, ep1d_wat,         &
       ep1d_lnd, ep1d_ice, weasd, weasd_wat, weasd_lnd, weasd_ice, snowd, snowd_wat, snowd_lnd, snowd_ice, tprcp, tprcp_wat,       &
       tprcp_lnd, tprcp_ice, evap, evap_wat, evap_lnd, evap_ice, hflx, hflx_wat, hflx_lnd, hflx_ice, qss, qss_wat, qss_lnd,        &
-      qss_ice, tsfc, tsfco, tsfcl, tsfc_wat, tsfc_lnd, tsfc_ice, tisfc, tice, hice, cice, errmsg, errflg)
+      qss_ice, tsfc, tsfco, tsfcl, tsfc_wat, tsfc_lnd, tsfc_ice, tisfc, tice, hice, cice, tiice, stc, errmsg, errflg)
 
       implicit none
 
-      integer,                              intent(in) :: im
+      integer,                              intent(in) :: im, kice, km
       logical,                              intent(in) :: cplflx, frac_grid, cplwav2atm
       logical, dimension(im),               intent(in) :: flag_cice, dry, wet, icy
       integer, dimension(im),               intent(in) :: islmsk
@@ -315,11 +315,14 @@ contains
       real(kind=kind_phys), dimension(im),  intent(in   ) :: tice ! interstitial sea ice temperature
       real(kind=kind_phys), dimension(im),  intent(inout) :: hice, cice
 
+      real(kind=kind_phys), dimension(im, kice),  intent(in   ) :: tiice
+      real(kind=kind_phys), dimension(im, km),    intent(inout) :: stc
+
       character(len=*), intent(out) :: errmsg
       integer,          intent(out) :: errflg
 
       ! Local variables
-      integer :: i
+      integer :: i, k
       real(kind=kind_phys) :: txl, txi, txo, tem
 
       ! Initialize CCPP error handling variables
@@ -482,6 +485,9 @@ contains
             hflx(i)   = hflx_ice(i)
             qss(i)    = qss_ice(i)
             tsfc(i)   = tsfc_ice(i)
+            do k=1,kice ! store tiice in stc to reduce output in the nonfrac grid case
+              stc(i,k)=tiice(i,k)
+            end do
           endif
 
           zorll(i) = zorl_lnd(i)

--- a/physics/GFS_surface_composites.meta
+++ b/physics/GFS_surface_composites.meta
@@ -162,7 +162,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[zorl_ocn]
+[zorl_wat]
   standard_name = surface_roughness_length_over_ocean_interstitial
   long_name = surface roughness length over ocean (temporary use as interstitial)
   units = cm
@@ -198,7 +198,7 @@
   kind = kind_phys
   intent = in
   optional = F
-[snowd_ocn]
+[snowd_wat]
   standard_name = surface_snow_thickness_water_equivalent_over_ocean
   long_name = water equivalent snow depth over ocean
   units = mm
@@ -234,7 +234,7 @@
   kind = kind_phys
   intent = in
   optional = F
-[tprcp_ocn]
+[tprcp_wat]
   standard_name = nonnegative_lwe_thickness_of_precipitation_amount_on_dynamics_timestep_over_ocean
   long_name = total precipitation amount in each time step over ocean
   units = m
@@ -297,7 +297,7 @@
   kind = kind_phys
   intent = in
   optional = F
-[weasd_ocn]
+[weasd_wat]
   standard_name = water_equivalent_accumulated_snow_depth_over_ocean
   long_name = water equiv of acc snow depth over ocean
   units = mm
@@ -360,7 +360,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[tsfc_ocn]
+[tsfc_wat]
   standard_name = surface_skin_temperature_over_ocean_interstitial
   long_name = surface skin temperature over ocean (temporary use as interstitial)
   units = K
@@ -414,7 +414,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[tsurf_ocn]
+[tsurf_wat]
   standard_name = surface_skin_temperature_after_iteration_over_ocean
   long_name = surface skin temperature after iteration over ocean
   units = K
@@ -476,7 +476,7 @@
   kind = kind_phys
   intent = in
   optional = F
-[semis_ocn]
+[semis_wat]
   standard_name = surface_longwave_emissivity_over_ocean_interstitial
   long_name = surface lw emissivity in fraction over ocean (temporary use as interstitial)
   units = frac
@@ -575,7 +575,7 @@
   type = logical
   intent = in
   optional = F
-[semis_ocn]
+[semis_wat]
   standard_name = surface_longwave_emissivity_over_ocean_interstitial
   long_name = surface lw emissivity in fraction over ocean (temporary use as interstitial)
   units = frac
@@ -629,7 +629,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[gabsbdlw_ocn]
+[gabsbdlw_wat]
   standard_name = surface_downwelling_longwave_flux_absorbed_by_ground_over_ocean
   long_name = total sky surface downward longwave flux absorbed by the ground over ocean
   units = W m-2
@@ -813,7 +813,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[zorl_ocn]
+[zorl_wat]
   standard_name = surface_roughness_length_over_ocean_interstitial
   long_name = surface roughness length over ocean (temporary use as interstitial)
   units = cm
@@ -849,7 +849,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[cd_ocn]
+[cd_wat]
   standard_name = surface_drag_coefficient_for_momentum_in_air_over_ocean
   long_name = surface exchange coeff for momentum over ocean
   units = none
@@ -885,7 +885,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[cdq_ocn]
+[cdq_wat]
   standard_name = surface_drag_coefficient_for_heat_and_moisture_in_air_over_ocean
   long_name = surface exchange coeff heat & moisture over ocean
   units = none
@@ -921,7 +921,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[rb_ocn]
+[rb_wat]
   standard_name = bulk_richardson_number_at_lowest_model_level_over_ocean
   long_name = bulk Richardson number at the surface over ocean
   units = none
@@ -957,7 +957,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[stress_ocn]
+[stress_wat]
   standard_name = surface_wind_stress_over_ocean
   long_name = surface wind stress over ocean
   units = m2 s-2
@@ -993,7 +993,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[ffmm_ocn]
+[ffmm_wat]
   standard_name = Monin_Obukhov_similarity_function_for_momentum_over_ocean
   long_name = Monin-Obukhov similarity function for momentum over ocean
   units = none
@@ -1029,7 +1029,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[ffhh_ocn]
+[ffhh_wat]
   standard_name = Monin_Obukhov_similarity_function_for_heat_over_ocean
   long_name = Monin-Obukhov similarity function for heat over ocean
   units = none
@@ -1065,7 +1065,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[uustar_ocn]
+[uustar_wat]
   standard_name = surface_friction_velocity_over_ocean
   long_name = surface friction velocity over ocean
   units = m s-1
@@ -1101,7 +1101,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[fm10_ocn]
+[fm10_wat]
   standard_name = Monin_Obukhov_similarity_function_for_momentum_at_10m_over_ocean
   long_name = Monin-Obukhov similarity parameter for momentum at 10m over ocean
   units = none
@@ -1137,7 +1137,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[fh2_ocn]
+[fh2_wat]
   standard_name = Monin_Obukhov_similarity_function_for_heat_at_2m_over_ocean
   long_name = Monin-Obukhov similarity parameter for heat at 2m over ocean
   units = none
@@ -1173,7 +1173,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[tsurf_ocn]
+[tsurf_wat]
   standard_name = surface_skin_temperature_after_iteration_over_ocean
   long_name = surface skin temperature after iteration over ocean
   units = K
@@ -1209,7 +1209,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[cmm_ocn]
+[cmm_wat]
   standard_name = surface_drag_wind_speed_for_momentum_in_air_over_ocean
   long_name = momentum exchange coefficient over ocean
   units = m s-1
@@ -1245,7 +1245,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[chh_ocn]
+[chh_wat]
   standard_name = surface_drag_mass_flux_for_heat_and_moisture_in_air_over_ocean
   long_name = thermal exchange coefficient over ocean
   units = kg m-2 s-1
@@ -1281,7 +1281,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[gflx_ocn]
+[gflx_wat]
   standard_name = upward_heat_flux_in_soil_over_ocean
   long_name = soil heat flux over ocean
   units = W m-2
@@ -1317,7 +1317,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[ep1d_ocn]
+[ep1d_wat]
   standard_name = surface_upward_potential_latent_heat_flux_over_ocean
   long_name = surface upward potential latent heat flux over ocean
   units = W m-2
@@ -1353,7 +1353,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[weasd_ocn]
+[weasd_wat]
   standard_name = water_equivalent_accumulated_snow_depth_over_ocean
   long_name = water equiv of acc snow depth over ocean
   units = mm
@@ -1389,7 +1389,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[snowd_ocn]
+[snowd_wat]
   standard_name = surface_snow_thickness_water_equivalent_over_ocean
   long_name = water equivalent snow depth over ocean
   units = mm
@@ -1425,7 +1425,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[tprcp_ocn]
+[tprcp_wat]
   standard_name = nonnegative_lwe_thickness_of_precipitation_amount_on_dynamics_timestep_over_ocean
   long_name = total precipitation amount in each time step over ocean
   units = m
@@ -1461,7 +1461,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[evap_ocn]
+[evap_wat]
   standard_name = kinematic_surface_upward_latent_heat_flux_over_ocean
   long_name = kinematic surface upward latent heat flux over ocean
   units = kg kg-1 m s-1
@@ -1497,7 +1497,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[hflx_ocn]
+[hflx_wat]
   standard_name = kinematic_surface_upward_sensible_heat_flux_over_ocean
   long_name = kinematic surface upward sensible heat flux over ocean
   units = K m s-1
@@ -1533,7 +1533,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[qss_ocn]
+[qss_wat]
   standard_name = surface_specific_humidity_over_ocean
   long_name = surface air saturation specific humidity over ocean
   units = kg kg-1
@@ -1587,7 +1587,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[tsfc_ocn]
+[tsfc_wat]
   standard_name = surface_skin_temperature_over_ocean_interstitial
   long_name = surface skin temperature over ocean (temporary use as interstitial)
   units = K

--- a/physics/GFS_surface_composites.meta
+++ b/physics/GFS_surface_composites.meta
@@ -695,6 +695,22 @@
   type = integer
   intent = in
   optional = F
+[kice]
+  standard_name = ice_vertical_dimension
+  long_name = vertical loop extent for ice levels, start at 1
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[km]
+  standard_name = soil_vertical_dimension
+  long_name = soil vertical layer dimension
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
 [cplflx]
   standard_name = flag_for_flux_coupling
   long_name = flag controlling cplflx collection (default off)
@@ -1646,6 +1662,24 @@
   long_name = ice fraction over open water
   units = frac
   dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[tiice]
+  standard_name = internal_ice_temperature
+  long_name = sea ice internal temperature
+  units = K
+  dimensions = (horizontal_dimension,ice_vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[stc]
+  standard_name = soil_temperature
+  long_name = soil temperature
+  units = K
+  dimensions = (horizontal_dimension,soil_vertical_dimension)
   type = real
   kind = kind_phys
   intent = inout

--- a/physics/GFS_surface_generic.F90
+++ b/physics/GFS_surface_generic.F90
@@ -215,8 +215,8 @@
 !! \htmlinclude GFS_surface_generic_post_run.html
 !!
       subroutine GFS_surface_generic_post_run (im, cplflx, cplwav, lssav, icy, wet, dtf, ep1d, gflx, tgrs_1, qgrs_1, ugrs_1, vgrs_1,&
-        adjsfcdlw, adjsfcdsw, adjnirbmd, adjnirdfd, adjvisbmd, adjvisdfd, adjsfculw, adjsfculw_ocn, adjnirbmu, adjnirdfu,           &
-        adjvisbmu, adjvisdfu,t2m, q2m, u10m, v10m, tsfc, tsfc_ocn, pgr, xcosz, evbs, evcw, trans, sbsno, snowc, snohf,              &
+        adjsfcdlw, adjsfcdsw, adjnirbmd, adjnirdfd, adjvisbmd, adjvisdfd, adjsfculw, adjsfculw_wat, adjnirbmu, adjnirdfu,           &
+        adjvisbmu, adjvisdfu,t2m, q2m, u10m, v10m, tsfc, tsfc_wat, pgr, xcosz, evbs, evcw, trans, sbsno, snowc, snohf,              &
         epi, gfluxi, t1, q1, u1, v1, dlwsfci_cpl, dswsfci_cpl, dlwsfc_cpl, dswsfc_cpl, dnirbmi_cpl, dnirdfi_cpl, dvisbmi_cpl,       &
         dvisdfi_cpl, dnirbm_cpl, dnirdf_cpl, dvisbm_cpl, dvisdf_cpl, nlwsfci_cpl, nlwsfc_cpl, t2mi_cpl, q2mi_cpl, u10mi_cpl,        &
         v10mi_cpl, tsfci_cpl, psurfi_cpl, nnirbmi_cpl, nnirdfi_cpl, nvisbmi_cpl, nvisdfi_cpl, nswsfci_cpl, nswsfc_cpl, nnirbm_cpl,  &
@@ -231,8 +231,8 @@
         real(kind=kind_phys),                   intent(in) :: dtf
 
         real(kind=kind_phys), dimension(im),  intent(in)  :: ep1d, gflx, tgrs_1, qgrs_1, ugrs_1, vgrs_1, adjsfcdlw, adjsfcdsw, &
-          adjnirbmd, adjnirdfd, adjvisbmd, adjvisdfd, adjsfculw, adjsfculw_ocn, adjnirbmu, adjnirdfu, adjvisbmu, adjvisdfu,    &
-          t2m, q2m, u10m, v10m, tsfc, tsfc_ocn, pgr, xcosz, evbs, evcw, trans, sbsno, snowc, snohf
+          adjnirbmd, adjnirdfd, adjvisbmd, adjvisdfd, adjsfculw, adjsfculw_wat, adjnirbmu, adjnirdfu, adjvisbmu, adjvisdfu,    &
+          t2m, q2m, u10m, v10m, tsfc, tsfc_wat, pgr, xcosz, evbs, evcw, trans, sbsno, snowc, snohf
 
         real(kind=kind_phys), dimension(im),  intent(inout) :: epi, gfluxi, t1, q1, u1, v1, dlwsfci_cpl, dswsfci_cpl, dlwsfc_cpl, &
           dswsfc_cpl, dnirbmi_cpl, dnirdfi_cpl, dvisbmi_cpl, dvisdfi_cpl, dnirbm_cpl, dnirdf_cpl, dvisbm_cpl, dvisdf_cpl, &
@@ -287,13 +287,13 @@
             dvisdf_cpl  (i) = dvisdf_cpl(i) + adjvisdfd(i)*dtf
             nlwsfci_cpl (i) = adjsfcdlw(i)  - adjsfculw(i)
             if (wet(i)) then
-              nlwsfci_cpl(i) = adjsfcdlw(i) - adjsfculw_ocn(i)
+              nlwsfci_cpl(i) = adjsfcdlw(i) - adjsfculw_wat(i)
             endif
             nlwsfc_cpl  (i) = nlwsfc_cpl(i) + nlwsfci_cpl(i)*dtf
             t2mi_cpl    (i) = t2m(i)
             q2mi_cpl    (i) = q2m(i)
             tsfci_cpl   (i) = tsfc(i)
-!           tsfci_cpl   (i) = tsfc_ocn(i)
+!           tsfci_cpl   (i) = tsfc_wat(i)
             psurfi_cpl  (i) = pgr(i)
           enddo
 

--- a/physics/GFS_surface_generic.meta
+++ b/physics/GFS_surface_generic.meta
@@ -669,7 +669,7 @@
   kind = kind_phys
   intent = in
   optional = F
-[adjsfculw_ocn]
+[adjsfculw_wat]
   standard_name = surface_upwelling_longwave_flux_over_ocean_interstitial
   long_name = surface upwelling longwave flux at current time over ocean (temporary use as interstitial)
   units = W m-2
@@ -759,7 +759,7 @@
   kind = kind_phys
   intent = in
   optional = F
-[tsfc_ocn]
+[tsfc_wat]
   standard_name = surface_skin_temperature_over_ocean_interstitial
   long_name = surface skin temperature over ocean (temporary use as interstitial)
   units = K

--- a/physics/dcyc2.f
+++ b/physics/dcyc2.f
@@ -47,8 +47,8 @@
 !    call dcyc2t3                                                       !
 !      inputs:                                                          !
 !          ( solhr,slag,sdec,cdec,sinlat,coslat,                        !
-!            xlon,coszen,tsfc_lnd,tsfc_ice,tsfc_ocn,                    !
-!            tf,tsflw,sfcemis_lnd,sfcemis_ice,sfcemis_ocn,              !
+!            xlon,coszen,tsfc_lnd,tsfc_ice,tsfc_wat,                    !
+!            tf,tsflw,sfcemis_lnd,sfcemis_ice,sfcemis_wat,              !
 !            sfcdsw,sfcnsw,sfcdlw,swh,swhc,hlw,hlwc,                    !
 !            sfcnirbmu,sfcnirdfu,sfcvisbmu,sfcvisdfu,                   !
 !            sfcnirbmd,sfcnirdfd,sfcvisbmd,sfcvisdfd,                   !
@@ -58,7 +58,7 @@
 !            dtdt,dtdtc,                                                !
 !      outputs:                                                         !
 !            adjsfcdsw,adjsfcnsw,adjsfcdlw,                             !
-!            adjsfculw_lnd,adjsfculw_ice,adjsfculw_ocn,xmu,xcosz,       !
+!            adjsfculw_lnd,adjsfculw_ice,adjsfculw_wat,xmu,xcosz,       !
 !            adjnirbmu,adjnirdfu,adjvisbmu,adjvisdfu,                   !
 !            adjdnnbmd,adjdnndfd,adjdnvbmd,adjdnvdfd)                   !
 !                                                                       !
@@ -74,11 +74,11 @@
 !     coszen (im)  - real, avg of cosz over daytime sw call interval    !
 !     tsfc_lnd  (im) - real, bottom surface temperature over land (k)   !
 !     tsfc_ice  (im) - real, bottom surface temperature over ice (k)    !
-!     tsfc_ocn  (im) - real, bottom surface temperature over ocean (k)  !
+!     tsfc_wat  (im) - real, bottom surface temperature over ocean (k)  !
 !     tf     (im)  - real, surface air (layer 1) temperature (k)        !
 !     sfcemis_lnd(im) - real, surface emissivity (fraction) o. land (k) !
 !     sfcemis_ice(im) - real, surface emissivity (fraction) o. ice (k)  !
-!     sfcemis_ocn(im) - real, surface emissivity (fraction) o. ocean (k)!
+!     sfcemis_wat(im) - real, surface emissivity (fraction) o. ocean (k)!
 !     tsflw  (im)  - real, sfc air (layer 1) temp in k saved in lw call !
 !     sfcdsw (im)  - real, total sky sfc downward sw flux ( w/m**2 )    !
 !     sfcnsw (im)  - real, total sky sfc net sw into ground (w/m**2)    !
@@ -115,7 +115,7 @@
 !     adjsfcdlw(im)- real, time step adjusted sfc dn lw flux (w/m**2)   !
 !     adjsfculw_lnd(im)- real, sfc upw. lw flux at current time (w/m**2)!
 !     adjsfculw_ice(im)- real, sfc upw. lw flux at current time (w/m**2)!
-!     adjsfculw_ocn(im)- real, sfc upw. lw flux at current time (w/m**2)!
+!     adjsfculw_wat(im)- real, sfc upw. lw flux at current time (w/m**2)!
 !     adjnirbmu(im)- real, t adj sfc nir-beam sw upward flux (w/m2)     !
 !     adjnirdfu(im)- real, t adj sfc nir-diff sw upward flux (w/m2)     !
 !     adjvisbmu(im)- real, t adj sfc uv+vis-beam sw upward flux (w/m2)  !
@@ -179,8 +179,8 @@
       subroutine dcyc2t3_run                                            &
 !  ---  inputs:
      &     ( solhr,slag,sdec,cdec,sinlat,coslat,                        &
-     &       xlon,coszen,tsfc_lnd,tsfc_ice,tsfc_ocn,tf,tsflw,           &
-     &       sfcemis_lnd, sfcemis_ice, sfcemis_ocn,                     &
+     &       xlon,coszen,tsfc_lnd,tsfc_ice,tsfc_wat,tf,tsflw,           &
+     &       sfcemis_lnd, sfcemis_ice, sfcemis_wat,                     &
      &       sfcdsw,sfcnsw,sfcdlw,swh,swhc,hlw,hlwc,                    &
      &       sfcnirbmu,sfcnirdfu,sfcvisbmu,sfcvisdfu,                   &
      &       sfcnirbmd,sfcnirdfd,sfcvisbmd,sfcvisdfd,                   &
@@ -191,7 +191,7 @@
      &       dtdt,dtdtc,                                                &
 !  ---  outputs:
      &       adjsfcdsw,adjsfcnsw,adjsfcdlw,                             &
-     &       adjsfculw_lnd,adjsfculw_ice,adjsfculw_ocn,xmu,xcosz,       &
+     &       adjsfculw_lnd,adjsfculw_ice,adjsfculw_wat,xmu,xcosz,       &
      &       adjnirbmu,adjnirdfu,adjvisbmu,adjvisdfu,                   &
      &       adjnirbmd,adjnirdfd,adjvisbmd,adjvisdfd,                   &
      &       errmsg,errflg                                              &
@@ -225,8 +225,8 @@
      &      sfcdsw, sfcnsw
 
       real(kind=kind_phys), dimension(im), intent(in) ::                &
-     &                         tsfc_lnd, tsfc_ice, tsfc_ocn,            &
-     &                         sfcemis_lnd, sfcemis_ice, sfcemis_ocn
+     &                         tsfc_lnd, tsfc_ice, tsfc_wat,            &
+     &                         sfcemis_lnd, sfcemis_ice, sfcemis_wat
 
       real(kind=kind_phys), dimension(im), intent(in) ::                &
      &      sfcnirbmu, sfcnirdfu, sfcvisbmu, sfcvisdfu,                 &
@@ -246,7 +246,7 @@
      &      adjnirbmd, adjnirdfd, adjvisbmd, adjvisdfd
 
       real(kind=kind_phys), dimension(im), intent(out) ::               &
-     &      adjsfculw_lnd, adjsfculw_ice, adjsfculw_ocn
+     &      adjsfculw_lnd, adjsfculw_ice, adjsfculw_wat
 
       character(len=*), intent(out) :: errmsg
       integer,          intent(out) :: errflg
@@ -321,9 +321,9 @@
      &                     + (one - sfcemis_ice(i)) * adjsfcdlw(i)
         endif
         if (wet(i)) then
-          tem2 = tsfc_ocn(i) * tsfc_ocn(i)
-          adjsfculw_ocn(i) =  sfcemis_ocn(i) * con_sbc * tem2 * tem2
-     &                     + (one - sfcemis_ocn(i)) * adjsfcdlw(i)
+          tem2 = tsfc_wat(i) * tsfc_wat(i)
+          adjsfculw_wat(i) =  sfcemis_wat(i) * con_sbc * tem2 * tem2
+     &                     + (one - sfcemis_wat(i)) * adjsfcdlw(i)
         endif
 !     if (lprnt .and. i == ipr) write(0,*)' in dcyc3: dry==',dry(i)
 !    &,' wet=',wet(i),' icy=',icy(i),' tsfc3=',tsfc3(i,:)

--- a/physics/dcyc2.meta
+++ b/physics/dcyc2.meta
@@ -92,7 +92,7 @@
   kind = kind_phys
   intent = in
   optional = F
-[tsfc_ocn]
+[tsfc_wat]
   standard_name = surface_skin_temperature_over_ocean_interstitial
   long_name = surface skin temperature over ocean (temporary use as interstitial)
   units = K
@@ -146,7 +146,7 @@
   kind = kind_phys
   intent = in
   optional = F
-[sfcemis_ocn]
+[sfcemis_wat]
   standard_name = surface_longwave_emissivity_over_ocean_interstitial
   long_name = surface lw emissivity in fraction over ocean (temporary use as interstitial)
   units = frac
@@ -419,7 +419,7 @@
   kind = kind_phys
   intent = out
   optional = F
-[adjsfculw_ocn]
+[adjsfculw_wat]
   standard_name = surface_upwelling_longwave_flux_over_ocean_interstitial
   long_name = surface upwelling longwave flux at current time over ocean (temporary use as interstitial)
   units = W m-2

--- a/physics/gcycle.F90
+++ b/physics/gcycle.F90
@@ -239,6 +239,7 @@
             Sfcprop(nb)%smc (ix,ls) = SMCFC1 (len + (ls-1)*npts)
             Sfcprop(nb)%stc (ix,ls) = STCFC1 (len + (ls-1)*npts)
             Sfcprop(nb)%slc (ix,ls) = SLCFC1 (len + (ls-1)*npts)
+            if (ls<=Model%kice) Sfcprop(nb)%tiice (ix,ls) = STCFC1 (len + (ls-1)*npts)
           enddo
         ENDDO                 !-----END BLOCK SIZE LOOP------------------------------
       ENDDO                   !-----END BLOCK LOOP-------------------------------

--- a/physics/module_MYJSFC_wrapper.F90
+++ b/physics/module_MYJSFC_wrapper.F90
@@ -37,16 +37,16 @@
      &  pblh, slmsk, zorl, ustar, rib,             &
      &  cm,ch,stress,ffm,ffh,fm10,fh2,             &
      &  landfrac,lakefrac,oceanfrac,fice,          &
-     &  z0rl_ocn,  z0rl_lnd,  z0rl_ice,            &   ! intent(inout)
-     &  ustar_ocn, ustar_lnd, ustar_ice,           &   ! intent(inout)
-     &  cm_ocn,    cm_lnd,    cm_ice,              &   ! intent(inout)
-     &  ch_ocn,    ch_lnd,    ch_ice,              &   ! intent(inout)
-     &  rb_ocn,    rb_lnd,    rb_ice,              &   ! intent(inout)
-     &  stress_ocn,stress_lnd,stress_ice,          &   ! intent(inout)
-     &  fm_ocn,    fm_lnd,    fm_ice,              &   ! intent(inout)
-     &  fh_ocn,    fh_lnd,    fh_ice,              &   ! intent(inout)
-     &  fm10_ocn,  fm10_lnd,  fm10_ice,            &   ! intent(inout)
-     &  fh2_ocn,   fh2_lnd,   fh2_ice,             &   ! intent(inout)
+     &  z0rl_wat,  z0rl_lnd,  z0rl_ice,            &   ! intent(inout)
+     &  ustar_wat, ustar_lnd, ustar_ice,           &   ! intent(inout)
+     &  cm_wat,    cm_lnd,    cm_ice,              &   ! intent(inout)
+     &  ch_wat,    ch_lnd,    ch_ice,              &   ! intent(inout)
+     &  rb_wat,    rb_lnd,    rb_ice,              &   ! intent(inout)
+     &  stress_wat,stress_lnd,stress_ice,          &   ! intent(inout)
+     &  fm_wat,    fm_lnd,    fm_ice,              &   ! intent(inout)
+     &  fh_wat,    fh_lnd,    fh_ice,              &   ! intent(inout)
+     &  fm10_wat,  fm10_lnd,  fm10_ice,            &   ! intent(inout)
+     &  fh2_wat,   fh2_lnd,   fh2_ice,             &   ! intent(inout)
      &  wind,      con_cp,    con_g,    con_rd,    &
      &  me, lprnt, errmsg, errflg )             ! intent(inout)
 !
@@ -107,16 +107,16 @@
       real(kind=kind_phys), dimension(im), intent(inout) ::  &
      &        landfrac, lakefrac, oceanfrac, fice
       real(kind=kind_phys), dimension(im), intent(inout) ::  &
-     &                    z0rl_ocn,  z0rl_lnd,  z0rl_ice,    &
-     &                   ustar_ocn, ustar_lnd, ustar_ice,    &
-     &                      cm_ocn,    cm_lnd,    cm_ice,    &
-     &                      ch_ocn,    ch_lnd,    ch_ice,    &
-     &                      rb_ocn,    rb_lnd,    rb_ice,    &
-     &                  stress_ocn,stress_lnd,stress_ice,    &
-     &                      fm_ocn,    fm_lnd,    fm_ice,    &
-     &                      fh_ocn,    fh_lnd,    fh_ice,    &
-     &                    fm10_ocn,  fm10_lnd,  fm10_ice,    &
-     &                     fh2_ocn,   fh2_lnd,   fh2_ice,    &
+     &                    z0rl_wat,  z0rl_lnd,  z0rl_ice,    &
+     &                   ustar_wat, ustar_lnd, ustar_ice,    &
+     &                      cm_wat,    cm_lnd,    cm_ice,    &
+     &                      ch_wat,    ch_lnd,    ch_ice,    &
+     &                      rb_wat,    rb_lnd,    rb_ice,    &
+     &                  stress_wat,stress_lnd,stress_ice,    &
+     &                      fm_wat,    fm_lnd,    fm_ice,    &
+     &                      fh_wat,    fh_lnd,    fh_ice,    &
+     &                    fm10_wat,  fm10_lnd,  fm10_ice,    &
+     &                     fh2_wat,   fh2_lnd,   fh2_ice,    &
      &                      wind
 
 
@@ -404,16 +404,16 @@
 
       do i = 1, im
          if(flag_iter(i))then
-                z0rl_ocn(i) = zorl(i)
-                  cm_ocn(i) = cm(i)
-                  ch_ocn(i) = ch(i)
-                  rb_ocn(i) = rib(i)
-              stress_ocn(i) = stress(i)
-                  fm_ocn(i) = ffm(i)
-                  fh_ocn(i) = ffh(i)
-               ustar_ocn(i) = ustar(i)
-                fm10_ocn(i) = fm10(i)
-                 fh2_ocn(i) = fh2(i)
+                z0rl_wat(i) = zorl(i)
+                  cm_wat(i) = cm(i)
+                  ch_wat(i) = ch(i)
+                  rb_wat(i) = rib(i)
+              stress_wat(i) = stress(i)
+                  fm_wat(i) = ffm(i)
+                  fh_wat(i) = ffh(i)
+               ustar_wat(i) = ustar(i)
+                fm10_wat(i) = fm10(i)
+                 fh2_wat(i) = fh2(i)
 
                 z0rl_lnd(i) = zorl(i)
                   cm_lnd(i) = cm(i)

--- a/physics/module_MYJSFC_wrapper.meta
+++ b/physics/module_MYJSFC_wrapper.meta
@@ -473,7 +473,7 @@
   kind = kind_phys
   intent = in
   optional = F
-[z0rl_ocn]
+[z0rl_wat]
   standard_name = surface_roughness_length_over_ocean_interstitial
   long_name = surface roughness length over ocean (interstitial)
   units = cm
@@ -500,7 +500,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[ustar_ocn]
+[ustar_wat]
   standard_name = surface_friction_velocity_over_ocean
   long_name = surface friction velocity over ocean
   units = m s-1
@@ -527,7 +527,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[cm_ocn]
+[cm_wat]
   standard_name = surface_drag_coefficient_for_momentum_in_air_over_ocean
   long_name = surface exchange coeff for momentum over ocean
   units = none
@@ -554,7 +554,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[ch_ocn]
+[ch_wat]
   standard_name = surface_drag_coefficient_for_heat_and_moisture_in_air_over_ocean
   long_name = surface exchange coeff heat & moisture over ocean
   units = none
@@ -581,7 +581,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[rb_ocn]
+[rb_wat]
   standard_name = bulk_richardson_number_at_lowest_model_level_over_ocean
   long_name = bulk Richardson number at the surface over ocean
   units = none
@@ -608,7 +608,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[stress_ocn]
+[stress_wat]
   standard_name = surface_wind_stress_over_ocean
   long_name = surface wind stress over ocean
   units = m2 s-2
@@ -635,7 +635,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[fm_ocn]
+[fm_wat]
   standard_name = Monin_Obukhov_similarity_function_for_momentum_over_ocean
   long_name = Monin-Obukhov similarity funct for momentum over ocean
   units = none
@@ -662,7 +662,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[fh_ocn]
+[fh_wat]
   standard_name = Monin_Obukhov_similarity_function_for_heat_over_ocean
   long_name = Monin-Obukhov similarity function for heat over ocean
   units = none
@@ -689,7 +689,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[fm10_ocn]
+[fm10_wat]
   standard_name = Monin_Obukhov_similarity_function_for_momentum_at_10m_over_ocean
   long_name = Monin-Obukhov parameter for momentum at 10m over ocean
   units = none
@@ -716,7 +716,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[fh2_ocn]
+[fh2_wat]
   standard_name = Monin_Obukhov_similarity_function_for_heat_at_2m_over_ocean
   long_name = Monin-Obukhov parameter for heat at 2m over ocean
   units = none

--- a/physics/sfc_diff.f
+++ b/physics/sfc_diff.f
@@ -68,19 +68,19 @@
      &                    flag_iter,redrag,                             &  !intent(in)
      &                    u10m,v10m,sfc_z0_type,                        &  !hafs,z0 type !intent(in)
      &                    wet,dry,icy,                                  &  !intent(in)
-     &                    tskin_ocn, tskin_lnd, tskin_ice,              &  !intent(in)
-     &                    tsurf_ocn, tsurf_lnd, tsurf_ice,              &  !intent(in)
-     &                   snwdph_ocn,snwdph_lnd,snwdph_ice,              &  !intent(in)
-     &                     z0rl_ocn,  z0rl_lnd,  z0rl_ice,              &  !intent(inout)
-     &                    ustar_ocn, ustar_lnd, ustar_ice,              &  !intent(inout)
-     &                       cm_ocn,    cm_lnd,    cm_ice,              &  !intent(inout)
-     &                       ch_ocn,    ch_lnd,    ch_ice,              &  !intent(inout)
-     &                       rb_ocn,    rb_lnd,    rb_ice,              &  !intent(inout)
-     &                   stress_ocn,stress_lnd,stress_ice,              &  !intent(inout)
-     &                       fm_ocn,    fm_lnd,    fm_ice,              &  !intent(inout)
-     &                       fh_ocn,    fh_lnd,    fh_ice,              &  !intent(inout)
-     &                     fm10_ocn,  fm10_lnd,  fm10_ice,              &  !intent(inout)
-     &                      fh2_ocn,   fh2_lnd,   fh2_ice,              &  !intent(inout)
+     &                    tskin_wat, tskin_lnd, tskin_ice,              &  !intent(in)
+     &                    tsurf_wat, tsurf_lnd, tsurf_ice,              &  !intent(in)
+     &                   snwdph_wat,snwdph_lnd,snwdph_ice,              &  !intent(in)
+     &                     z0rl_wat,  z0rl_lnd,  z0rl_ice,              &  !intent(inout)
+     &                    ustar_wat, ustar_lnd, ustar_ice,              &  !intent(inout)
+     &                       cm_wat,    cm_lnd,    cm_ice,              &  !intent(inout)
+     &                       ch_wat,    ch_lnd,    ch_ice,              &  !intent(inout)
+     &                       rb_wat,    rb_lnd,    rb_ice,              &  !intent(inout)
+     &                   stress_wat,stress_lnd,stress_ice,              &  !intent(inout)
+     &                       fm_wat,    fm_lnd,    fm_ice,              &  !intent(inout)
+     &                       fh_wat,    fh_lnd,    fh_ice,              &  !intent(inout)
+     &                     fm10_wat,  fm10_lnd,  fm10_ice,              &  !intent(inout)
+     &                      fh2_wat,   fh2_lnd,   fh2_ice,              &  !intent(inout)
      &                    errmsg, errflg)                                  !intent(out)
 !
       implicit none
@@ -100,21 +100,21 @@
      &                    wind,sigmaf,shdmax,                           &
      &                    z0pert,ztpert ! mg, sfc-perts
       real(kind=kind_phys), dimension(im), intent(in)    ::             &
-     &                    tskin_ocn, tskin_lnd, tskin_ice,              &
-     &                    tsurf_ocn, tsurf_lnd, tsurf_ice,              &
-     &                   snwdph_ocn,snwdph_lnd,snwdph_ice
+     &                    tskin_wat, tskin_lnd, tskin_ice,              &
+     &                    tsurf_wat, tsurf_lnd, tsurf_ice,              &
+     &                   snwdph_wat,snwdph_lnd,snwdph_ice
 
       real(kind=kind_phys), dimension(im), intent(inout) ::             &
-     &                     z0rl_ocn,  z0rl_lnd,  z0rl_ice,              &
-     &                    ustar_ocn, ustar_lnd, ustar_ice,              &
-     &                       cm_ocn,    cm_lnd,    cm_ice,              &
-     &                       ch_ocn,    ch_lnd,    ch_ice,              &
-     &                       rb_ocn,    rb_lnd,    rb_ice,              &
-     &                   stress_ocn,stress_lnd,stress_ice,              &
-     &                       fm_ocn,    fm_lnd,    fm_ice,              &
-     &                       fh_ocn,    fh_lnd,    fh_ice,              &
-     &                     fm10_ocn,  fm10_lnd,  fm10_ice,              &
-     &                      fh2_ocn,   fh2_lnd,   fh2_ice
+     &                     z0rl_wat,  z0rl_lnd,  z0rl_ice,              &
+     &                    ustar_wat, ustar_lnd, ustar_ice,              &
+     &                       cm_wat,    cm_lnd,    cm_ice,              &
+     &                       ch_wat,    ch_lnd,    ch_ice,              &
+     &                       rb_wat,    rb_lnd,    rb_ice,              &
+     &                   stress_wat,stress_lnd,stress_ice,              &
+     &                       fm_wat,    fm_lnd,    fm_ice,              &
+     &                       fh_wat,    fh_lnd,    fh_ice,              &
+     &                     fm10_wat,  fm10_lnd,  fm10_ice,              &
+     &                      fh2_wat,   fh2_lnd,   fh2_ice
       character(len=*), intent(out) :: errmsg
       integer,          intent(out) :: errflg
 !
@@ -281,17 +281,17 @@
 !      the stuff now put into "stability"
 
           if (wet(i)) then ! Some open ocean
-            tvs          = 0.5 * (tsurf_ocn(i)+tskin_ocn(i)) * virtfac
-            z0           = 0.01 * z0rl_ocn(i)
+            tvs          = 0.5 * (tsurf_wat(i)+tskin_wat(i)) * virtfac
+            z0           = 0.01 * z0rl_wat(i)
             z0max        = max(1.0e-6, min(z0,z1(i)))
-            ustar_ocn(i) = sqrt(grav * z0 / charnock)
+            ustar_wat(i) = sqrt(grav * z0 / charnock)
             wind10m      = sqrt(u10m(i)*u10m(i)+v10m(i)*v10m(i))
 
 !**  test xubin's new z0
 
 !           ztmax  = z0max
 
-            restar = max(ustar_ocn(i)*z0max*visi, 0.000001)
+            restar = max(ustar_wat(i)*z0max*visi, 0.000001)
 
 !           restar = log(restar)
 !           restar = min(restar,5.)
@@ -314,17 +314,17 @@
 !
             call stability
 !  ---  inputs:
-     &       (z1(i), snwdph_ocn(i), thv1, wind(i),
+     &       (z1(i), snwdph_wat(i), thv1, wind(i),
      &        z0max, ztmax, tvs, grav,
 !  ---  outputs:
-     &        rb_ocn(i), fm_ocn(i), fh_ocn(i), fm10_ocn(i), fh2_ocn(i),
-     &        cm_ocn(i), ch_ocn(i), stress_ocn(i), ustar_ocn(i))
+     &        rb_wat(i), fm_wat(i), fh_wat(i), fm10_wat(i), fh2_wat(i),
+     &        cm_wat(i), ch_wat(i), stress_wat(i), ustar_wat(i))
 !
 !  update z0 over ocean
 !
             if (sfc_z0_type >= 0) then
               if (sfc_z0_type == 0) then
-                z0 = (charnock / grav) * ustar_ocn(i) * ustar_ocn(i)
+                z0 = (charnock / grav) * ustar_wat(i) * ustar_wat(i)
 
 ! mbek -- toga-coare flux algorithm
 !               z0 = (charnock / grav) * ustar(i)*ustar(i) +  arnu/ustar(i)
@@ -335,19 +335,19 @@
 !               z0 = arnu / (ustar(i) * ff ** pp)
 
                 if (redrag) then
-                  z0rl_ocn(i) = 100.0 * max(min(z0, z0s_max), 1.e-7)
+                  z0rl_wat(i) = 100.0 * max(min(z0, z0s_max), 1.e-7)
                 else
-                  z0rl_ocn(i) = 100.0 * max(min(z0,.1), 1.e-7)
+                  z0rl_wat(i) = 100.0 * max(min(z0,.1), 1.e-7)
                 endif
 
               elseif (sfc_z0_type == 6) then   ! wang
                  call znot_m_v6(wind10m, z0)  ! wind, m/s, z0, m
-                 z0rl_ocn(i) = 100.0 * z0          ! cm
+                 z0rl_wat(i) = 100.0 * z0          ! cm
               elseif (sfc_z0_type == 7) then   ! wang
                  call znot_m_v7(wind10m, z0)  ! wind, m/s, z0, m
-                 z0rl_ocn(i) = 100.0 * z0          ! cm
+                 z0rl_wat(i) = 100.0 * z0          ! cm
               else
-                 z0rl_ocn(i) = 1.0e-4
+                 z0rl_wat(i) = 1.0e-4
               endif
 
             endif

--- a/physics/sfc_diff.meta
+++ b/physics/sfc_diff.meta
@@ -244,7 +244,7 @@
   type = logical
   intent = in
   optional = F
-[tskin_ocn]
+[tskin_wat]
   standard_name = surface_skin_temperature_over_ocean_interstitial
   long_name = surface skin temperature over ocean (temporary use as interstitial)
   units = K
@@ -271,7 +271,7 @@
   kind = kind_phys
   intent = in
   optional = F
-[tsurf_ocn]
+[tsurf_wat]
   standard_name = surface_skin_temperature_after_iteration_over_ocean
   long_name = surface skin temperature after iteration over ocean
   units = K
@@ -298,7 +298,7 @@
   kind = kind_phys
   intent = in
   optional = F
-[snwdph_ocn]
+[snwdph_wat]
   standard_name = surface_snow_thickness_water_equivalent_over_ocean
   long_name = water equivalent snow depth over ocean
   units = mm
@@ -325,7 +325,7 @@
   kind = kind_phys
   intent = in
   optional = F
-[z0rl_ocn]
+[z0rl_wat]
   standard_name = surface_roughness_length_over_ocean_interstitial
   long_name = surface roughness length over ocean (temporary use as interstitial)
   units = cm
@@ -352,7 +352,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[ustar_ocn]
+[ustar_wat]
   standard_name = surface_friction_velocity_over_ocean
   long_name = surface friction velocity over ocean
   units = m s-1
@@ -379,7 +379,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[cm_ocn]
+[cm_wat]
   standard_name = surface_drag_coefficient_for_momentum_in_air_over_ocean
   long_name = surface exchange coeff for momentum over ocean
   units = none
@@ -406,7 +406,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[ch_ocn]
+[ch_wat]
   standard_name = surface_drag_coefficient_for_heat_and_moisture_in_air_over_ocean
   long_name = surface exchange coeff heat & moisture over ocean
   units = none
@@ -433,7 +433,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[rb_ocn]
+[rb_wat]
   standard_name = bulk_richardson_number_at_lowest_model_level_over_ocean
   long_name = bulk Richardson number at the surface over ocean
   units = none
@@ -460,7 +460,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[stress_ocn]
+[stress_wat]
   standard_name = surface_wind_stress_over_ocean
   long_name = surface wind stress over ocean
   units = m2 s-2
@@ -487,7 +487,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[fm_ocn]
+[fm_wat]
   standard_name = Monin_Obukhov_similarity_function_for_momentum_over_ocean
   long_name = Monin-Obukhov similarity function for momentum over ocean
   units = none
@@ -514,7 +514,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[fh_ocn]
+[fh_wat]
   standard_name = Monin_Obukhov_similarity_function_for_heat_over_ocean
   long_name = Monin-Obukhov similarity function for heat over ocean
   units = none
@@ -541,7 +541,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[fm10_ocn]
+[fm10_wat]
   standard_name = Monin_Obukhov_similarity_function_for_momentum_at_10m_over_ocean
   long_name = Monin-Obukhov similarity parameter for momentum at 10m over ocean
   units = none
@@ -568,7 +568,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[fh2_ocn]
+[fh2_wat]
   standard_name = Monin_Obukhov_similarity_function_for_heat_at_2m_over_ocean
   long_name = Monin-Obukhov similarity parameter for heat at 2m over ocean
   units = none

--- a/physics/sfc_drv_ruc.F90
+++ b/physics/sfc_drv_ruc.F90
@@ -147,7 +147,7 @@ module lsm_ruc
      &       imp_physics, imp_physics_gfdl, imp_physics_thompson,       &
      &       smcwlt2, smcref2, do_mynnsfclay,                           &
      &       con_cp, con_rv, con_rd, con_g, con_pi, con_hvap, con_fvirt,& !  constants
-     &       weasd, snwdph, tskin, tskin_ocn,                           & !  in/outs
+     &       weasd, snwdph, tskin, tskin_wat,                           & !  in/outs
      &       rainnc, rainc, ice, snow, graupel,                         & ! in
      &       srflag, smois, tslb, sh2o, keepfr, smfrkeep,               & ! in/outs, on RUC levels
      &       canopy, trans, tsurf, tsnow, zorl,                         &
@@ -196,7 +196,7 @@ module lsm_ruc
       real (kind=kind_phys), dimension(lsoil_ruc) :: dzs
       real (kind=kind_phys), dimension(lsoil_ruc), intent(inout   ) :: zs
       real (kind=kind_phys), dimension(im), intent(inout) :: weasd,     &
-     &       snwdph, tskin, tskin_ocn,                                  &
+     &       snwdph, tskin, tskin_wat,                                  &
      &       srflag, canopy, trans, tsurf, zorl, tsnow,                 &
      &       sfcqc, sfcqv, sfcdew, fice, tice, sfalb, smcwlt2, smcref2
 !  ---  in
@@ -314,7 +314,7 @@ module lsm_ruc
 
         call rucinit          (flag_restart, im, lsoil_ruc, lsoil, nlev, & ! in
                                isot, soiltyp, vegtype, fice,             & ! in
-                               land, tskin, tskin_ocn, tg3,              & ! in
+                               land, tskin, tskin_wat, tg3,              & ! in
                                smc, slc, stc,                            & ! in
                                smcref2, smcwlt2,                         & ! inout
                                lsm_ruc, lsm,                             & ! in
@@ -1040,7 +1040,7 @@ module lsm_ruc
 !! This subroutine contains RUC LSM initialization.
       subroutine rucinit      (restart, im, lsoil_ruc, lsoil, nlev,   & ! in
                                isot, soiltyp, vegtype, fice,          & ! in
-                               land, tsurf, tsurf_ocn,                & ! in
+                               land, tsurf, tsurf_wat,                & ! in
                                tg3, smc, slc, stc,                    & ! in
                                smcref2, smcwlt2,                      & ! inout
                                lsm_ruc, lsm,                          & ! in
@@ -1057,7 +1057,7 @@ module lsm_ruc
       integer,                                 intent(in   ) :: lsoil_ruc
       integer,                                 intent(in   ) :: lsoil
       logical,               dimension(im),    intent(in   ) :: land
-      real (kind=kind_phys), dimension(im),    intent(in   ) :: tsurf, tsurf_ocn
+      real (kind=kind_phys), dimension(im),    intent(in   ) :: tsurf, tsurf_wat
       real (kind=kind_phys), dimension(im),    intent(inout) :: smcref2
       real (kind=kind_phys), dimension(im),    intent(inout) :: smcwlt2
       real (kind=kind_phys), dimension(im),    intent(in   ) :: tg3
@@ -1216,7 +1216,7 @@ module lsm_ruc
          ! land only version
           if (land(i)) then
             tsk(i,j) = tsurf(i)
-            sst(i,j) = tsurf_ocn(i)
+            sst(i,j) = tsurf_wat(i)
             tbot(i,j)= tg3(i)
             ivgtyp(i,j)=vegtype(i)
             isltyp(i,j)=soiltyp(i)

--- a/physics/sfc_drv_ruc.meta
+++ b/physics/sfc_drv_ruc.meta
@@ -782,7 +782,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[tskin_ocn]
+[tskin_wat]
   standard_name = surface_skin_temperature_over_ocean_interstitial
   long_name = surface skin temperature over ocean (temporary use as interstitial)
   units = K

--- a/physics/sfc_nst.f
+++ b/physics/sfc_nst.f
@@ -675,7 +675,7 @@ cc
 !> \section NSST_general_pre_algorithm General Algorithm
 !! @{
       subroutine sfc_nst_pre_run
-     &    (im, wet, tsfc_ocn, tsurf_ocn, tseal, xt, xz, dt_cool,
+     &    (im, wet, tsfc_wat, tsurf_wat, tseal, xt, xz, dt_cool,
      &     z_c, tref, cplflx, oceanfrac, errmsg, errflg)
 
       use machine , only : kind_phys
@@ -686,12 +686,12 @@ cc
       integer, intent(in) :: im
       logical, dimension(im), intent(in) :: wet
       real (kind=kind_phys), dimension(im), intent(in) ::
-     &      tsfc_ocn, xt, xz, dt_cool, z_c, oceanfrac
+     &      tsfc_wat, xt, xz, dt_cool, z_c, oceanfrac
       logical, intent(in) :: cplflx
 
 !  ---  input/outputs:
       real (kind=kind_phys), dimension(im), intent(inout) ::
-     &    tsurf_ocn, tseal, tref
+     &    tsurf_wat, tseal, tref
 
 !  ---  outputs:
       character(len=*), intent(out) :: errmsg
@@ -714,9 +714,9 @@ cc
 !          tem         = (oro(i)-oro_uf(i)) * rlapse
           ! DH* 20190927 simplyfing this code because tem is zero
           !tem          = zero
-          !tseal(i)     = tsfc_ocn(i)  + tem
-          tseal(i)     = tsfc_ocn(i)
-          !tsurf_ocn(i) = tsurf_ocn(i) + tem
+          !tseal(i)     = tsfc_wat(i)  + tem
+          tseal(i)     = tsfc_wat(i)
+          !tsurf_wat(i) = tsurf_wat(i) + tem
           ! *DH
         endif
       enddo
@@ -736,7 +736,7 @@ cc
             endif
             tseal(i) = tref(i) + dt_warm - dt_cool(i)
 !                  - (Sfcprop%oro(i)-Sfcprop%oro_uf(i))*rlapse
-            tsurf_ocn(i) = tseal(i)
+            tsurf_wat(i) = tseal(i)
           endif
         enddo
       endif
@@ -779,7 +779,7 @@ cc
       subroutine sfc_nst_post_run                                       &
      &     ( im, rlapse, tgice, wet, icy, oro, oro_uf, nstf_name1,      &
      &       nstf_name4, nstf_name5, xt, xz, dt_cool, z_c, tref, xlon,  &
-     &       tsurf_ocn, tsfc_ocn, dtzm, errmsg, errflg                  &
+     &       tsurf_wat, tsfc_wat, dtzm, errmsg, errflg                  &
      &     )
 
       use machine , only : kind_phys
@@ -797,8 +797,8 @@ cc
      &      dt_cool, z_c, tref, xlon
 
 !  ---  input/outputs:
-      real (kind=kind_phys), dimension(im), intent(inout) :: tsurf_ocn, &
-     &      tsfc_ocn
+      real (kind=kind_phys), dimension(im), intent(inout) :: tsurf_wat, &
+     &      tsfc_wat
 
 !  ---  outputs:
       real (kind=kind_phys), dimension(size(xlon,1)), intent(out) ::    &
@@ -821,7 +821,7 @@ cc
 
 !      do i = 1, im
 !        if (wet(i) .and. .not. icy(i)) then
-!          tsurf_ocn(i) = tsurf_ocn(i) - (oro(i)-oro_uf(i)) * rlapse
+!          tsurf_wat(i) = tsurf_wat(i) - (oro(i)-oro_uf(i)) * rlapse
 !        endif
 !      enddo
 
@@ -838,8 +838,8 @@ cc
 !          if (wet(i) .and. .not.icy(i)) then
 !          if (wet(i) .and. (Model%frac_grid .or. .not. icy(i))) then
           if (wet(i)) then
-            tsfc_ocn(i) = max(tgice, tref(i) + dtzm(i))
-!           tsfc_ocn(i) = max(271.2, tref(i) + dtzm(i)) -  &
+            tsfc_wat(i) = max(tgice, tref(i) + dtzm(i))
+!           tsfc_wat(i) = max(271.2, tref(i) + dtzm(i)) -  &
 !                           (oro(i)-oro_uf(i))*rlapse
           endif
         enddo

--- a/physics/sfc_nst.meta
+++ b/physics/sfc_nst.meta
@@ -679,7 +679,7 @@
   type = logical
   intent = in
   optional = F
-[tsfc_ocn]
+[tsfc_wat]
   standard_name = surface_skin_temperature_over_ocean_interstitial
   long_name = surface skin temperature over ocean (temporary use as interstitial)
   units = K
@@ -688,7 +688,7 @@
   kind = kind_phys
   intent = in
   optional = F
-[tsurf_ocn]
+[tsurf_wat]
   standard_name = surface_skin_temperature_after_iteration_over_ocean
   long_name = surface skin temperature after iteration over ocean
   units = K
@@ -938,7 +938,7 @@
   kind = kind_phys
   intent = in
   optional = F
-[tsurf_ocn]
+[tsurf_wat]
   standard_name = surface_skin_temperature_after_iteration_over_ocean
   long_name = surface skin temperature after iteration over ocean
   units = K
@@ -947,7 +947,7 @@
   kind = kind_phys
   intent = inout
   optional = F
-[tsfc_ocn]
+[tsfc_wat]
   standard_name = surface_skin_temperature_over_ocean_interstitial
   long_name = surface skin temperature over ocean (temporary use as interstitial)
   units = K

--- a/physics/sfc_sice.f
+++ b/physics/sfc_sice.f
@@ -40,12 +40,12 @@
 !>  \section detailed_sice_run GFS Sea Ice Driver Detailed Algorithm
 !>  @{
       subroutine sfc_sice_run                                           &
-     &     ( im, km, sbc, hvap, tgice, cp, eps, epsm1, rvrdm1, grav,    & !  ---  inputs:
+     &     ( im, kice, sbc, hvap, tgice, cp, eps, epsm1, rvrdm1, grav,  & !  ---  inputs:
      &       t0c, rd, ps, t1, q1, delt,                                 &
      &       sfcemis, dlwflx, sfcnsw, sfcdsw, srflag,                   &
      &       cm, ch, prsl1, prslki, prsik1, prslk1, islimsk, wind,      &
      &       flag_iter, lprnt, ipr, cimin,                              &
-     &       hice, fice, tice, weasd, tskin, tprcp, stc, ep,            & !  ---  input/outputs:
+     &       hice, fice, tice, weasd, tskin, tprcp, tiice, ep,          & !  ---  input/outputs:
      &       snwdph, qsurf, snowmt, gflux, cmm, chh, evap, hflx,        & !  
      &       cplflx, cplchm, flag_cice, islmsk_cice,                    &
      &       errmsg, errflg
@@ -58,12 +58,12 @@
 !                                                                       !
 !    call sfc_sice                                                      !
 !       inputs:                                                         !
-!          ( im, km, ps, t1, q1, delt,                                  !
+!          ( im, kice, ps, t1, q1, delt,                                !
 !            sfcemis, dlwflx, sfcnsw, sfcdsw, srflag,                   !
 !            cm, ch, prsl1, prslki, prsik1, prslk1, islimsk, wind,      !
 !            flag_iter,                                                 !
 !       input/outputs:                                                  !
-!            hice, fice, tice, weasd, tskin, tprcp, stc, ep,            !
+!            hice, fice, tice, weasd, tskin, tprcp, tiice, ep,            !
 !       outputs:                                                        !
 !            snwdph, qsurf, snowmt, gflux, cmm, chh, evap, hflx )       !
 !                                                                       !
@@ -90,7 +90,7 @@
 !  ====================  defination of variables  ====================  !
 !                                                                       !
 !  inputs:                                                       size   !
-!     im, km   - integer, horiz dimension and num of soil layers   1    !
+!     im, kice - integer, horiz dimension and num of ice layers    1    !
 !     ps       - real, surface pressure                            im   !
 !     t1       - real, surface layer mean temperature ( k )        im   !
 !     q1       - real, surface layer mean specific humidity        im   !
@@ -117,7 +117,7 @@
 !     weasd    - real, water equivalent accumulated snow depth (mm)im   !
 !     tskin    - real, ground surface skin temperature ( k )       im   !
 !     tprcp    - real, total precipitation                         im   !
-!     stc      - real, soil temp (k)                              im,km !
+!     tiice    - real, temperature of ice internal (k)          im,kice !
 !     ep       - real, potential evaporation                       im   !
 !                                                                       !
 !  outputs:                                                             !
@@ -148,7 +148,7 @@
       real(kind=kind_phys), parameter :: dsi   = one/0.33d0
 
 !  ---  inputs:
-      integer, intent(in) :: im, km, ipr
+      integer, intent(in) :: im, kice, ipr
       logical, intent(in) :: lprnt
       logical, intent(in) :: cplflx
       logical, intent(in) :: cplchm
@@ -170,7 +170,7 @@
       real (kind=kind_phys), dimension(im), intent(inout) :: hice,      &
      &       fice, tice, weasd, tskin, tprcp, ep
 
-      real (kind=kind_phys), dimension(im,km), intent(inout) :: stc
+      real (kind=kind_phys), dimension(im,kice), intent(inout) :: tiice
 
 !  ---  outputs:
       real (kind=kind_phys), dimension(im), intent(inout) :: snwdph,    &
@@ -236,12 +236,12 @@
           endif
         endif
       enddo
-!> - Update/read sea ice temperature from soil temperature and initialize variables.
+!  --- ...  update sea ice temperature
 
       do k = 1, kmi
         do i = 1, im
           if (flag(i)) then
-            stsice(i,k) = stc(i,k)
+            stsice(i,k) = tiice(i,k)
           endif
         enddo
       enddo
@@ -391,7 +391,7 @@
       do k = 1, kmi
         do i = 1, im
           if (flag(i)) then
-            stc(i,k) = min(stsice(i,k), t0c)
+            tiice(i,k) = min(stsice(i,k), t0c)
           endif
         enddo
       enddo

--- a/physics/sfc_sice.meta
+++ b/physics/sfc_sice.meta
@@ -9,9 +9,9 @@
   type = integer
   intent = in
   optional = F
-[km]
-  standard_name = soil_vertical_dimension
-  long_name = vertical loop extent for soil levels, start at 1
+[kice]
+  standard_name = ice_vertical_dimension
+  long_name = vertical loop extent for ice levels, start at 1
   units = count
   dimensions = ()
   type = integer
@@ -346,11 +346,11 @@
   kind = kind_phys
   intent = inout
   optional = F
-[stc]
-  standard_name = soil_temperature
-  long_name = soil temp
+[tiice]
+  standard_name = internal_ice_temperature
+  long_name = sea ice internal temperature
   units = K
-  dimensions = (horizontal_dimension,soil_vertical_dimension)
+  dimensions = (horizontal_dimension,ice_vertical_dimension)
   type = real
   kind = kind_phys
   intent = inout


### PR DESCRIPTION
As described in Issue #437, Sfcprop%stc is currently used to store temperatures for both soil and internal ice. In the case of fractional grid, both surface types can exist at a single grid point. Thus we introduced a separate array called "tiice" to store internal ice temperature. "tiice" will be added to phyf*nc output only when frac_grid=T. 

Arrays named "_ocn" are replaced by "_wat", so they can be used over lake as well. 

The model passed regression tests for both uncoupled FV3 and coupled FV3 with frac_grid=F. 