### PR TITLE
Replaced the flag_cice condition by dusfcin_cpl

### DIFF
--- a/physics/GFS_PBL_generic.F90
+++ b/physics/GFS_PBL_generic.F90
@@ -313,7 +313,7 @@
         dqdt, dusfc_cpl, dvsfc_cpl, dtsfc_cpl,                                                                                 &
         dqsfc_cpl, dusfci_cpl, dvsfci_cpl, dtsfci_cpl, dqsfci_cpl, dusfc_diag, dvsfc_diag, dtsfc_diag, dqsfc_diag,             &
         dusfci_diag, dvsfci_diag, dtsfci_diag, dqsfci_diag, dt3dt, du3dt_PBL, du3dt_OGWD, dv3dt_PBL, dv3dt_OGWD, dq3dt,        &
-        dq3dt_ozone, rd, cp, fvirt, hvap, t1, q1, prsl, hflx, ushfsfci, oceanfrac, flag_cice, dusfc_cice, dvsfc_cice,          &
+        dq3dt_ozone, rd, cp, fvirt, hvap, t1, q1, prsl, hflx, ushfsfci, oceanfrac, dusfc_cice, dvsfc_cice,                     &
         dtsfc_cice, dqsfc_cice, wet, dry, icy, wind, stress_wat, hflx_wat, evap_wat, ugrs1, vgrs1, dkt_cpl, dkt, hffac, hefac, &
         ugrs, vgrs, tgrs, qgrs, save_u, save_v, save_t, save_q, errmsg, errflg)
 
@@ -329,7 +329,6 @@
       integer, intent(in) :: imp_physics_zhao_carr, imp_physics_mg, imp_physics_fer_hires
       logical, intent(in) :: ltaerosol, cplflx, cplchm, lssav, ldiag3d, qdiag3d, lsidea
       logical, intent(in) :: hybedmf, do_shoc, satmedmf, shinhong, do_ysu
-      logical, dimension(:), intent(in) :: flag_cice
 
       logical, intent(in) :: flag_for_pbl_generic_tend      
       real(kind=kind_phys), dimension(im, levs), intent(in) :: save_u, save_v, save_t
@@ -546,7 +545,7 @@
         do i=1,im
           if (oceanfrac(i) > zero) then ! Ocean only, NO LAKES
             if ( .not. wet(i)) then ! no open water
-              if (flag_cice(i)) then !use results from CICE
+              if (dusfc_cice(i) < huge ) then !use results from CICE
                 dusfci_cpl(i) = dusfc_cice(i)
                 dvsfci_cpl(i) = dvsfc_cice(i)
                 dtsfci_cpl(i) = dtsfc_cice(i)
@@ -554,8 +553,8 @@
               else !use PBL fluxes when CICE fluxes is unavailable
                 dusfci_cpl(i) = dusfc1(i)
                 dvsfci_cpl(i) = dvsfc1(i)
-                dtsfci_cpl(i) = dtsfc1(i)
-                dqsfci_cpl(i) = dqsfc1(i)
+                dtsfci_cpl(i) = dtsfc1(i)*hffac(i)
+                dqsfci_cpl(i) = dqsfc1(i)*hefac(i)
               end if
             elseif (icy(i) .or. dry(i)) then ! use stress_ocean from sfc_diff for opw component at mixed point
               tem1 = max(q1(i), 1.e-8)
@@ -590,7 +589,7 @@
 !!
           endif ! Ocean only, NO LAKES
         enddo
-      endif
+      endif ! if cplflx
 
 !-------------------------------------------------------lssav if loop ----------
       if (lssav) then

--- a/physics/GFS_PBL_generic.meta
+++ b/physics/GFS_PBL_generic.meta
@@ -1166,14 +1166,6 @@
   kind = kind_phys
   intent = in
   optional = F
-[flag_cice]
-  standard_name = flag_for_cice
-  long_name = flag for cice
-  units = flag
-  dimensions = (horizontal_dimension)
-  type = logical
-  intent = in
-  optional = F
 [dusfc_cice]
   standard_name = surface_x_momentum_flux_for_coupling
   long_name = sfc x momentum flux for coupling


### PR DESCRIPTION
When ice flux is huge (undefined) in the 1st time step cold run, use PBL-calculated ice fluxes instead. This will change results in the coupled model only. Passed regression tests for standalone FV3.

This refers to issue #472. 