### PR TITLE
Update for new RRTMG cloud overlap methods (replaced by #487)

### DIFF
--- a/physics/GFS_rrtmg_pre.F90
+++ b/physics/GFS_rrtmg_pre.F90
@@ -33,7 +33,7 @@
           faerlw1, faerlw2, faerlw3, aerodp,                         &
           clouds1, clouds2, clouds3, clouds4, clouds5, clouds6,      &
           clouds7, clouds8, clouds9, cldsa,                          &
-          mtopa, mbota, de_lgth, alb1d, errmsg, errflg)
+          mtopa, mbota, de_lgth, alpha, alb1d, errmsg, errflg)
 
       use machine,                   only: kind_phys
       use GFS_typedefs,              only: GFS_statein_type,   &
@@ -146,6 +146,7 @@
       integer,              dimension(size(Grid%xlon,1),3),                intent(out) :: mbota
       integer,              dimension(size(Grid%xlon,1),3),                intent(out) :: mtopa
       real(kind=kind_phys), dimension(size(Grid%xlon,1)),                  intent(out) :: de_lgth
+      real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+LTP),   intent(out) :: alpha
       real(kind=kind_phys), dimension(size(Grid%xlon,1)),                  intent(out) :: alb1d
 
       character(len=*), intent(out) :: errmsg
@@ -156,14 +157,14 @@
 
       integer :: i, j, k, k1, k2, lsk, lv, n, itop, ibtc, LP1, lla, llb, lya, lyb
 
-      real(kind=kind_phys) :: es, qs, delt, tem0d
+      real(kind=kind_phys) :: es, qs, delt, tem0d, pfac
 
       real(kind=kind_phys), dimension(size(Grid%xlon,1)) :: cvt1, cvb1, tem1d, tskn
 
       real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+LTP) :: &
                           htswc, htlwc, gcice, grain, grime, htsw0, htlw0, &
                           rhly, tvly,qstl, vvel, clw, ciw, prslk1, tem2da, &
-                          cldcov, deltaq, cnvc, cnvw,                      &
+                          dzb, hzb, cldcov, deltaq, cnvc, cnvw,            &
                           effrl, effri, effrr, effrs, rho, orho
       ! for Thompson MP
       real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+LTP) :: &
@@ -171,7 +172,7 @@
                                   qi_mp, qs_mp, nc_mp, ni_mp, nwfa
 
       real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+LTP+1) :: tem2db
-!     real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+LTP+1) :: hz
+      real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+LTP+1) :: hz
 
       real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+LTP,min(4,Model%ncnd)) :: ccnd
       real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+LTP,2:Model%ntrac) :: tracer1
@@ -432,6 +433,10 @@
         enddo
 
 !  ---  ...  level height and layer thickness (km)
+! dz:  Layer thickness between layer boundaries
+! dzb: Layer thickness between layer centers (lowest is from surface to lowest layer center)
+! hz:  Height of each level (i.e. layer boundary)
+! hzb: Height of each layer center
 
         tem0d = 0.001 * rog
         do i = 1, IM
@@ -439,10 +444,20 @@
             dz(i,k) = tem0d * (tem2db(i,k+1) - tem2db(i,k)) * tvly(i,k)
           enddo
 
-!         hz(i,LMP) = 0.0
-!         do k = LMK, 1, -1
-!           hz(i,k) = hz(i,k+1) + dz(i,k)
-!         enddo
+          hz(i,LMP) = 0.0
+          do k = LMK, 1, -1
+            hz(i,k) = hz(i,k+1) + dz(i,k)
+          enddo
+
+          do k = LMK, 1, -1
+            pfac = (tem2db(i,k+1) - tem2da(i,k)) / (tem2db(i,k+1) - tem2db(i,k))
+            hzb(i,k) = hz(i,k+1) + pfac * (hz(i,k) - hz(i,k+1))
+          enddo
+
+          do k = LMK-1, 1, -1
+            dzb(i,k) = hzb(i,k) - hzb(i,k+1)
+          enddo
+          dzb(i,LMK) = hzb(i,LMK) - hz(i,LMP)
         enddo
 
       else                               ! input data from sfc to toa
@@ -483,6 +498,10 @@
         enddo
 
 !  ---  ...  level height and layer thickness (km)
+! dz:  Layer thickness between layer boundaries
+! dzb: Layer thickness between layer centers (lowest is from surface to lowest layer center)
+! hz:  Height of each level (i.e. layer boundary)
+! hzb: Height of each layer center
 
         tem0d = 0.001 * rog
         do i = 1, IM
@@ -490,10 +509,20 @@
             dz(i,k) = tem0d * (tem2db(i,k) - tem2db(i,k+1)) * tvly(i,k)
           enddo
 
-!         hz(i,1) = 0.0
-!         do k = 1, LMP
-!           hz(i,k+1) = hz(i,k) + dz(i,k)
-!         enddo
+          hz(i,1) = 0.0
+          do k = 1, LMK
+            hz(i,k+1) = hz(i,k) + dz(i,k)
+          enddo
+
+          do k = 1, LMK
+            pfac = (tem2db(i,k) - tem2da(i,k)) / (tem2db(i,k) - tem2db(i,k+1))
+            hzb(i,k) = hz(i,k) + pfac * (hz(i,k+1) - hz(i,k))
+          enddo
+
+          do k = 2, LMK
+            dzb(i,k) = hzb(i,k) - hzb(i,k-1)
+          enddo
+          dzb(i,1) = hzb(i,1) - hz(i,1)
         enddo
 
       endif                              ! end_if_ivflip
@@ -815,19 +844,21 @@
                                          ! or unified cloud and/or with MG microphysics
 
           if (Model%uni_cld .and. Model%ncld >= 2) then
-            call progclduni (plyr, plvl, tlyr, tvly, ccnd, ncndl,         & !  ---  inputs
-                             Grid%xlat, Grid%xlon, Sfcprop%slmsk,dz,delp, &
-                             IM, LMK, LMP, cldcov,                        &
-                             effrl, effri, effrr, effrs, Model%effr_in,   &
-                             clouds, cldsa, mtopa, mbota, de_lgth)          !  ---  outputs
+            call progclduni (plyr, plvl, tlyr, tvly, ccnd, ncndl,           & !  ---  inputs
+                             Grid%xlat, Grid%xlon, Sfcprop%slmsk,dz,delp,   &
+                             IM, LMK, LMP, cldcov,                          &
+                             effrl, effri, effrr, effrs, Model%effr_in,     &
+                             dzb, Grid%xlat_d, Model%julian, Model%yearlen, &
+                             clouds, cldsa, mtopa, mbota, de_lgth, alpha)     !  ---  outputs
           else
-            call progcld1 (plyr ,plvl, tlyr, tvly, qlyr, qstl, rhly,    & !  ---  inputs
-                           ccnd(1:IM,1:LMK,1), Grid%xlat,Grid%xlon,     &
-                           Sfcprop%slmsk, dz, delp, IM, LMK, LMP,       &
-                           Model%uni_cld, Model%lmfshal,                &
-                           Model%lmfdeep2, cldcov,                      &
-                           effrl, effri, effrr, effrs, Model%effr_in,   &
-                           clouds, cldsa, mtopa, mbota, de_lgth)          !  ---  outputs
+            call progcld1 (plyr ,plvl, tlyr, tvly, qlyr, qstl, rhly,        & !  ---  inputs
+                           ccnd(1:IM,1:LMK,1), Grid%xlat,Grid%xlon,         &
+                           Sfcprop%slmsk, dz, delp, IM, LMK, LMP,           &
+                           Model%uni_cld, Model%lmfshal,                    &
+                           Model%lmfdeep2, cldcov,                          &
+                           effrl, effri, effrr, effrs, Model%effr_in,       &
+                           dzb, Grid%xlat_d, Model%julian, Model%yearlen,   &
+                           clouds, cldsa, mtopa, mbota, de_lgth, alpha)       !  ---  outputs
           endif
 
         elseif(Model%imp_physics == 98) then      ! zhao/moorthi's prognostic cloud+pdfcld
@@ -837,7 +868,8 @@
                          cnvw, cnvc, Grid%xlat, Grid%xlon,              &
                          Sfcprop%slmsk, dz, delp, im, lmk, lmp, deltaq, &
                          Model%sup, Model%kdt, me,                      &
-                         clouds, cldsa, mtopa, mbota, de_lgth)               !  ---  outputs
+                         dzb, Grid%xlat_d, Model%julian, Model%yearlen, &
+                         clouds, cldsa, mtopa, mbota, de_lgth, alpha)        !  ---  outputs
 
 
         elseif (Model%imp_physics == 11) then           ! GFDL cloud scheme
@@ -847,21 +879,24 @@
                            ccnd(1:IM,1:LMK,1), cnvw, cnvc,                &
                            Grid%xlat, Grid%xlon, Sfcprop%slmsk,           &
                            cldcov, dz, delp, im, lmk, lmp,                &
-                           clouds, cldsa, mtopa, mbota, de_lgth)               !  ---  outputs
+                           dzb, Grid%xlat_d, Model%julian, Model%yearlen, &
+                           clouds, cldsa, mtopa, mbota, de_lgth, alpha)        !  ---  outputs
           else
 
             call progclduni (plyr, plvl, tlyr, tvly, ccnd, ncndl,         &    !  ---  inputs
                             Grid%xlat, Grid%xlon, Sfcprop%slmsk, dz,delp, &
                             IM, LMK, LMP, cldcov,                         &
                             effrl, effri, effrr, effrs, Model%effr_in,    &
-                            clouds, cldsa, mtopa, mbota, de_lgth)              !  ---  outputs
+                            dzb, Grid%xlat_d, Model%julian, Model%yearlen,&
+                            clouds, cldsa, mtopa, mbota, de_lgth, alpha)        !  ---  outputs
 !           call progcld4o (plyr, plvl, tlyr, tvly, qlyr, qstl, rhly,       &   !  ---  inputs
 !                           tracer1, Grid%xlat, Grid%xlon, Sfcprop%slmsk,   &
 !                           dz, delp,                                       &
 !                           ntrac-1, Model%ntcw-1,Model%ntiw-1,Model%ntrw-1,&
 !                           Model%ntsw-1,Model%ntgl-1,Model%ntclamt-1,      &
 !                           im, lmk, lmp,                                   &
-!                           clouds, cldsa, mtopa, mbota, de_lgth)               !  ---  outputs
+!                           dzb, Grid%xlat_d, Model%julian, Model%yearlen,  &
+!                           clouds, cldsa, mtopa, mbota, de_lgth, alpha)        !  ---  outputs
           endif
 
         elseif(Model%imp_physics == 6 .or. Model%imp_physics == 15) then
@@ -871,15 +906,16 @@
             Tbd%phy_f3d(:,:,Model%nseffr) = 250.
           endif
 
-          call progcld5 (plyr,plvl,tlyr,qlyr,qstl,rhly,tracer1,     &  !  --- inputs
-                         Grid%xlat,Grid%xlon,Sfcprop%slmsk,dz,delp, &
-                         ntrac-1, ntcw-1,ntiw-1,ntrw-1,             &
-                         ntsw-1,ntgl-1,                             &
-                         im, lmk, lmp, Model%uni_cld,               &
-                         Model%lmfshal,Model%lmfdeep2,              &
-                         cldcov(:,1:LMK),Tbd%phy_f3d(:,:,1),        &
-                         Tbd%phy_f3d(:,:,2), Tbd%phy_f3d(:,:,3),    &
-                         clouds,cldsa,mtopa,mbota, de_lgth)            !  --- outputs
+          call progcld5 (plyr,plvl,tlyr,qlyr,qstl,rhly,tracer1,        &  !  --- inputs
+                         Grid%xlat,Grid%xlon,Sfcprop%slmsk,dz,delp,    &
+                         ntrac-1, ntcw-1,ntiw-1,ntrw-1,                &
+                         ntsw-1,ntgl-1,                                &
+                         im, lmk, lmp, Model%uni_cld,                  &
+                         Model%lmfshal,Model%lmfdeep2,                 &
+                         cldcov(:,1:LMK),Tbd%phy_f3d(:,:,1),           &
+                         Tbd%phy_f3d(:,:,2), Tbd%phy_f3d(:,:,3),       &
+                         dzb, Grid%xlat_d, Model%julian, Model%yearlen,&
+                         clouds,cldsa,mtopa,mbota, de_lgth, alpha)        !  --- outputs
 
 
         elseif(Model%imp_physics == Model%imp_physics_thompson) then                              ! Thompson MP
@@ -900,19 +936,21 @@
                          Grid%xlat, Grid%xlon, Sfcprop%slmsk, dz,delp,  &
                          IM, LMK, LMP, clouds(:,1:LMK,1),               &
                          effrl, effri, effrr, effrs, Model%effr_in ,    &
-                         clouds, cldsa, mtopa, mbota, de_lgth)            !  ---  outputs
+                         dzb, Grid%xlat_d, Model%julian, Model%yearlen, &
+                         clouds, cldsa, mtopa, mbota, de_lgth, alpha)        !  ---  outputs
 
           else
             ! MYNN PBL or GF convective are not used
-            call progcld5 (plyr,plvl,tlyr,qlyr,qstl,rhly,tracer1,   & !  --- inputs
-                         Grid%xlat,Grid%xlon,Sfcprop%slmsk,dz,delp, &
-                         ntrac-1, ntcw-1,ntiw-1,ntrw-1,             &
-                         ntsw-1,ntgl-1,                             &
-                         im, lmk, lmp, Model%uni_cld,               &
-                         Model%lmfshal,Model%lmfdeep2,              &
-                         cldcov(:,1:LMK),Tbd%phy_f3d(:,:,1),        &
-                         Tbd%phy_f3d(:,:,2), Tbd%phy_f3d(:,:,3),    &
-                         clouds,cldsa,mtopa,mbota, de_lgth)           !  --- outputs
+            call progcld5 (plyr,plvl,tlyr,qlyr,qstl,rhly,tracer1,      & !  --- inputs
+                         Grid%xlat,Grid%xlon,Sfcprop%slmsk,dz,delp,    &
+                         ntrac-1, ntcw-1,ntiw-1,ntrw-1,                &
+                         ntsw-1,ntgl-1,                                &
+                         im, lmk, lmp, Model%uni_cld,                  &
+                         Model%lmfshal,Model%lmfdeep2,                 &
+                         cldcov(:,1:LMK),Tbd%phy_f3d(:,:,1),           &
+                         Tbd%phy_f3d(:,:,2), Tbd%phy_f3d(:,:,3),       &
+                         dzb, Grid%xlat_d, Model%julian, Model%yearlen,&
+                         clouds,cldsa,mtopa,mbota, de_lgth, alpha)        !  --- outputs
           endif ! MYNN PBL or GF
 
         endif                            ! end if_imp_physics

--- a/physics/GFS_rrtmg_pre.meta
+++ b/physics/GFS_rrtmg_pre.meta
@@ -554,6 +554,15 @@
   kind = kind_phys
   intent = out
   optional = F
+[alpha]
+  standard_name = cloud_overlap_decorrelation_parameter
+  long_name = cloud overlap decorrelation parameter
+  units = frac
+  dimensions = (horizontal_dimension,adjusted_vertical_layer_dimension_for_radiation)
+  type = real
+  kind = kind_phys
+  intent = out
+  optional = F
 [alb1d]
   standard_name = surface_albedo_perturbation
   long_name = surface albedo perturbation

--- a/physics/physcons.F90
+++ b/physics/physcons.F90
@@ -137,6 +137,9 @@
   real(kind=kind_phys),parameter:: rhosnow    = 100._kind_phys                     !< density of snow (kg/m^3)
   real(kind=kind_phys),parameter:: rhoair     = 1.28_kind_phys                     !< density of air near surface (kg/m^3)
 
+! Decorrelation length constant (km) for iovrlw/iovrsw = 4 or 5 and idcor = 0
+  real(kind=kind_phys),parameter:: decorr_con = 2.50_kind_phys
+
 !........................................!
       end module physcons                !
 !========================================!

--- a/physics/physparam.f
+++ b/physics/physparam.f
@@ -234,6 +234,8 @@
 !!\n =1:use maximum-random cloud overlapping method
 !!\n =2:use maximum cloud overlapping method
 !!\n =3:use decorrelation length overlapping method
+!!\n =4:use exponential overlapping method
+!!\n =5:use exponential-random overlapping method
 !!\n Opr GFS/CFS=1; see IOVR_SW in run scripts
       integer, save :: iovrsw  = 1
 !> cloud overlapping control flag for LW
@@ -241,8 +243,14 @@
 !!\n =1:use maximum-random cloud overlapping method
 !!\n =2:use maximum cloud overlapping method
 !!\n =3:use decorrelation length overlapping method
+!!\n =4:use exponential overlapping method
+!!\n =5:use exponential-random overlapping method
 !!\n Opr GFS/CFS=1; see IOVR_LW in run scripts
       integer, save :: iovrlw  = 1
+!!\n Decorrelation length type for iovrlw/iovrsw = 4 or 5
+!!\n =0:use constant decorrelation length defined by decorr_con (in module physcons)
+!!\n =1:use day-of-year and latitude-varying decorrelation length
+      integer, save :: idcor   = 1
 
 !> sub-column cloud approx flag in SW radiation
 !!\n =0:no McICA approximation in SW radiation

--- a/physics/radlw_main.f
+++ b/physics/radlw_main.f
@@ -6,7 +6,7 @@
 !!!!!               lw-rrtm3 radiation package description             !!!!!
 !!!!!  ==============================================================  !!!!!
 !                                                                          !
-!   this package includes ncep's modifications of the rrtm-lw radiation    !
+!   this package includes ncep's modifications of the rrtmg-lw radiation   !
 !   code from aer inc.                                                     !
 !                                                                          !
 !    the lw-rrtm3 package includes these parts:                            !
@@ -39,7 +39,7 @@
 !          inputs:                                                         !
 !           (plyr,plvl,tlyr,tlvl,qlyr,olyr,gasvmr,                         !
 !            clouds,icseed,aerosols,sfemis,sfgtmp,                         !
-!            dzlyr,delpin,de_lgth,                                         !
+!            dzlyr,delpin,de_lgth,alpha,                                   !
 !            npts, nlay, nlp1, lprnt,                                      !
 !          outputs:                                                        !
 !            hlwc,topflx,sfcflx,cldtau,                                    !
@@ -93,17 +93,38 @@
 !                                                                          !
 !==========================================================================!
 !                                                                          !
-!    the original aer's program declarations:                              !
+!    the original aer program declarations:                                !
 !                                                                          !
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!                                                                          |
-!  Copyright 2002-2007, Atmospheric & Environmental Research, Inc. (AER).  |
-!  This software may be used, copied, or redistributed as long as it is    |
-!  not sold and this copyright notice is reproduced on each copy made.     |
-!  This model is provided as is without any express or implied warranties. |
-!                       (http://www.rtweb.aer.com/)                        |
-!                                                                          |
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!                                                                              !
+! Copyright (c) 2002-2020, Atmospheric & Environmental Research, Inc. (AER)    !
+! All rights reserved.                                                         !
+!                                                                              !
+! Redistribution and use in source and binary forms, with or without           !
+! modification, are permitted provided that the following conditions are met:  !
+!  * Redistributions of source code must retain the above copyright            !
+!    notice, this list of conditions and the following disclaimer.             !
+!  * Redistributions in binary form must reproduce the above copyright         !
+!    notice, this list of conditions and the following disclaimer in the       !
+!    documentation and/or other materials provided with the distribution.      !
+!  * Neither the name of Atmospheric & Environmental Research, Inc., nor       !
+!    the names of its contributors may be used to endorse or promote products  !
+!    derived from this software without specific prior written permission.     !
+!                                                                              !
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"  !
+! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE    !
+! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE   !
+! ARE DISCLAIMED. IN NO EVENT SHALL ATMOSPHERIC & ENVIRONMENTAL RESEARCH, INC.,!
+! BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR       !
+! CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF         !
+! SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS     !
+! INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN      !
+! CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)      !
+! ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF       !
+! THE POSSIBILITY OF SUCH DAMAGE.                                              !
+!                        (http://www.rtweb.aer.com/)                           !
+!                                                                              !
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !                                                                          !
 ! ************************************************************************ !
 !                                                                          !
@@ -136,8 +157,14 @@
 ! ************************************************************************ !
 !                                                                          !
 !    references:                                                           !
-!    (rrtm_lw/rrtmg_lw):                                                   !
-!      clough, s.A., m.w. shephard, e.j. mlawer, j.s. delamere,            !
+!    (rrtmg_lw/rrtm_lw):                                                   !
+!      iacono, m.j., j.s. delamere, e.j. mlawer, m.w. shepard,             !
+!      s.a. clough, and w.d collins, radiative forcing by long-lived       !
+!      greenhouse gases: calculations with the aer radiative transfer      !
+!      models, j, geophys. res., 113, d13103, doi:10.1029/2008jd009944,    !
+!      2008.                                                               !
+!                                                                          !
+!      clough, s.a., m.w. shephard, e.j. mlawer, j.s. delamere,            !
 !      m.j. iacono, k. cady-pereira, s. boukabara, and p.d. brown:         !
 !      atmospheric radiative transfer modeling: a summary of the aer       !
 !      codes, j. quant. spectrosc. radiat. transfer, 91, 233-244, 2005.    !
@@ -234,12 +261,21 @@
 !       jun 2018,  h-m lin/y-t hou   -- added new option of cloud overlap  !
 !                     method 'de-correlation-length' for mcica application !
 !                                                                          !
+! ************************************************************************ !
+!                                                                          !
+!    additional aer revision history:                                      !
+!       jul 2020,  m.j. iacono   -- added new mcica cloud overlap options  !
+!                     exponential and exponential-random. each method can  !
+!                     use either a constant or a latitude-varying and      !
+!                     day-of-year varying decorrelation length selected    !
+!                     with parameter "idcor".                              !
+!                                                                          !
 !!!!!  ==============================================================  !!!!!
 !!!!!                         end descriptions                         !!!!!
 !!!!!  ==============================================================  !!!!!
 
 !> This module contains the CCPP-compliant NCEP's modifications of the 
-!! rrtm-lw radiation code from aer inc.
+!! rrtmg-lw radiation code from aer inc.
       module rrtmg_lw 
 !
       use physparam,        only : ilwrate, ilwrgas, ilwcliq, ilwcice,  &
@@ -360,7 +396,7 @@
 !! \brief This module includes NCEP's modifications of the RRTMG-LW radiation
 !! code from AER.
 !!
-!! The RRTM-LW package includes three files:
+!! The RRTMG-LW package includes three files:
 !! - radlw_param.f, which contains:
 !!  - module_radlw_parameters: band parameters set up
 !! - radlw_datatb.f, which contains modules:
@@ -389,7 +425,7 @@
      &       gasvmr_ch4, gasvmr_o2, gasvmr_co, gasvmr_cfc11,            &
      &       gasvmr_cfc12, gasvmr_cfc22, gasvmr_ccl4,                   &
      &       icseed,aeraod,aerssa,sfemis,sfgtmp,                        &
-     &       dzlyr,delpin,de_lgth,                                      &
+     &       dzlyr,delpin,de_lgth,alpha,                                &
      &       npts, nlay, nlp1, lprnt, cld_cf, lslwr,                    &
      &       hlwc,topflx,sfcflx,cldtau,                                 &   !  ---  outputs
      &       HLW0,HLWB,FLXPRF,                                          &   !  ---  optional
@@ -444,6 +480,7 @@
 !     dzlyr(npts,nlay) : layer thickness (km)                           !
 !     delpin(npts,nlay): layer pressure thickness (mb)                  !
 !     de_lgth(npts)    : cloud decorrelation length (km)                !
+!     alpha(npts,nlay) : EXP/ER cloud overlap decorrelation parameter   !
 !     npts           : total number of horizontal points                !
 !     nlay, nlp1     : total number of vertical layers, levels          !
 !     lprnt          : cntl flag for diagnostic print out               !
@@ -492,6 +529,8 @@
 !           =1: maximum/random overlapping clouds                       !
 !           =2: maximum overlap cloud (used for isubclw>0 only)         !
 !           =3: decorrelation-length overlap (for isubclw>0 only)       !
+!           =4: exponential cloud overlap (AER)                         !
+!           =5: exponential-random cloud overlap (AER)                  !
 !   ivflip  - control flag for vertical index direction                 !
 !           =0: vertical index from toa to surface                      !
 !           =1: vertical index from surface to toa                      !
@@ -589,6 +628,7 @@
 
       real (kind=kind_phys), dimension(npts), intent(in) :: sfemis,     &
      &       sfgtmp, de_lgth
+      real (kind=kind_phys), dimension(npts,nlay), intent(in) :: alpha
 
       real (kind=kind_phys), dimension(npts,nlay,nbands),intent(in)::   &
      &       aeraod, aerssa
@@ -650,6 +690,7 @@
 
       real (kind=kind_phys) :: tem0, tem1, tem2, pwvcm, summol, stemp,  &
      &                         delgth
+      real (kind=kind_phys), dimension(nlay) :: alph
 
       integer, dimension(npts) :: ipseed
       integer, dimension(nlay) :: jp, jt, jt1, indself, indfor, indminor
@@ -756,6 +797,7 @@
             tavel(k)= tlyr(iplon,k1)
             tz(k)   = tlvl(iplon,k1)
             dz(k)   = dzlyr(iplon,k1)
+            if (iovrlw == 4 .or. iovrlw == 5) alph(k) = alpha(iplon,k) ! alpha decorrelation
 
 !> -# Set absorber amount for h2o, co2, and o3.
 
@@ -868,6 +910,7 @@
             tavel(k)= tlyr(iplon,k)
             tz(k)   = tlvl(iplon,k+1)
             dz(k)   = dzlyr(iplon,k)
+            if (iovrlw == 4 .or. iovrlw == 5) alph(k) = alpha(iplon,k) ! alpha decorrelation
 
 !  --- ...  set absorber amount
 !test use
@@ -1017,7 +1060,7 @@
           call cldprop                                                  &
 !  ---  inputs:
      &     ( cldfrc,clwp,relw,ciwp,reiw,cda1,cda2,cda3,cda4,            &
-     &       nlay, nlp1, ipseed(iplon), dz, delgth,                     &
+     &       nlay, nlp1, ipseed(iplon), dz, delgth, alph,               &
 !  ---  outputs:
      &       cldfmc, taucld                                             &
      &     )
@@ -1344,7 +1387,7 @@
 !
 !===> ... begin here
 !
-      if ( iovrlw<0 .or. iovrlw>3 ) then
+      if ( iovrlw<0 .or. iovrlw>5 ) then
         print *,'  *** Error in specification of cloud overlap flag',   &
      &          ' IOVRLW=',iovrlw,' in RLWINIT !!'
         stop
@@ -1486,13 +1529,14 @@
 !!\param ipseed          permutation seed for generating random numbers (isubclw>0)
 !!\param dz              layer thickness (km) 
 !!\param de_lgth         layer cloud decorrelation length (km)  
+!!\param alpha           EXP/ER cloud overlap decorrelation parameter
 !!\param cldfmc          cloud fraction for each sub-column
 !!\param taucld          cloud optical depth for bands (non-mcica)
 !!\section gen_cldprop cldprop General Algorithm
 !> @{
       subroutine cldprop                                                &
      &     ( cfrac,cliqp,reliq,cicep,reice,cdat1,cdat2,cdat3,cdat4,     & !  ---  inputs
-     &       nlay, nlp1, ipseed, dz, de_lgth,                           &
+     &       nlay, nlp1, ipseed, dz, de_lgth, alpha,                    &
      &       cldfmc, taucld                                             & !  ---  outputs
      &     )
 
@@ -1528,6 +1572,7 @@
 !                                                                       !
 !    dz     - real, layer thickness (km)                           nlay !
 !    de_lgth- real, layer cloud decorrelation length (km)             1 !
+!    alpha  - real, EXP/ER decorrelation parameter                 nlay !
 !    nlay  - integer, number of vertical layers                      1  !
 !    nlp1  - integer, number of vertical levels                      1  !
 !    ipseed- permutation seed for generating random numbers (isubclw>0) !
@@ -1598,6 +1643,7 @@
       real (kind=kind_phys), dimension(nlay),   intent(in) :: cliqp,    &
      &       reliq, cicep, reice, cdat1, cdat2, cdat3, cdat4, dz
       real (kind=kind_phys),                    intent(in) :: de_lgth
+      real (kind=kind_phys), dimension(nlay),   intent(in) :: alpha
 
 !  ---  outputs:
       real (kind=kind_phys), dimension(ngptlw,nlay),intent(out):: cldfmc
@@ -1772,7 +1818,7 @@
 
         call mcica_subcol                                               &
 !  ---  inputs:
-     &     ( cldf, nlay, ipseed, dz, de_lgth,                           &
+     &     ( cldf, nlay, ipseed, dz, de_lgth, alpha,                    &
 !  ---  output:
      &       lcloudy                                                    &
      &     )
@@ -1802,11 +1848,12 @@
 !!\param ipseed      permute seed for random num generator
 !!\param dz          layer thickness
 !!\param de_lgth     layer cloud decorrelation length (km)
+!!\param alpha       EXP/ER cloud overlap decorrelation parameter
 !!\param lcloudy     sub-colum cloud profile flag array
 !!\section mcica_subcol_gen mcica_subcol General Algorithm
 !! @{
       subroutine mcica_subcol                                           &
-     &    ( cldf, nlay, ipseed, dz, de_lgth,                            & !  ---  inputs
+     &    ( cldf, nlay, ipseed, dz, de_lgth, alpha,                     & !  ---  inputs
      &      lcloudy                                                     & !  ---  outputs
      &    )
 
@@ -1821,6 +1868,7 @@
 !              for lw and sw, use values differ by the number of g-pts. !
 !   dz      - real, layer thickness (km)                           nlay !
 !   de_lgth - real, layer cloud decorrelation length (km)            1  !
+!    alpha  - real, EXP/ER decorrelation parameter                 nlay !
 !                                                                       !
 !  output variables:                                                    !
 !   lcloudy - logical, sub-colum cloud profile flag array    ngptlw*nlay!
@@ -1838,6 +1886,7 @@
 
       real (kind=kind_phys), dimension(nlay), intent(in) :: cldf, dz
       real (kind=kind_phys),                  intent(in) :: de_lgth
+      real (kind=kind_phys), dimension(nlay), intent(in) :: alpha
 
 !  ---  outputs:
       logical, dimension(ngptlw,nlay), intent(out) :: lcloudy
@@ -1993,6 +2042,58 @@
             do n = 1, ngptlw
               if ( cdfun2(n,k) <= fac_lcf(k1) ) then
                 cdfunc(n,k) = cdfunc(n,k1)
+              endif
+            enddo
+          enddo
+
+        case( 4:5 )        ! exponential and exponential-random cloud overlap
+
+!  ---  Use previously derived decorrelation parameter, alpha, to specify
+!       the exponenential transition of cloud correlation in the vertical column.
+!
+!       For exponential cloud overlap, the correlation is applied across layers
+!       without regard to the configuration of clear and cloudy layers.
+
+!       For exponential-random cloud overlap, a new exponential transition is 
+!       performed within each group of adjacent cloudy layers and blocks of 
+!       cloudy layers with clear layers between them are correlated randomly. 
+!
+!       NOTE: The code below is identical for case (4) and (5) because the 
+!       distinction in the vertical correlation between EXP and ER is already 
+!       built into the specification of alpha (in subroutine get_alpha). 
+
+!  ---  setup 2 sets of random numbers
+
+          call random_number ( rand2d, stat )
+
+          k1 = 0
+          do k = 1, nlay
+            do n = 1, ngptlw
+              k1 = k1 + 1
+              cdfunc(n,k) = rand2d(k1)
+            enddo
+          enddo
+
+          call random_number ( rand2d, stat )
+
+          k1 = 0
+          do k = 1, nlay
+            do n = 1, ngptlw
+              k1 = k1 + 1
+              cdfun2(n,k) = rand2d(k1)
+            enddo
+          enddo
+
+!  ---  then working upward from the surface:
+!       if a random number (from an independent set: cdfun2) is smaller than 
+!       alpha, then use the previous layer's number, otherwise use a new random
+!       number (keep the originally assigned one in cdfunc for that layer).
+
+          do k = 2, nlay
+            k1 = k - 1
+            do n = 1, ngptlw
+              if ( cdfun2(n,k) < alpha(k) ) then
+                   cdfunc(n,k) = cdfunc(n,k1)
               endif
             enddo
           enddo

--- a/physics/radlw_main.meta
+++ b/physics/radlw_main.meta
@@ -207,6 +207,15 @@
   kind = kind_phys
   intent = in
   optional = F
+[alpha]
+  standard_name = cloud_overlap_decorrelation_parameter
+  long_name = cloud overlap decorrelation parameter
+  units = frac
+  dimensions = (horizontal_dimension,adjusted_vertical_layer_dimension_for_radiation)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
 [npts]
   standard_name = horizontal_loop_extent
   long_name = horizontal dimension

--- a/physics/radsw_main.f
+++ b/physics/radsw_main.f
@@ -6,7 +6,7 @@
 !             sw-rrtm3 radiation package description              !!!!!
 !  ==============================================================  !!!!!
 !                                                                          !
-!   this package includes ncep's modifications of the rrtm-sw radiation    !
+!   this package includes ncep's modifications of the rrtmg-sw radiation   !
 !   code from aer inc.                                                     !
 !                                                                          !
 !   the sw-rrtm3 package includes these parts:                             !
@@ -38,7 +38,7 @@
 !         inputs:                                                          !
 !           (plyr,plvl,tlyr,tlvl,qlyr,olyr,gasvmr,                         !
 !            clouds,icseed,aerosols,sfcalb,                                !
-!            dzlyr,delpin,de_lgth,                                         !
+!            dzlyr,delpin,de_lgth,alpha,                                   !
 !            cosz,solcon,NDAY,idxday,                                      !
 !            npts, nlay, nlp1, lprnt,                                      !
 !         outputs:                                                         !
@@ -104,17 +104,38 @@
 !                                                                          !
 !==========================================================================!
 !                                                                          !
-!   the original program declarations:                                     !
+!   the original aer program declarations:                                 !
 !                                                                          !
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!                                                                          !
-!  Copyright 2002-2007, Atmospheric & Environmental Research, Inc. (AER).  !
-!  This software may be used, copied, or redistributed as long as it is    !
-!  not sold and this copyright notice is reproduced on each copy made.     !
-!  This model is provided as is without any express or implied warranties. !
-!                       (http://www.rtweb.aer.com/)                        !
-!                                                                          !
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!                                                                              !
+! Copyright (c) 2002-2020, Atmospheric & Environmental Research, Inc. (AER)    !
+! All rights reserved.                                                         !
+!                                                                              !
+! Redistribution and use in source and binary forms, with or without           !
+! modification, are permitted provided that the following conditions are met:  !
+!  * Redistributions of source code must retain the above copyright            !
+!    notice, this list of conditions and the following disclaimer.             !
+!  * Redistributions in binary form must reproduce the above copyright         !
+!    notice, this list of conditions and the following disclaimer in the       !
+!    documentation and/or other materials provided with the distribution.      !
+!  * Neither the name of Atmospheric & Environmental Research, Inc., nor       !
+!    the names of its contributors may be used to endorse or promote products  !
+!    derived from this software without specific prior written permission.     !
+!                                                                              !
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"  !
+! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE    !
+! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE   !
+! ARE DISCLAIMED. IN NO EVENT SHALL ATMOSPHERIC & ENVIRONMENTAL RESEARCH, INC.,!
+! BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR       !
+! CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF         !
+! SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS     !
+! INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN      !
+! CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)      !
+! ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF       !
+! THE POSSIBILITY OF SUCH DAMAGE.                                              !
+!                        (http://www.rtweb.aer.com/)                           !
+!                                                                              !
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !                                                                          !
 ! ************************************************************************ !
 !                                                                          !
@@ -144,7 +165,13 @@
 ! ************************************************************************ !
 !                                                                          !
 !    references:                                                           !
-!    (rrtm_sw/rrtmg_sw):                                                   !
+!    (rrtmg_sw/rrtm_sw):                                                   !
+!      iacono, m.j., j.s. delamere, e.j. mlawer, m.w. shepard,             !
+!      s.a. clough, and w.d collins, radiative forcing by long-lived       !
+!      greenhouse gases: calculations with the aer radiative transfer      !
+!      models, j, geophys. res., 113, d13103, doi:10.1029/2008jd009944,    !
+!      2008.                                                               !
+!                                                                          !
 !      clough, s.a., m.w. shephard, e.j. mlawer, j.s. delamere,            !
 !      m.j. iacono, k. cady-pereira, s. boukabara, and p.d. brown:         !
 !      atmospheric radiative transfer modeling: a summary of the aer       !
@@ -189,7 +216,7 @@
 !                                                                          !
 !   ncep modifications history log:                                        !
 !                                                                          !
-!       sep 2003,  yu-tai hou        -- received aer's rrtm-sw gcm version !
+!       sep 2003,  yu-tai hou        -- received aer's rrtmg-sw gcm version!
 !                    code (v224)                                           !
 !       nov 2003,  yu-tai hou        -- corrected errors in direct/diffuse !
 !                    surface alabedo components.                           !
@@ -260,12 +287,21 @@
 !                      scheme. (used if iswcliq=2); added new option of    !
 !                      cloud overlap method 'de-correlation-length'.       !
 !                                                                          !
+! ************************************************************************ !
+!                                                                          !
+!    additional aer revision history:                                      !
+!       jul 2020,  m.j. iacono   -- added new mcica cloud overlap options  !
+!                     exponential and exponential-random. each method can  !
+!                     use either a constant or a latitude-varying and      !
+!                     day-of-year varying decorrelation length selected    !
+!                     with parameter "idcor".                              !
+!                                                                          !
 !!!!!  ==============================================================  !!!!!
 !!!!!                         end descriptions                         !!!!!
 !!!!!  ==============================================================  !!!!!
 
-!> This module contains the CCPP-compliant NCEP's modifications of the rrtm-sw radiation 
-!! code from aer inc.     
+!> This module contains the CCPP-compliant NCEP's modifications of the 
+!! rrtmg-sw radiation code from aer inc.     
       module rrtmg_sw 
 !
       use physparam,        only : iswrate, iswrgas, iswcliq, iswcice,  &
@@ -422,7 +458,7 @@
 !! |  29  |      820-2600    |H2O             |CO2               |CO2              |H2O                |
 !!\tableofcontents
 !!
-!! The RRTM-SW package includes three files:
+!! The RRTMG-SW package includes three files:
 !! - radsw_param.f, which contains:
 !!  - module_radsw_parameters: specifies major parameters of the spectral
 !!    bands and defines the construct structures of derived-type variables
@@ -467,7 +503,7 @@
      &       icseed, aeraod, aerssa, aerasy,                            &
      &       sfcalb_nir_dir, sfcalb_nir_dif,                            &
      &       sfcalb_uvis_dir, sfcalb_uvis_dif,                          &
-     &       dzlyr,delpin,de_lgth,                                      &
+     &       dzlyr,delpin,de_lgth,alpha,                                &
      &       cosz,solcon,NDAY,idxday,                                   &
      &       npts, nlay, nlp1, lprnt,                                   &
      &       cld_cf, lsswr,                                             &
@@ -528,6 +564,7 @@
 !   dzlyr(npts,nlay) : layer thickness in km                            !
 !   delpin(npts,nlay): layer pressure thickness (mb)                    !
 !   de_lgth(npts)    : clouds decorrelation length (km)                 !
+!   alpha(npts,nlay) : EXP/ER cloud overlap decorrelation parameter     !
 !   cosz  (npts)     : cosine of solar zenith angle                     !
 !   solcon           : solar constant                      (w/m**2)     !
 !   NDAY             : num of daytime points                            !
@@ -595,6 +632,8 @@
 !           =1: maximum/random overlapping clouds                       !
 !           =2: maximum overlap cloud                                   !
 !           =3: decorrelation-length overlap clouds                     !
+!           =4: exponential cloud overlap (AER)                         !
+!           =5: exponential-random cloud overlap (AER)                  !
 !   ivflip  - control flg for direction of vertical index               !
 !           =0: index from toa to surface                               !
 !           =1: index from surface to toa                               !
@@ -691,6 +730,7 @@
 
       real (kind=kind_phys), intent(in) :: cosz(npts), solcon,          &
      &       de_lgth(npts)
+      real (kind=kind_phys), dimension(npts,nlay), intent(in) :: alpha
 
 !  ---  outputs:
       real (kind=kind_phys), dimension(npts,nlay), intent(inout) :: hswc
@@ -740,6 +780,7 @@
       real (kind=kind_phys) :: cosz1, sntz1, tem0, tem1, tem2, s0fac,   &
      &       ssolar, zcf0, zcf1, ftoau0, ftoauc, ftoadc,                &
      &       fsfcu0, fsfcuc, fsfcd0, fsfcdc, suvbfc, suvbf0, delgth
+      real (kind=kind_phys), dimension(nlay) :: alph
 
 !  ---  column amount of absorbing gases:
 !       (:,m) m = 1-h2o, 2-co2, 3-o3, 4-n2o, 5-ch4, 6-o2, 7-co
@@ -869,6 +910,8 @@
             tavel(k) = tlyr(j1,kk)
             delp (k) = delpin(j1,kk)
             dz   (k) = dzlyr (j1,kk)
+            if (iovrsw == 4 .or. iovrsw == 5) alph(k) = alpha(j1,k) ! alpha decorrelation
+
 !> -# Set absorber and gas column amount, convert from volume mixing
 !!    ratio to molec/cm2 based on coldry (scaled to 1.0e-20)
 !!    - colamt(nlay,maxgas):column amounts of absorbing gases 1 to
@@ -958,6 +1001,7 @@
             tavel(k) = tlyr(j1,k)
             delp (k) = delpin(j1,k)
             dz   (k) = dzlyr (j1,k)
+            if (iovrsw == 4 .or. iovrsw == 5) alph(k) = alpha(j1,k)   ! alpha decorrelation
 
 !  --- ...  set absorber amount
 !test use
@@ -1080,7 +1124,7 @@
           call cldprop                                                  &
 !  ---  inputs:
      &     ( cfrac,cliqp,reliq,cicep,reice,cdat1,cdat2,cdat3,cdat4,     &
-     &       zcf1, nlay, ipseed(j1), dz, delgth,                        &
+     &       zcf1, nlay, ipseed(j1), dz, delgth, alph,                  &
 !  ---  outputs:
      &       taucw, ssacw, asycw, cldfrc, cldfmc                        &
      &     )
@@ -1409,7 +1453,7 @@
 !
 !===> ... begin here
 !
-      if ( iovrsw<0 .or. iovrsw>3 ) then
+      if ( iovrsw<0 .or. iovrsw>5 ) then
         print *,'  *** Error in specification of cloud overlap flag',   &
      &          ' IOVRSW=',iovrsw,' in RSWINIT !!'
         stop
@@ -1530,6 +1574,7 @@
 !!                      (isubcsw>0)
 !!\param dz             layer thickness (km)
 !!\param delgth         layer cloud decorrelation length (km)
+!!\param alpha          EXP/ER cloud overlap decorrelation parameter
 !!\param taucw          cloud optical depth, w/o delta scaled
 !!\param ssacw          weighted cloud single scattering albedo
 !!                      (ssa = ssacw / taucw)
@@ -1542,7 +1587,7 @@
 !-----------------------------------
       subroutine cldprop                                                &
      &     ( cfrac,cliqp,reliq,cicep,reice,cdat1,cdat2,cdat3,cdat4,     &   !  ---  inputs
-     &       cf1, nlay, ipseed, dz, delgth,                             &
+     &       cf1, nlay, ipseed, dz, delgth, alpha,                      &
      &       taucw, ssacw, asycw, cldfrc, cldfmc                        &   !  ---  output
      &     )
 
@@ -1581,6 +1626,7 @@
 !    ipseed- permutation seed for generating random numbers (isubcsw>0) !
 !    dz    - real, layer thickness (km)                            nlay !
 !    delgth- real, layer cloud decorrelation length (km)            1   !
+!    alpha - real, EXP/ER decorrelation parameter                  nlay !
 !                                                                       !
 !  outputs:                                                             !
 !    taucw  - real, cloud optical depth, w/o delta scaled    nlay*nbdsw !
@@ -1633,6 +1679,7 @@
 
       real (kind=kind_phys), dimension(nlay), intent(in) :: cliqp,      &
      &       reliq, cicep, reice, cdat1, cdat2, cdat3, cdat4, cfrac, dz
+      real (kind=kind_phys), dimension(nlay), intent(in) :: alpha
 
 !  ---  outputs:
       real (kind=kind_phys), dimension(nlay,ngptsw), intent(out) ::     &
@@ -1885,7 +1932,7 @@
 
         call mcica_subcol                                               &
 !  ---  inputs:
-     &     ( cldf, nlay, ipseed, dz, delgth,                            &
+     &     ( cldf, nlay, ipseed, dz, delgth, alpha,                     &
 !  ---  outputs:
      &       lcloudy                                                    &
      &     )
@@ -1920,12 +1967,13 @@
 !!\param ipseed      permute seed for random num generator
 !!\param dz          layer thickness (km)
 !!\param de_lgth     layer cloud decorrelation length (km)
+!!\param alpha       EXP/ER cloud overlap decorrelation parameter
 !!\param lcloudy     sub-colum cloud profile flag array
 !!\section mcica_sw_gen mcica_subcol General Algorithm
 !> @{
 ! ----------------------------------
       subroutine mcica_subcol                                           &
-     &    ( cldf, nlay, ipseed, dz, de_lgth,                            &       !  ---  inputs
+     &    ( cldf, nlay, ipseed, dz, de_lgth, alpha,                     &       !  ---  inputs
      &      lcloudy                                                     &       !  ---  outputs
      &    )
 
@@ -1940,6 +1988,7 @@
 !              for lw and sw, use values differ by the number of g-pts. !
 !    dz    - real, layer thickness (km)                            nlay !
 !    de_lgth-real, layer cloud decorrelation length (km)            1   !
+!    alpha  - real, EXP/ER decorrelation parameter                 nlay !
 !                                                                       !
 !  output variables:                                                    !
 !   lcloudy - logical, sub-colum cloud profile flag array    nlay*ngptsw!
@@ -1950,6 +1999,8 @@
 !                 =1: maximum/random overlapping clouds                 !
 !                 =2: maximum overlap cloud                             !
 !                 =3: cloud decorrelation-length overlap method         !
+!                 =4: exponential cloud overlap method (AER)            !
+!                 =5: exponential-random cloud overlap method (AER)     !
 !                                                                       !
 !  =====================    end of definitions    ====================  !
 
@@ -1960,6 +2011,7 @@
 
       real (kind=kind_phys), dimension(nlay), intent(in) :: cldf, dz
       real (kind=kind_phys), intent(in) :: de_lgth
+      real (kind=kind_phys), dimension(nlay), intent(in) :: alpha
 
 !  ---  outputs:
       logical, dimension(nlay,ngptsw), intent(out):: lcloudy
@@ -2110,6 +2162,58 @@
             do k = nlay-1, 1, -1
               k1 = k + 1
               if ( cdfun2(k,n) <= fac_lcf(k1) ) then
+                   cdfunc(k,n) = cdfunc(k1,n)
+              endif
+            enddo
+          enddo
+
+        case( 4:5 )        ! exponential and exponential-random cloud overlap
+
+!  ---  Use previously derived decorrelation parameter, alpha, to specify
+!       the exponenential transition of cloud correlation in the vertical column.
+!
+!       For exponential cloud overlap, the correlation is applied across layers
+!       without regard to the configuration of clear and cloudy layers.
+
+!       For exponential-random cloud overlap, a new exponential transition is 
+!       performed within each group of adjacent cloudy layers and blocks of 
+!       cloudy layers with clear layers between them are correlated randomly. 
+!
+!       NOTE: The code below is identical for case (4) and (5) because the 
+!       distinction in the vertical correlation between EXP and ER is already 
+!       built into the specification of alpha (in subroutine get_alpha). 
+
+!  ---  setup 2 sets of random numbers
+
+          call random_number ( rand2d, stat )
+
+          k1 = 0
+          do n = 1, ngptsw
+            do k = 1, nlay
+              k1 = k1 + 1
+              cdfunc(k,n) = rand2d(k1)
+            enddo
+          enddo
+
+          call random_number ( rand2d, stat )
+
+          k1 = 0
+          do n = 1, ngptsw
+            do k = 1, nlay
+              k1 = k1 + 1
+              cdfun2(k,n) = rand2d(k1)
+            enddo
+          enddo
+
+!  ---  then working upward from the surface:
+!       if a random number (from an independent set: cdfun2) is smaller than 
+!       alpha, then use the previous layer's number, otherwise use a new random
+!       number (keep the originally assigned one in cdfunc for that layer).
+
+          do n = 1, ngptsw
+            do k = 2, nlay
+              k1 = k - 1
+              if ( cdfun2(k,n) < alpha(k) ) then
                    cdfunc(k,n) = cdfunc(k1,n)
               endif
             enddo

--- a/physics/radsw_main.meta
+++ b/physics/radsw_main.meta
@@ -234,6 +234,15 @@
   kind = kind_phys
   intent = in
   optional = F
+[alpha]
+  standard_name = cloud_overlap_decorrelation_parameter
+  long_name = cloud overlap decorrelation parameter
+  units = frac
+  dimensions = (horizontal_dimension,adjusted_vertical_layer_dimension_for_radiation)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
 [cosz]
   standard_name = cosine_of_zenith_angle
   long_name = cosine of the solar zenit angle


### PR DESCRIPTION
The RRTMG cloud overlap updates add two new cloud overlap methods, exponential and exponential-random, which are selected using the existing iovr_lw and iovr_sw control parameter (4=EXP; 5=ER). Each method requires the calculation of the vertical decorrelation parameter, alpha, which is done through calls to a new subroutine, get_alpha, which resides in radiation_clouds.f. In addition, alpha requires the specification of a decorrelation length, and two ways have been provided to define this quantity, either as a constant or as a latitude-varying and day-of-year varying quantity. The decorrelation length method is selected through the new control parameter, idcor, which is set in physparam.f. If required (when idcor=0), the constant decorrelation length is defined through the new parameter decorr_con (in units of km) in physcons.F90.  

- Source file GFS_rrtmg_pre.F90 was modified to specify the distance between model layers that is required for defining alpha, which is done with the progcld* subroutines.  
- Source files physcons.F90 and physparam.f were changes as described above. 
- Source file radiation_clouds.f was modified to change each of the progcld* subroutines to call get_alpha prior to the calls to gethml. The latter was changed to generate the high, middle and low cloud diagnostic for the EXP and ER overlap methods.  The decision was made to create the new get_alpha subroutine and to call it prior to the radiation in order to facilitate future expansion should more sophisticated methods for defining the decorrelation length and alpha prove beneficial in future research. The alpha parameter is output from GFS_typedefs.F90 and passed to the RRTMG radiation. - Source files radlw_main.f and radsw_main.f were modified to allow use of EXP and ER (and the required alpha) within the sub-column generator that defines the sub-grid cloud properties for the radiative transfer calculations. 
- The .meta files associated with the affected source files were also modified to allow proper generation of the related CAP files. 