### PR TITLE
Diagnostic instantaneous 3D cloud fractions added.

### DIFF
--- a/physics/GFS_rrtmg_pre.F90
+++ b/physics/GFS_rrtmg_pre.F90
@@ -32,7 +32,7 @@
           faersw1,  faersw2,  faersw3,                               &
           faerlw1, faerlw2, faerlw3, aerodp,                         &
           clouds1, clouds2, clouds3, clouds4, clouds5, clouds6,      &
-          clouds7, clouds8, clouds9, cldsa,                          &
+          clouds7, clouds8, clouds9, cldsa, cldfra,                  &
           mtopa, mbota, de_lgth, alb1d, errmsg, errflg)
 
       use machine,                   only: kind_phys
@@ -142,6 +142,7 @@
       real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+LTP),   intent(out) :: clouds7
       real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+LTP),   intent(out) :: clouds8
       real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+LTP),   intent(out) :: clouds9
+      real(kind=kind_phys), dimension(size(Grid%xlon,1),Model%levr+LTP),   intent(out) :: cldfra
       real(kind=kind_phys), dimension(size(Grid%xlon,1),5),                intent(out) :: cldsa
       integer,              dimension(size(Grid%xlon,1),3),                intent(out) :: mbota
       integer,              dimension(size(Grid%xlon,1),3),                intent(out) :: mtopa
@@ -930,6 +931,7 @@
             clouds7(i,k)  = clouds(i,k,7)
             clouds8(i,k)  = clouds(i,k,8)
             clouds9(i,k)  = clouds(i,k,9)
+            cldfra(i,k)   = clouds(i,k,1)
          enddo
        enddo
 

--- a/physics/GFS_rrtmg_pre.meta
+++ b/physics/GFS_rrtmg_pre.meta
@@ -529,6 +529,15 @@
   kind = kind_phys
   intent = out
   optional = F
+[cldfra]
+  standard_name = instantaneous_3d_cloud_fraction
+  long_name = instantaneous 3D cloud fraction for all MPs
+  units = frac
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = out
+  optional = F
 [mtopa]
   standard_name = model_layer_number_at_cloud_top
   long_name = vertical indices for low, middle and high cloud tops


### PR DESCRIPTION
## Description

(Instructions: this, and all subsequent sections of text should be removed and filled in as appropriate.)
Diagnostic cldfra array outputs 3D instantaneous cloud fractions.  Works with WSM6, Thompson and GFDL mp schemes.  No results changed.

UPDATE: Provided a bug fix to GFS_restart.F90 with an if condition added in the ifdef CCPP block to test for reflectivity flag. RTs have been updated. Test run in 3-km FV3 LAM was successful and plots looked good.

### Issue(s) addressed

https://github.com/ufs-community/ufs-weather-model/issues/158
https://github.com/NOAA-EMC/fv3atm/pull/154
https://github.com/NCAR/ccpp-physics/pull/484

## Testing

How were these changes tested?  
Tested on hera with the SAR configuration.  Evaluated fields from run with Thompson microphyics and GFDL microphysics. 
Full RTs performed on hera.

## Dependencies
FV3
ccpp/physics