### PR TITLE
release/public-v4: fix unicode errors

### DIFF
--- a/.github/workflows/basic_checks.yml
+++ b/.github/workflows/basic_checks.yml
@@ -1,0 +1,33 @@
+name: Basic checks for CCPP physics schemes
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Init submodules
+      run: git submodule update --init --recursive
+    #- name: Update packages
+    #  run: |
+    #    /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    #    #brew install autoconf automake coreutils gcc@9 libtool mpich gnu-sed wget
+    #    brew install automake coreutils mpich gnu-sed
+    - name: Check for ASCII encoding
+      run: ./tools/check_encoding.py
+      #run: |
+        #export CC=gcc-9
+        #export FC=gfortran-9
+        #export CXX=g++-9
+        #mkdir build
+        #cd build
+        #cmake -DCMAKE_INSTALL_PREFIX=$PWD/../install .. 2>&1 | tee log.cmake
+        #make -j8 2>&1 | tee log.make
+        #cd ..
+        #ls -l install/bin/ESMF_Info
+        #ls -l install/bin/wgrib2
+        #cat install/share/nceplibs-external.cmake.config

--- a/physics/cires_ugwp.F90
+++ b/physics/cires_ugwp.F90
@@ -6,8 +6,8 @@
 !! "Unified": a) all GW effects due to both dissipation/breaking; b) identical GW solvers for all GW sources; c) ability to replace solvers.
 !! Unified Formalism:
 !! 1. GW Sources: Stochastic and physics based mechanisms for GW-excitations in the lower atmosphere, calibrated by the high-res analyses/forecasts, and observations (3 types of GW sources: orography, convection, fronts/jets).
-!! 2. GW Propagation: Unified solver for “propagation, dissipation and breaking” excited from all type of GW sources.
-!! 3. GW Effects: Unified representation of GW impacts on the ‘resolved’ flow for all sources (energy-balanced schemes for momentum, heat and mixing).
+!! 2. GW Propagation: Unified solver for "propagation, dissipation and breaking" excited from all type of GW sources.
+!! 3. GW Effects: Unified representation of GW impacts on the "resolved" flow for all sources (energy-balanced schemes for momentum, heat and mixing).
 !! https://www.weather.gov/media/sti/nggps/Presentations%202017/02%20NGGPS_VYUDIN_2017_.pdf
 
 module cires_ugwp

--- a/physics/drag_suite.F90
+++ b/physics/drag_suite.F90
@@ -90,7 +90,7 @@
 !! the GWD scheme has the same physical basis as in Alpert (1987) with the addition
 !! of enhancement factors for the amplitude, G, and mountain shape details
 !! in G(Fr) to account for effects from the mountain blocking.  A factor,
-!! E m’, is an enhancement factor on the stress in the Alpert '87 scheme.
+!! E m', is an enhancement factor on the stress in the Alpert '87 scheme.
 !!  The E ranges from no enhancement to an upper limit of 3, E=E(OA)[1-3],
 !!  and is a function of OA, the Orographic Asymmetry defined in KA (1995) as
 !!
@@ -105,9 +105,9 @@
 !!
 !!
 !! where Nx is the number of grid intervals for the large scale domain being
-!! considered. So the term, E(OA)m’/  \f$ \Delta X \f$ in Kim's scheme represents
-!! a multiplier on G shown in Alpert's eq (1), where m’ is the number of mountains
-!! in a sub-grid scale box. Kim increased the complexity of m’ making it a
+!! considered. So the term, E(OA)m'/  \f$ \Delta X \f$ in Kim's scheme represents
+!! a multiplier on G shown in Alpert's eq (1), where m' is the number of mountains
+!! in a sub-grid scale box. Kim increased the complexity of m' making it a
 !! function of the fractional area of the sub-grid mountain and the asymmetry
 !! and convexity statistics which are found from running a gravity wave
 !!  model for a large number of cases:

--- a/physics/gwdps.f
+++ b/physics/gwdps.f
@@ -87,7 +87,7 @@
 !! the GWD scheme has the same physical basis as in Alpert (1987) with the addition
 !! of enhancement factors for the amplitude, G, and mountain shape details
 !! in G(Fr) to account for effects from the mountain blocking.  A factor,
-!! E m’, is an enhancement factor on the stress in the Alpert '87 scheme.
+!! E m', is an enhancement factor on the stress in the Alpert '87 scheme.
 !!  The E ranges from no enhancement to an upper limit of 3, E=E(OA)[1-3],
 !!  and is a function of OA, the Orographic Asymmetry defined in Kim and Arakawa (1995) 
 !! \cite kim_and_arakawa_1995 as
@@ -103,9 +103,9 @@
 !! \; (x_{j} \; - \; \bar{x} )^2}{N_{x}} } 
 !!\f]
 !! where \f$N_{x}\f$ is the number of grid intervals for the large scale domain being
-!! considered. So the term, E(OA)m’/  \f$ \Delta X \f$ in Kim's scheme represents
-!! a multiplier on G shown in Alpert's eq (1), where m’ is the number of mountains
-!! in a sub-grid scale box. Kim increased the complexity of m’ making it a
+!! considered. So the term, E(OA)m'/  \f$ \Delta X \f$ in Kim's scheme represents
+!! a multiplier on G shown in Alpert's eq (1), where m' is the number of mountains
+!! in a sub-grid scale box. Kim increased the complexity of m' making it a
 !! function of the fractional area of the sub-grid mountain and the asymmetry
 !! and convexity statistics which are found from running a gravity wave
 !!  model for a large number of cases:

--- a/physics/micro_mg_utils.F90
+++ b/physics/micro_mg_utils.F90
@@ -2656,7 +2656,7 @@ end subroutine graupel_rime_splintering
 !      prdg(i) = epsg*(q(i)-qvi(i))/abi
 !
 !! make sure not pushed into ice supersat/subsat
-!! put this in main mg3 code…..check for it…
+!! put this in main mg3 code ... check for it ...
 !! formula from reisner 2 scheme
 
 !!

--- a/physics/samfdeepcnv.f
+++ b/physics/samfdeepcnv.f
@@ -63,7 +63,7 @@
 !!        + 2) For the "dynamic control", using a reference cloud work function, estimate the change in cloud work function due to the large-scale dynamics. Following the quasi-equilibrium assumption, calculate the cloud base mass flux required to keep the large-scale convective destabilization in balance with the stabilization effect of the convection.
 !!  -# For grid sizes smaller than the threshold value (currently 8 km):
 !!        + 1) compute the cloud base mass flux using the cumulus updraft velocity averaged ove the whole cloud depth.
-!!  -# For scale awareness, the updraft fraction (sigma) is obtained as a function of cloud base entrainment. Then, the final cloud base mass flux is obtained by the original mass flux multiplied by the (1−sigma) 2  .
+!!  -# For scale awareness, the updraft fraction (sigma) is obtained as a function of cloud base entrainment. Then, the final cloud base mass flux is obtained by the original mass flux multiplied by the (1-sigma) 2.
 !!  -# For the "feedback control", calculate updated values of the state variables by multiplying the cloud base mass flux and the tendencies calculated per unit cloud base mass flux from the static control.
 !!
 !!  \section samfdeep_detailed GFS samfdeepcnv Detailed Algorithm

--- a/physics/ugwp_driver_v0.F
+++ b/physics/ugwp_driver_v0.F
@@ -267,7 +267,7 @@
 !! subgrid-scale orography effects in FV3GFS, EMC reinstalled the 
 !! original gwdps-code with updated efficiency factors for the mountain
 !! blocking and OGW drag. The GFS OGW is described in the separate section 
-!! (\ref gfs_gwdps) and its “call” moved into UGWP-driver subroutine.
+!! (\ref gfs_gwdps) and its "call" moved into UGWP-driver subroutine.
 !! This combination of NGW and OGW schemes was tested in the FV3GFS-L127
 !! medium-range forecasts (15-30 days) for C96, C192, C384 and C768 
 !! resolutions and work in progress to introduce the optimal choice for

--- a/tools/check_encoding.py
+++ b/tools/check_encoding.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+#import chardet
+import os
+import sys
+
+
+SUFFICES = [ '.f', '.F', '.f90', '.F90', '.meta' ]
+
+for root, dirs, files in os.walk(os.getcwd()):
+    print root, dirs, files
+    for file in files:
+        suffix = os.path.splitext(file)[1]
+        print file, suffix
+        if suffix in SUFFICES:
+            with open(os.path.join(root, file)) as f:
+                contents = f.read()
+            try:
+                contents.decode('ascii')
+            except UnicodeDecodeError:
+                for line in contents.split('\n'):
+                    try:
+                        line.decode('ascii')
+                    except UnicodeDecodeError:
+                        raise Exception('Detected non-ascii characters in file {}, line: "{}"'.format(os.path.join(root, file), line))


### PR DESCRIPTION
## Description

This PR brings in changes that went into master and that fix and prevent future unicode errors in the inline documentation. Without these changes, some systems using Python 3 abort during the `ccpp_prebuild.py` call.

Note that we will need to retag ccpp-physics v4.1.0 after this PR is merged.

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/499
https://github.com/NOAA-EMC/fv3atm/pull/172
https://github.com/ufs-community/ufs-weather-model/pull/204

## Testing

See https://github.com/ufs-community/ufs-weather-model/pull/204