### PR TITLE
release/public-v5: update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "physics/rte-rrtmgp"]
 	path = physics/rte-rrtmgp
-	url = https://github.com/RobertPincus/rte-rrtmgp
-	branch = dtc/ccpp
+	url = https://github.com/earth-system-radiation/rte-rrtmgp
+	branch = release/public-v5


### PR DESCRIPTION
Update .gitmodules to point to release/public-v5 branch of physics/rte-rrtmgp; update URL for physics/rte-rrtmgp.

Associated PRs:

https://github.com/NOAA-EMC/NEMS/pull/80
https://github.com/NCAR/ccpp-framework/pull/324
https://github.com/NCAR/ccpp-physics/pull/500
https://github.com/NOAA-EMC/fv3atm/pull/173
https://github.com/ufs-community/ufs-weather-model/pull/205

For regression testing information, see https://github.com/ufs-community/ufs-weather-model/pull/205