### PR TITLE
feature/transition-to-capgen-1: remove DDT dependency in radiation physics, correct units

### DIFF
--- a/physics/GFS_DCNV_generic.meta
+++ b/physics/GFS_DCNV_generic.meta
@@ -445,7 +445,7 @@
 [upd_mf]
   standard_name = cumulative_atmosphere_updraft_convective_mass_flux
   long_name = cumulative updraft mass flux
-  units = Pa
+  units = kg m-1 s-2
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
@@ -454,7 +454,7 @@
 [dwn_mf]
   standard_name = cumulative_atmosphere_downdraft_convective_mass_flux
   long_name = cumulative downdraft mass flux
-  units = Pa
+  units = kg m-1 s-2 
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
@@ -463,7 +463,7 @@
 [det_mf]
   standard_name = cumulative_atmosphere_detrainment_convective_mass_flux
   long_name = cumulative detrainment mass flux
-  units = Pa
+  units = kg m-1 s-2
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys

--- a/physics/GFS_rrtmg_post.F90
+++ b/physics/GFS_rrtmg_post.F90
@@ -11,43 +11,44 @@
 !> \section arg_table_GFS_rrtmg_post_run Argument Table
 !! \htmlinclude GFS_rrtmg_post_run.html
 !!
-      subroutine GFS_rrtmg_post_run (Model, Grid, Diag, Radtend, Statein, &
-              Coupling, scmpsw, im, lm, ltp, kt, kb, kd, raddt, aerodp,   &
-              cldsa, mtopa, mbota, clouds1, cldtaulw, cldtausw, nday,     &
-              errmsg, errflg)
+      subroutine GFS_rrtmg_post_run (im, km, kmp1, lm, ltp, kt, kb, kd, nspc1, &
+              nfxr, nday, lsswr, lslwr, lssav, fhlwr, fhswr, raddt, coszen,    &
+              coszdg, prsi, tgrs, aerodp, cldsa, mtopa, mbota, clouds1,        &
+              cldtaulw, cldtausw, sfcflw, sfcfsw, topflw, topfsw, scmpsw,      &
+              fluxr, errmsg, errflg)
 
       use machine,                             only: kind_phys
-      use GFS_typedefs,                        only: GFS_statein_type,   &
-                                                     GFS_coupling_type,  &
-                                                     GFS_control_type,   &
-                                                     GFS_grid_type,      &
-                                                     GFS_radtend_type,   &
-                                                     GFS_diag_type
-      use module_radiation_aerosols,           only: NSPC1
-      use module_radsw_parameters,             only: cmpfsw_type
+      use module_radsw_parameters,             only: topfsw_type, sfcfsw_type, &
+                                                     cmpfsw_type
       use module_radlw_parameters,             only: topflw_type, sfcflw_type
-      use module_radsw_parameters,             only: topfsw_type, sfcfsw_type
 
       implicit none
 
       ! Interface variables
-      type(GFS_control_type),              intent(in)    :: Model
-      type(GFS_grid_type),                 intent(in)    :: Grid
-      type(GFS_statein_type),              intent(in)    :: Statein
-      type(GFS_coupling_type),             intent(inout) :: Coupling
-      type(GFS_radtend_type),              intent(in)    :: Radtend
-      type(GFS_diag_type),                 intent(inout) :: Diag
-      type(cmpfsw_type), dimension(size(Grid%xlon,1)), intent(in) :: scmpsw
-
-      integer,              intent(in) :: im, lm, ltp, kt, kb, kd, nday
-      real(kind=kind_phys), intent(in) :: raddt
-
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),NSPC1),  intent(in) :: aerodp
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),5),      intent(in) :: cldsa
-      integer,              dimension(size(Grid%xlon,1),3),      intent(in) :: mbota, mtopa
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP), intent(in) :: clouds1
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP), intent(in) :: cldtausw
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP), intent(in) :: cldtaulw
+      integer,              intent(in) :: im, km, kmp1, lm, ltp, kt, kb, kd,   &
+                                          nspc1, nfxr, nday
+      logical,              intent(in) :: lsswr, lslwr, lssav
+      real(kind=kind_phys), intent(in) :: raddt, fhlwr, fhswr
+            
+      real(kind=kind_phys), dimension(im),        intent(in) :: coszen, coszdg
+      
+      real(kind=kind_phys), dimension(im,kmp1),   intent(in) :: prsi
+      real(kind=kind_phys), dimension(im,km),     intent(in) :: tgrs
+      
+      real(kind=kind_phys), dimension(im,NSPC1),  intent(in) :: aerodp
+      real(kind=kind_phys), dimension(im,5),      intent(in) :: cldsa
+      integer,              dimension(im,3),      intent(in) :: mbota, mtopa
+      real(kind=kind_phys), dimension(im,lm+LTP), intent(in) :: clouds1
+      real(kind=kind_phys), dimension(im,lm+LTP), intent(in) :: cldtausw
+      real(kind=kind_phys), dimension(im,lm+LTP), intent(in) :: cldtaulw
+      
+      type(sfcflw_type), dimension(im), intent(in) :: sfcflw
+      type(sfcfsw_type), dimension(im), intent(in) :: sfcfsw
+      type(cmpfsw_type), dimension(im), intent(in) :: scmpsw
+      type(topflw_type), dimension(im), intent(in) :: topflw
+      type(topfsw_type), dimension(im), intent(in) :: topfsw
+      
+      real(kind=kind_phys), dimension(im,nfxr), intent(inout) :: fluxr
 
       character(len=*), intent(out) :: errmsg
       integer, intent(out) :: errflg
@@ -60,7 +61,7 @@
       errmsg = ''
       errflg = 0
 
-      if (.not. (Model%lsswr .or. Model%lslwr)) return
+      if (.not. (lsswr .or. lslwr)) return
 
 !>  - For time averaged output quantities (including total-sky and
 !!    clear-sky SW and LW fluxes at TOA and surface; conventional
@@ -70,77 +71,77 @@
 
 !  --- ...  collect the fluxr data for wrtsfc
 
-      if (Model%lssav) then
-        if (Model%lsswr) then
+      if (lssav) then
+        if (lsswr) then
           do i=1,im
-!            Diag%fluxr(i,34) = Diag%fluxr(i,34) + Model%fhswr*aerodp(i,1)  ! total aod at 550nm
-!            Diag%fluxr(i,35) = Diag%fluxr(i,35) + Model%fhswr*aerodp(i,2)  ! DU aod at 550nm
-!            Diag%fluxr(i,36) = Diag%fluxr(i,36) + Model%fhswr*aerodp(i,3)  ! BC aod at 550nm
-!            Diag%fluxr(i,37) = Diag%fluxr(i,37) + Model%fhswr*aerodp(i,4)  ! OC aod at 550nm
-!            Diag%fluxr(i,38) = Diag%fluxr(i,38) + Model%fhswr*aerodp(i,5)  ! SU aod at 550nm
-!            Diag%fluxr(i,39) = Diag%fluxr(i,39) + Model%fhswr*aerodp(i,6)  ! SS aod at 550nm
-             Diag%fluxr(i,34) = aerodp(i,1)  ! total aod at 550nm
-             Diag%fluxr(i,35) = aerodp(i,2)  ! DU aod at 550nm
-             Diag%fluxr(i,36) = aerodp(i,3)  ! BC aod at 550nm
-             Diag%fluxr(i,37) = aerodp(i,4)  ! OC aod at 550nm
-             Diag%fluxr(i,38) = aerodp(i,5)  ! SU aod at 550nm
-             Diag%fluxr(i,39) = aerodp(i,6)  ! SS aod at 550nm
+!            fluxr(i,34) = fluxr(i,34) + fhswr*aerodp(i,1)  ! total aod at 550nm
+!            fluxr(i,35) = fluxr(i,35) + fhswr*aerodp(i,2)  ! DU aod at 550nm
+!            fluxr(i,36) = fluxr(i,36) + fhswr*aerodp(i,3)  ! BC aod at 550nm
+!            fluxr(i,37) = fluxr(i,37) + fhswr*aerodp(i,4)  ! OC aod at 550nm
+!            fluxr(i,38) = fluxr(i,38) + fhswr*aerodp(i,5)  ! SU aod at 550nm
+!            fluxr(i,39) = fluxr(i,39) + fhswr*aerodp(i,6)  ! SS aod at 550nm
+             fluxr(i,34) = aerodp(i,1)  ! total aod at 550nm
+             fluxr(i,35) = aerodp(i,2)  ! DU aod at 550nm
+             fluxr(i,36) = aerodp(i,3)  ! BC aod at 550nm
+             fluxr(i,37) = aerodp(i,4)  ! OC aod at 550nm
+             fluxr(i,38) = aerodp(i,5)  ! SU aod at 550nm
+             fluxr(i,39) = aerodp(i,6)  ! SS aod at 550nm
           enddo
         endif
 
 !  ---  save lw toa and sfc fluxes
-        if (Model%lslwr) then
+        if (lslwr) then
           do i=1,im
 !  ---  lw total-sky fluxes
-            Diag%fluxr(i,1 ) = Diag%fluxr(i,1 ) + Model%fhlwr *    Diag%topflw(i)%upfxc   ! total sky top lw up
-            Diag%fluxr(i,19) = Diag%fluxr(i,19) + Model%fhlwr * Radtend%sfcflw(i)%dnfxc   ! total sky sfc lw dn
-            Diag%fluxr(i,20) = Diag%fluxr(i,20) + Model%fhlwr * Radtend%sfcflw(i)%upfxc   ! total sky sfc lw up
+            fluxr(i,1 ) = fluxr(i,1 ) + fhlwr * topflw(i)%upfxc   ! total sky top lw up
+            fluxr(i,19) = fluxr(i,19) + fhlwr * sfcflw(i)%dnfxc   ! total sky sfc lw dn
+            fluxr(i,20) = fluxr(i,20) + fhlwr * sfcflw(i)%upfxc   ! total sky sfc lw up
 !  ---  lw clear-sky fluxes
-            Diag%fluxr(i,28) = Diag%fluxr(i,28) + Model%fhlwr *    Diag%topflw(i)%upfx0   ! clear sky top lw up
-            Diag%fluxr(i,30) = Diag%fluxr(i,30) + Model%fhlwr * Radtend%sfcflw(i)%dnfx0   ! clear sky sfc lw dn
-            Diag%fluxr(i,33) = Diag%fluxr(i,33) + Model%fhlwr * Radtend%sfcflw(i)%upfx0   ! clear sky sfc lw up
+            fluxr(i,28) = fluxr(i,28) + fhlwr * topflw(i)%upfx0   ! clear sky top lw up
+            fluxr(i,30) = fluxr(i,30) + fhlwr * sfcflw(i)%dnfx0   ! clear sky sfc lw dn
+            fluxr(i,33) = fluxr(i,33) + fhlwr * sfcflw(i)%upfx0   ! clear sky sfc lw up
           enddo
         endif
 
 !  ---  save sw toa and sfc fluxes with proper diurnal sw wgt. coszen=mean cosz over daylight
 !       part of sw calling interval, while coszdg= mean cosz over entire interval
-        if (Model%lsswr) then
+        if (lsswr) then
           do i = 1, IM
-            if (Radtend%coszen(i) > 0.) then
+            if (coszen(i) > 0.) then
 !  ---                                  sw total-sky fluxes
 !                                       -------------------
-              tem0d = Model%fhswr * Radtend%coszdg(i) / Radtend%coszen(i)
-              Diag%fluxr(i,2 ) = Diag%fluxr(i,2)  +    Diag%topfsw(i)%upfxc * tem0d  ! total sky top sw up
-              Diag%fluxr(i,3 ) = Diag%fluxr(i,3)  + Radtend%sfcfsw(i)%upfxc * tem0d  ! total sky sfc sw up
-              Diag%fluxr(i,4 ) = Diag%fluxr(i,4)  + Radtend%sfcfsw(i)%dnfxc * tem0d  ! total sky sfc sw dn
+              tem0d = fhswr * coszdg(i) / coszen(i)
+              fluxr(i,2 ) = fluxr(i,2)  +  topfsw(i)%upfxc * tem0d  ! total sky top sw up
+              fluxr(i,3 ) = fluxr(i,3)  +  sfcfsw(i)%upfxc * tem0d  ! total sky sfc sw up
+              fluxr(i,4 ) = fluxr(i,4)  +  sfcfsw(i)%dnfxc * tem0d  ! total sky sfc sw dn
 !  ---                                  sw uv-b fluxes
 !                                       --------------
-              Diag%fluxr(i,21) = Diag%fluxr(i,21) + scmpsw(i)%uvbfc * tem0d          ! total sky uv-b sw dn
-              Diag%fluxr(i,22) = Diag%fluxr(i,22) + scmpsw(i)%uvbf0 * tem0d          ! clear sky uv-b sw dn
+              fluxr(i,21) = fluxr(i,21) + scmpsw(i)%uvbfc * tem0d          ! total sky uv-b sw dn
+              fluxr(i,22) = fluxr(i,22) + scmpsw(i)%uvbf0 * tem0d          ! clear sky uv-b sw dn
 !  ---                                  sw toa incoming fluxes
 !                                       ----------------------
-              Diag%fluxr(i,23) = Diag%fluxr(i,23) + Diag%topfsw(i)%dnfxc * tem0d     ! top sw dn
+              fluxr(i,23) = fluxr(i,23) + topfsw(i)%dnfxc * tem0d     ! top sw dn
 !  ---                                  sw sfc flux components
 !                                       ----------------------
-              Diag%fluxr(i,24) = Diag%fluxr(i,24) + scmpsw(i)%visbm * tem0d          ! uv/vis beam sw dn
-              Diag%fluxr(i,25) = Diag%fluxr(i,25) + scmpsw(i)%visdf * tem0d          ! uv/vis diff sw dn
-              Diag%fluxr(i,26) = Diag%fluxr(i,26) + scmpsw(i)%nirbm * tem0d          ! nir beam sw dn
-              Diag%fluxr(i,27) = Diag%fluxr(i,27) + scmpsw(i)%nirdf * tem0d          ! nir diff sw dn
+              fluxr(i,24) = fluxr(i,24) + scmpsw(i)%visbm * tem0d          ! uv/vis beam sw dn
+              fluxr(i,25) = fluxr(i,25) + scmpsw(i)%visdf * tem0d          ! uv/vis diff sw dn
+              fluxr(i,26) = fluxr(i,26) + scmpsw(i)%nirbm * tem0d          ! nir beam sw dn
+              fluxr(i,27) = fluxr(i,27) + scmpsw(i)%nirdf * tem0d          ! nir diff sw dn
 !  ---                                  sw clear-sky fluxes
 !                                       -------------------
-              Diag%fluxr(i,29) = Diag%fluxr(i,29) + Diag%topfsw(i)%upfx0 * tem0d  ! clear sky top sw up
-              Diag%fluxr(i,31) = Diag%fluxr(i,31) + Radtend%sfcfsw(i)%upfx0 * tem0d  ! clear sky sfc sw up
-              Diag%fluxr(i,32) = Diag%fluxr(i,32) + Radtend%sfcfsw(i)%dnfx0 * tem0d  ! clear sky sfc sw dn
+              fluxr(i,29) = fluxr(i,29) + topfsw(i)%upfx0 * tem0d  ! clear sky top sw up
+              fluxr(i,31) = fluxr(i,31) + sfcfsw(i)%upfx0 * tem0d  ! clear sky sfc sw up
+              fluxr(i,32) = fluxr(i,32) + sfcfsw(i)%dnfx0 * tem0d  ! clear sky sfc sw dn
             endif
           enddo
         endif
 
 !  ---  save total and boundary layer clouds
 
-        if (Model%lsswr .or. Model%lslwr) then
+        if (lsswr .or. lslwr) then
           do i=1,im
-            Diag%fluxr(i,17) = Diag%fluxr(i,17) + raddt * cldsa(i,4)
-            Diag%fluxr(i,18) = Diag%fluxr(i,18) + raddt * cldsa(i,5)
+            fluxr(i,17) = fluxr(i,17) + raddt * cldsa(i,4)
+            fluxr(i,18) = fluxr(i,18) + raddt * cldsa(i,5)
           enddo
 
 !  ---  save cld frac,toplyr,botlyr and top temp, note that the order
@@ -152,15 +153,15 @@
               tem0d = raddt * cldsa(i,j)
               itop  = mtopa(i,j) - kd
               ibtc  = mbota(i,j) - kd
-              Diag%fluxr(i, 8-j) = Diag%fluxr(i, 8-j) + tem0d
-              Diag%fluxr(i,11-j) = Diag%fluxr(i,11-j) + tem0d * Statein%prsi(i,itop+kt)
-              Diag%fluxr(i,14-j) = Diag%fluxr(i,14-j) + tem0d * Statein%prsi(i,ibtc+kb)
-              Diag%fluxr(i,17-j) = Diag%fluxr(i,17-j) + tem0d * Statein%tgrs(i,itop)
+              fluxr(i, 8-j) = fluxr(i, 8-j) + tem0d
+              fluxr(i,11-j) = fluxr(i,11-j) + tem0d * prsi(i,itop+kt)
+              fluxr(i,14-j) = fluxr(i,14-j) + tem0d * prsi(i,ibtc+kb)
+              fluxr(i,17-j) = fluxr(i,17-j) + tem0d * tgrs(i,itop)
             enddo
           enddo
 
 !       Anning adds optical depth and emissivity output
-          if (Model%lsswr .and. (nday > 0)) then
+          if (lsswr .and. (nday > 0)) then
             do j = 1, 3
               do i = 1, IM
                 tem0d = raddt * cldsa(i,j)
@@ -170,12 +171,12 @@
                 do k=ibtc,itop
                   tem1 = tem1 + cldtausw(i,k)      ! approx .55 um channel
                 enddo
-                Diag%fluxr(i,43-j) = Diag%fluxr(i,43-j) + tem0d * tem1
+                fluxr(i,43-j) = fluxr(i,43-j) + tem0d * tem1
               enddo
             enddo
           endif
 
-          if (Model%lslwr) then
+          if (lslwr) then
             do j = 1, 3
               do i = 1, IM
                 tem0d = raddt * cldsa(i,j)
@@ -185,7 +186,7 @@
                 do k=ibtc,itop
                   tem2 = tem2 + cldtaulw(i,k)      ! approx 10. um channel
                 enddo
-                Diag%fluxr(i,46-j) = Diag%fluxr(i,46-j) + tem0d * (1.0-exp(-tem2))
+                fluxr(i,46-j) = fluxr(i,46-j) + tem0d * (1.0-exp(-tem2))
               enddo
             enddo
           endif

--- a/physics/GFS_rrtmg_post.meta
+++ b/physics/GFS_rrtmg_post.meta
@@ -7,65 +7,25 @@
 [ccpp-arg-table]
   name = GFS_rrtmg_post_run
   type = scheme
-[Model]
-  standard_name = GFS_control_type_instance
-  long_name = Fortran DDT containing FV3-GFS model control parameters
-  units = DDT
-  dimensions = ()
-  type = GFS_control_type
-  intent = in
-  optional = F
-[Grid]
-  standard_name = GFS_grid_type_instance
-  long_name = Fortran DDT containing FV3-GFS grid and interpolation related data
-  units = DDT
-  dimensions = ()
-  type = GFS_grid_type
-  intent = in
-  optional = F
-[Diag]
-  standard_name = GFS_diag_type_instance
-  long_name = Fortran DDT containing FV3-GFS diagnotics data
-  units = DDT
-  dimensions = ()
-  type = GFS_diag_type
-  intent = inout
-  optional = F
-[Radtend]
-  standard_name = GFS_radtend_type_instance
-  long_name = Fortran DDT containing FV3-GFS radiation tendencies
-  units = DDT
-  dimensions = ()
-  type = GFS_radtend_type
-  intent = in
-  optional = F
-[Statein]
-  standard_name = GFS_statein_type_instance
-  long_name = Fortran DDT containing FV3-GFS prognostic state data in from dycore
-  units = DDT
-  dimensions = ()
-  type = GFS_statein_type
-  intent = in
-  optional = F
-[Coupling]
-  standard_name = GFS_coupling_type_instance
-  long_name = Fortran DDT containing FV3-GFS fields to/from coupling with other components
-  units = DDT
-  dimensions = ()
-  type = GFS_coupling_type
-  intent = inout
-  optional = F
-[scmpsw]
-  standard_name = components_of_surface_downward_shortwave_fluxes
-  long_name = derived type for special components of surface downward shortwave fluxes
-  units = W m-2
-  dimensions = (horizontal_loop_extent)
-  type = cmpfsw_type
-  intent = in
-  optional = F
 [im]
   standard_name = horizontal_loop_extent
   long_name = horizontal loop extent
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[km]
+  standard_name = vertical_dimension
+  long_name = number of vertical levels
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[kmp1]
+  standard_name = vertical_dimension_plus_one
+  long_name = number of vertical levels plus one
   units = count
   dimensions = ()
   type = integer
@@ -111,11 +71,113 @@
   type = integer
   intent = in
   optional = F
+[nspc1]
+  standard_name = number_of_species_for_aerosol_optical_depth
+  long_name = number of species for output aerosol optical depth plus total
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[nfxr]
+  standard_name = number_of_radiation_diagnostic_variables
+  long_name = number of variables stored in the fluxr array
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[nday]
+  standard_name = daytime_points_dimension
+  long_name = daytime points dimension
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lsswr]
+  standard_name = flag_to_calc_sw
+  long_name = logical flags for sw radiation calls
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[lslwr]
+  standard_name = flag_to_calc_lw
+  long_name = logical flags for lw radiation calls
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[lssav]
+  standard_name = flag_diagnostics
+  long_name = logical flag for storing diagnostics
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[fhlwr]
+  standard_name = frequency_for_longwave_radiation
+  long_name = frequency for longwave radiation
+  units = s
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[fhswr]
+  standard_name = frequency_for_shortwave_radiation
+  long_name = frequency for shortwave radiation
+  units = s
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
 [raddt]
   standard_name = time_step_for_radiation
   long_name = radiation time step
   units = s
   dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[coszen]
+  standard_name = cosine_of_zenith_angle
+  long_name = mean cos of zenith angle over rad call period
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[coszdg]
+  standard_name = daytime_mean_cosz_over_rad_call_period
+  long_name = daytime mean cosz over rad call period
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[prsi]
+  standard_name = air_pressure_at_interface
+  long_name = air pressure at model layer interfaces
+  units = Pa
+  dimensions = (horizontal_loop_extent,vertical_dimension_plus_one)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[tgrs]
+  standard_name = air_temperature
+  long_name = model layer mean temperature
+  units = K
+  dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
   intent = in
@@ -181,13 +243,54 @@
   kind = kind_phys
   intent = in
   optional = F
-[nday]
-  standard_name = daytime_points_dimension
-  long_name = daytime points dimension
-  units = count
-  dimensions = ()
-  type = integer
+[sfcflw]
+  standard_name = lw_fluxes_sfc
+  long_name = lw radiation fluxes at sfc
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = sfcflw_type
   intent = in
+  optional = F
+[sfcfsw]
+  standard_name = sw_fluxes_sfc
+  long_name = sw radiation fluxes at sfc
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = sfcfsw_type
+  intent = in
+  optional = F
+[topflw]
+  standard_name = lw_fluxes_top_atmosphere
+  long_name = lw radiation fluxes at top
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = topflw_type
+  intent = in
+  optional = F
+[topfsw]
+  standard_name = sw_fluxes_top_atmosphere
+  long_name = sw radiation fluxes at toa
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = topfsw_type
+  intent = in
+  optional = F
+[scmpsw]
+  standard_name = components_of_surface_downward_shortwave_fluxes
+  long_name = derived type for special components of surface downward shortwave fluxes
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = cmpfsw_type
+  intent = in
+  optional = F
+[fluxr]
+  standard_name = cumulative_radiation_diagnostic
+  long_name = time-accumulated 2D radiation-related diagnostic fields
+  units = various
+  dimensions = (horizontal_loop_extent,number_of_radiation_diagnostic_variables)
+  type = real
+  kind = kind_phys
+  intent = inout
   optional = F
 [errmsg]
   standard_name = ccpp_error_message
@@ -206,4 +309,3 @@
   type = integer
   intent = out
   optional = F
-

--- a/physics/GFS_rrtmg_pre.F90
+++ b/physics/GFS_rrtmg_pre.F90
@@ -16,41 +16,31 @@
 !!
       ! Attention - the output arguments lm, im, lmk, lmp must not be set
       ! in the CCPP version - they are defined in the interstitial_create routine
-      subroutine GFS_rrtmg_pre_run (Model, Grid, Sfcprop, Statein,   & ! input
-          Tbd, Cldprop, Coupling,                                    &
-          Radtend,                                                   & ! input/output
-          imfdeepcnv, imfdeepcnv_gf,                                 &
-          f_ice, f_rain, f_rimef, flgmin, cwm,                       & ! F-A mp scheme only
-          lm, im, lmk, lmp,                                          & ! input
-          kd, kt, kb, raddt, delp, dz, plvl, plyr,                   & ! output
-          tlvl, tlyr, tsfg, tsfa, qlyr, olyr,                        &
-          gasvmr_co2,   gasvmr_n2o,   gasvmr_ch4,   gasvmr_o2,       &
-          gasvmr_co,    gasvmr_cfc11, gasvmr_cfc12,                  &
-          gasvmr_cfc22, gasvmr_ccl4,  gasvmr_cfc113,                 &
-          faersw1,  faersw2,  faersw3,                               &
-          faerlw1, faerlw2, faerlw3, aerodp,                         &
-          clouds1, clouds2, clouds3, clouds4, clouds5, clouds6,      &
-          clouds7, clouds8, clouds9, cldsa, cldfra,                  &
-          mtopa, mbota, de_lgth, alpha, alb1d, errmsg, errflg)
+      subroutine GFS_rrtmg_pre_run (im, levs, lm, lmk, lmp, n_var_lndp,        &
+        imfdeepcnv, imfdeepcnv_gf, me, ncnd, ntrac, num_p3d, npdf3d, ncnvcld3d,&
+        ntqv, ntcw,ntiw, ntlnc, ntinc, ncld, ntrw, ntsw, ntgl, ntwa, ntoz,     &
+        ntclamt, nleffr, nieffr, nseffr, lndp_type, kdt, imp_physics,          &
+        imp_physics_thompson, imp_physics_gfdl, imp_physics_zhao_carr,         &
+        imp_physics_zhao_carr_pdf, imp_physics_mg, imp_physics_wsm6,           &
+        imp_physics_fer_hires, lndp_var_list, lsswr, lslwr,                    &
+        ltaerosol, lgfdlmprad, uni_cld, effr_in, do_mynnedmf, lmfshal,         &
+        lmfdeep2, fhswr, fhlwr, solhr, sup, eps, epsm1, fvirt,                 &
+        rog, rocp, con_rd, xlat, xlon, coslat, sinlat, tsfc, slmsk,            &
+        prsi, prsl, prslk, tgrs, sfc_wts, phy_f3d_mg_cld, phy_f3d_reffr,       &
+        phy_f3d_cnvw, phy_f3d_cnvc, qgrs, aer_nm,                              & !inputs from here and above
+        coszen, coszdg, phy_f3d_leffr, phy_f3d_ieffr, phy_f3d_seffr,           &
+        clouds1, clouds2, clouds3, clouds4, clouds5,                           & !in/out from here and above
+        kd, kt, kb, mtopa, mbota, raddt, tsfg, tsfa, de_lgth, alb1d, delp, dz, & !output from here and below
+        plvl, plyr, tlvl, tlyr, qlyr, olyr, gasvmr_co2, gasvmr_n2o, gasvmr_ch4,&
+        gasvmr_o2, gasvmr_co, gasvmr_cfc11, gasvmr_cfc12, gasvmr_cfc22,        &
+        gasvmr_ccl4,  gasvmr_cfc113, aerodp, clouds6, clouds7, clouds8,        &
+        clouds9, cldsa, cldfra, faersw1, faersw2, faersw3, faerlw1, faerlw2,   &
+        faerlw3, alpha, errmsg, errflg)
 
       use machine,                   only: kind_phys
-      use GFS_typedefs,              only: GFS_statein_type,   &
-                                           GFS_stateout_type,  &
-                                           GFS_sfcprop_type,   &
-                                           GFS_coupling_type,  &
-                                           GFS_control_type,   &
-                                           GFS_grid_type,      &
-                                           GFS_tbd_type,       &
-                                           GFS_cldprop_type,   &
-                                           GFS_radtend_type,   &
-                                           GFS_diag_type
+
       use physparam
-      use physcons,                  only: eps   => con_eps,         &
-     &                                     epsm1 => con_epsm1,       &
-     &                                     fvirt => con_fvirt        &
-     &,                                    rog   => con_rog          &
-     &,                                    rocp  => con_rocp         &
-     &,                                    con_rd
+
       use radcons,                   only: itsfc,ltp, lextop, qmin,  &
                                            qme5, qme6, epsq, prsmin
       use funcphys,                  only: fpvs
@@ -79,86 +69,129 @@
 
       implicit none
 
-      type(GFS_control_type),              intent(in)    :: Model
-      type(GFS_grid_type),                 intent(in)    :: Grid
-      type(GFS_sfcprop_type),              intent(in)    :: Sfcprop
-      type(GFS_statein_type),              intent(in)    :: Statein
-      type(GFS_radtend_type),              intent(inout) :: Radtend
-      type(GFS_tbd_type),                  intent(in)    :: Tbd
-      type(GFS_cldprop_type),              intent(in)    :: Cldprop
-      type(GFS_coupling_type),             intent(in)    :: Coupling
+      integer,              intent(in)  :: im, levs, lm, lmk, lmp, n_var_lndp, &
+                                           imfdeepcnv,                         &
+                                           imfdeepcnv_gf, me, ncnd, ntrac,     &
+                                           num_p3d, npdf3d, ncnvcld3d, ntqv,   &
+                                           ntcw, ntiw, ntlnc, ntinc, ncld,     &
+                                           ntrw, ntsw, ntgl, ntwa, ntoz,       &
+                                           ntclamt, nleffr, nieffr, nseffr,    &
+                                           lndp_type,                          &
+                                           kdt, imp_physics,                   &
+                                           imp_physics_thompson,               &
+                                           imp_physics_gfdl,                   &
+                                           imp_physics_zhao_carr,              &
+                                           imp_physics_zhao_carr_pdf,          &
+                                           imp_physics_mg, imp_physics_wsm6,   &
+                                           imp_physics_fer_hires
 
-      integer,              intent(in)  :: im, lm, lmk, lmp
-      integer,              intent(in)  :: imfdeepcnv, imfdeepcnv_gf
-      integer,              intent(out) :: kd, kt, kb
+      character(len=3), dimension(:), intent(in) :: lndp_var_list
 
-! F-A mp scheme only
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP), intent(in) :: f_ice, &
-                                                                       f_rain, f_rimef
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP), intent(out) :: cwm
-      real(kind=kind_phys), dimension(size(Grid%xlon,1)),        intent(in)  :: flgmin
-      real(kind=kind_phys), intent(out) :: raddt
+      logical,              intent(in) :: lsswr, lslwr, ltaerosol, lgfdlmprad, &
+                                          uni_cld, effr_in, do_mynnedmf,       &
+                                          lmfshal, lmfdeep2
 
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP),   intent(out) :: delp, &
-                                                            dz, plyr, tlyr, qlyr, olyr
+      real(kind=kind_phys), intent(in) :: fhswr, fhlwr, solhr, sup
+      real(kind=kind_phys), intent(in) :: eps, epsm1, fvirt, rog, rocp, con_rd
 
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+1+LTP), intent(out) :: plvl, tlvl
+      real(kind=kind_phys), dimension(:), intent(in) :: xlat, xlon,   &
+                                                        coslat, sinlat, tsfc,  &
+                                                        slmsk
 
-      real(kind=kind_phys), dimension(size(Grid%xlon,1)),          intent(out) :: tsfg, tsfa
+      real(kind=kind_phys), dimension(:,:), intent(in) :: prsi, prsl, prslk,   &
+                                                          tgrs, sfc_wts,       &
+                                                          phy_f3d_mg_cld,      &
+                                                          phy_f3d_reffr,       &
+                                                          phy_f3d_cnvw,        &
+                                                          phy_f3d_cnvc
 
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP),   intent(out) :: gasvmr_co2, &
-                                  gasvmr_n2o, gasvmr_ch4, gasvmr_o2, gasvmr_co, gasvmr_cfc11, &
-                                  gasvmr_cfc12, gasvmr_cfc22, gasvmr_ccl4, gasvmr_cfc113
+      real(kind=kind_phys), dimension(:,:,:), intent(in) :: qgrs, aer_nm
 
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP,NBDSW), intent(out) :: faersw1, &
-                                                                             faersw2, faersw3
+      real(kind=kind_phys), dimension(:),   intent(inout) :: coszen, coszdg
 
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP,NBDLW), intent(out) :: faerlw1, &
-                                                                             faerlw2, faerlw3
+      real(kind=kind_phys), dimension(:,:), intent(inout) :: phy_f3d_leffr,    &
+                                                             phy_f3d_ieffr,    &
+                                                             phy_f3d_seffr
+      real(kind=kind_phys), dimension(im,lm+LTP), intent(inout) :: clouds1,    &
+                                                             clouds2, clouds3, &
+                                                             clouds4, clouds5
 
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),NSPC1),        intent(out) :: aerodp
+      integer,                                      intent(out) :: kd, kt, kb
 
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP),       intent(inout) :: clouds1, &
-                                                             clouds2, clouds3, clouds4, clouds5
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP),       intent(out)   :: clouds6, &
-                                                             clouds7, clouds8, clouds9, cldfra
+      integer, dimension(im,3),                     intent(out) :: mbota, mtopa
 
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),5),            intent(out) :: cldsa
-      integer,              dimension(size(Grid%xlon,1),3),            intent(out) :: mbota, mtopa
-      real(kind=kind_phys), dimension(size(Grid%xlon,1)),              intent(out) :: de_lgth, alb1d
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP),       intent(out) :: alpha
+      real(kind=kind_phys),                         intent(out) :: raddt
+
+      real(kind=kind_phys), dimension(im),          intent(out) :: tsfg, tsfa
+      real(kind=kind_phys), dimension(im),          intent(out) :: de_lgth,    &
+                                                                   alb1d
+
+      real(kind=kind_phys), dimension(im,lm+LTP),   intent(out) :: delp, dz,   &
+                                                                   plyr, tlyr, &
+                                                                   qlyr, olyr
+
+      real(kind=kind_phys), dimension(im,lm+1+LTP), intent(out) :: plvl, tlvl
+
+
+
+      real(kind=kind_phys), dimension(im,lm+LTP),   intent(out) :: gasvmr_co2, &
+                                                                   gasvmr_n2o, &
+                                                                   gasvmr_ch4, &
+                                                                   gasvmr_o2,  &
+                                                                   gasvmr_co,  &
+                                                                   gasvmr_cfc11,&
+                                                                   gasvmr_cfc12,&
+                                                                   gasvmr_cfc22,&
+                                                                   gasvmr_ccl4,&
+                                                                   gasvmr_cfc113
+      real(kind=kind_phys), dimension(im,NSPC1),     intent(out) :: aerodp
+      real(kind=kind_phys), dimension(im,lm+LTP),    intent(out) :: clouds6,   &
+                                                                    clouds7,   &
+                                                                    clouds8,   &
+                                                                    clouds9,   &
+                                                                    cldfra
+      real(kind=kind_phys), dimension(im,5),            intent(out) :: cldsa
+
+      real(kind=kind_phys), dimension(im,lm+LTP,NBDSW), intent(out) :: faersw1,&
+                                                                       faersw2,&
+                                                                       faersw3
+
+      real(kind=kind_phys), dimension(im,lm+LTP,NBDLW), intent(out) :: faerlw1,&
+                                                                       faerlw2,&
+                                                                       faerlw3
+      real(kind=kind_phys), dimension(im,lm+LTP),       intent(out) :: alpha
 
       character(len=*), intent(out) :: errmsg
       integer,          intent(out) :: errflg
 
       ! Local variables
-      integer :: me, nfxr, ntrac, ntcw, ntiw, ncld, ntrw, ntsw, ntgl, ncndl, ntlnc, ntinc, ntwa
+      integer :: ncndl
 
-      integer :: i, j, k, k1, k2, lsk, lv, n, itop, ibtc, LP1, lla, llb, lya, lyb
+      integer :: i, j, k, k1, k2, lsk, lv, n, itop, ibtc, LP1, lla, llb, lya,lyb
 
       real(kind=kind_phys) :: es, qs, delt, tem0d, pfac
 
-      real(kind=kind_phys), dimension(size(Grid%xlon,1)) :: cvt1, cvb1, tem1d, tskn
+      real(kind=kind_phys), dimension(im) :: cvt1, cvb1, tem1d, tskn
 
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP) ::         &
+      real(kind=kind_phys), dimension(im,lm+LTP) ::         &
                           htswc, htlwc, gcice, grain, grime, htsw0, htlw0, &
                           rhly, tvly,qstl, vvel, clw, ciw, prslk1, tem2da, &
                           dzb, hzb, cldcov, deltaq, cnvc, cnvw,            &
                           effrl, effri, effrr, effrs, rho, orho
       ! for Thompson MP
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP) ::         &
+      real(kind=kind_phys), dimension(im,lm+LTP) ::         &
                                   re_cloud, re_ice, re_snow, qv_mp, qc_mp, &
                                   qi_mp, qs_mp, nc_mp, ni_mp, nwfa
 
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP+1) :: tem2db, hz
+      real(kind=kind_phys), dimension(im,lm+LTP+1) :: tem2db, hz
 
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP,min(4,Model%ncnd)) :: ccnd
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP,2:Model%ntrac) :: tracer1
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP,NF_CLDS)       :: clouds
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP,NF_VGAS)       :: gasvmr
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP,NBDSW,NF_AESW) ::faersw
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP,NBDLW,NF_AELW) ::faerlw
- 
+      real(kind=kind_phys), dimension(im,lm+LTP,min(4,ncnd))   :: ccnd
+      real(kind=kind_phys), dimension(im,lm+LTP,2:ntrac)       :: tracer1
+      real(kind=kind_phys), dimension(im,lm+LTP,NF_CLDS)       :: clouds
+      real(kind=kind_phys), dimension(im,lm+LTP,NF_VGAS)       :: gasvmr
+      real(kind=kind_phys), dimension(im,lm+LTP,NBDSW,NF_AESW) :: faersw
+      real(kind=kind_phys), dimension(im,lm+LTP,NBDLW,NF_AELW) :: faerlw
+
       real(kind=kind_phys) :: qvs
 !
 !===> ...  begin here
@@ -167,22 +200,10 @@
       errmsg = ''
       errflg = 0
 
-      if (.not. (Model%lsswr .or. Model%lslwr)) return
+      if (.not. (lsswr .or. lslwr)) return
 
       !--- set commonly used integers
-      me    = Model%me
-      NFXR  = Model%nfxr
-      NTRAC = Model%ntrac        ! tracers in grrad strip off sphum - start tracer1(2:NTRAC)
-      ntcw  = Model%ntcw
-      ntiw  = Model%ntiw
-      ntlnc = Model%ntlnc
-      ntinc = Model%ntinc
-      ncld  = Model%ncld
-      ntrw  = Model%ntrw
-      ntsw  = Model%ntsw
-      ntgl  = Model%ntgl
-      ntwa  = Model%ntwa
-      ncndl = min(Model%ncnd,4)
+      ncndl = min(ncnd,4)
 
       LP1 = LM + 1               ! num of in/out levels
 
@@ -219,7 +240,7 @@
         endif                      ! end if_ivflip_block
       endif   ! end if_lextop_block
 
-      raddt = min(Model%fhswr, Model%fhlwr)
+      raddt = min(fhswr, fhlwr)
 !     print *,' in grrad : raddt=',raddt
 
 
@@ -228,13 +249,13 @@
 
       if ( itsfc == 0 ) then            ! use same sfc skin-air/ground temp
         do i = 1, IM
-          tskn(i) = Sfcprop%tsfc(i)
-          tsfg(i) = Sfcprop%tsfc(i)
+          tskn(i) = tsfc(i)
+          tsfg(i) = tsfc(i)
         enddo
       else                              ! use diff sfc skin-air/ground temp
         do i = 1, IM
-          tskn(i) = Sfcprop%tsfc(i)
-          tsfg(i) = Sfcprop%tsfc(i)
+          tskn(i) = tsfc(i)
+          tsfg(i) = tsfc(i)
         enddo
       endif
 
@@ -243,34 +264,34 @@
 !
 
       lsk = 0
-      if (ivflip == 0 .and. lm < Model%levs) lsk = Model%levs - lm
+      if (ivflip == 0 .and. lm < levs) lsk = levs - lm
 
 !     convert pressure unit from pa to mb
       do k = 1, LM
         k1 = k + kd
         k2 = k + lsk
         do i = 1, IM
-          plvl(i,k1+kb) = Statein%prsi(i,k2+kb) * 0.01   ! pa to mb (hpa)
-          plyr(i,k1)    = Statein%prsl(i,k2)    * 0.01   ! pa to mb (hpa)
-          tlyr(i,k1)    = Statein%tgrs(i,k2)
-          prslk1(i,k1)  = Statein%prslk(i,k2)
+          plvl(i,k1+kb) = prsi(i,k2+kb) * 0.01   ! pa to mb (hpa)
+          plyr(i,k1)    = prsl(i,k2)    * 0.01   ! pa to mb (hpa)
+          tlyr(i,k1)    = tgrs(i,k2)
+          prslk1(i,k1)  = prslk(i,k2)
           rho(i,k1)     = plyr(i,k1)/(con_rd*tlyr(i,k1))
-          orho(i,k1)    = 1.0/rho(i,k1) 
+          orho(i,k1)    = 1.0/rho(i,k1)
 
 !>  - Compute relative humidity.
-          es  = min( Statein%prsl(i,k2),  fpvs( Statein%tgrs(i,k2) ) )  ! fpvs and prsl in pa
-          qs  = max( QMIN, eps * es / (Statein%prsl(i,k2) + epsm1*es) )
-          rhly(i,k1) = max( 0.0, min( 1.0, max(QMIN, Statein%qgrs(i,k2,1))/qs ) )
+          es  = min( prsl(i,k2),  fpvs( tgrs(i,k2) ) )  ! fpvs and prsl in pa
+          qs  = max( QMIN, eps * es / (prsl(i,k2) + epsm1*es) )
+          rhly(i,k1) = max( 0.0, min( 1.0, max(QMIN, qgrs(i,k2,ntqv))/qs ) )
           qstl(i,k1) = qs
         enddo
       enddo
 
       !--- recast remaining all tracers (except sphum) forcing them all to be positive
-      do j = 2, NTRAC
+      do j = 2, ntrac
         do k = 1, LM
           k1 = k + kd
           k2 = k + lsk
-          tracer1(:,k1,j) = max(0.0, Statein%qgrs(:,k2,j))
+          tracer1(:,k1,j) = max(0.0, qgrs(:,k2,j))
         enddo
       enddo
 !
@@ -279,28 +300,28 @@
           k1 = 1 + kd
           k2 = k1 + kb
           do i = 1, IM
-            plvl(i,k2)   = 0.01 * Statein%prsi(i,1+kb)          ! pa to mb (hpa)
+            plvl(i,k2)   = 0.01 * prsi(i,1+kb)          ! pa to mb (hpa)
             plyr(i,k1)   = 0.5 * (plvl(i,k2+1) + plvl(i,k2))
             prslk1(i,k1) = (plyr(i,k1)*0.001) ** rocp
           enddo
         else
           k1 = 1 + kd
           do i = 1, IM
-            plvl(i,k1) = Statein%prsi(i,1) * 0.01   ! pa to mb (hpa)
+            plvl(i,k1) = prsi(i,1) * 0.01   ! pa to mb (hpa)
           enddo
         endif
       else                                                 ! input data from sfc to top
-        if (Model%levs > lm) then
+        if (levs > lm) then
           k1 = lm + kd
           do i = 1, IM
-            plvl(i,k1+1) = 0.01 * Statein%prsi(i,Model%levs+1)  ! pa to mb (hpa)
+            plvl(i,k1+1) = 0.01 * prsi(i,levs+1)  ! pa to mb (hpa)
             plyr(i,k1)   = 0.5 * (plvl(i,k1+1) + plvl(i,k1))
             prslk1(i,k1) = (plyr(i,k1)*0.001) ** rocp
           enddo
         else
           k1 = lp1 + kd
           do i = 1, IM
-            plvl(i,k1) = Statein%prsi(i,lp1) * 0.01   ! pa to mb (hpa)
+            plvl(i,k1) = prsi(i,lp1) * 0.01   ! pa to mb (hpa)
           enddo
         endif
       endif
@@ -324,22 +345,21 @@
 !>  - Get layer ozone mass mixing ratio (if use ozone climatology data,
 !!    call getozn()).
 
-      if (Model%ntoz > 0) then            ! interactive ozone generation
+      if (ntoz > 0) then            ! interactive ozone generation
         do k=1,lmk
           do i=1,im
-            olyr(i,k) = max( QMIN, tracer1(i,k,Model%ntoz) )
+            olyr(i,k) = max( QMIN, tracer1(i,k,ntoz) )
           enddo
         enddo
       else                                ! climatological ozone
-        call getozn (prslk1, Grid%xlat, IM, LMK,    &     !  ---  inputs
-                     olyr)                                !  ---  outputs
+        call getozn (prslk1, xlat, im, lmk,    &     !  ---  inputs
+                     olyr)                           !  ---  outputs
       endif                               ! end_if_ntoz
 
 !>  - Call coszmn(), to compute cosine of zenith angle (only when SW is called)
-      if (Model%lsswr) then
-        call coszmn (Grid%xlon,Grid%sinlat,           &     !  ---  inputs
-                     Grid%coslat,Model%solhr, IM, me, &
-                     Radtend%coszen, Radtend%coszdg)        !  --- outputs
+      if (lsswr) then
+        call coszmn (xlon,sinlat,coslat,solhr,im,me, &     !  ---  inputs
+                     coszen, coszdg)                       !  ---  outputs
       endif
 
 !>  - Call getgases(), to set up non-prognostic gas volume mixing
@@ -357,8 +377,8 @@
 
 !  --- ...  set up non-prognostic gas volume mixing ratioes
 
-      call getgases (plvl, Grid%xlon, Grid%xlat, IM, LMK,  & !  --- inputs
-                     gasvmr)                                 !  --- outputs
+      call getgases (plvl, xlon, xlat, IM, LMK, & !  --- inputs
+                     gasvmr)                      !  --- outputs
 
 !CCPP: re-assign gasvmr(:,:,NF_VGAS) to gasvmr_X(:,:)
       do k = 1, LMK
@@ -398,9 +418,9 @@
         do k = 1, LM
           k1 = k + kd
           do i = 1, IM
-            qlyr(i,k1) = max( tem1d(i), Statein%qgrs(i,k,1) )
+            qlyr(i,k1) = max( tem1d(i), qgrs(i,k,ntqv) )
             tem1d(i)   = min( QME5, qlyr(i,k1) )
-            tvly(i,k1) = Statein%tgrs(i,k) * (1.0 + fvirt*qlyr(i,k1)) ! virtual T (K)
+            tvly(i,k1) = tgrs(i,k) * (1.0 + fvirt*qlyr(i,k1)) ! virtual T (K)
             delp(i,k1) = plvl(i,k1+1) - plvl(i,k1)
           enddo
         enddo
@@ -463,9 +483,9 @@
 
         do k = LM, 1, -1
           do i = 1, IM
-            qlyr(i,k) = max( tem1d(i), Statein%qgrs(i,k,1) )
+            qlyr(i,k) = max( tem1d(i), qgrs(i,k,ntqv) )
             tem1d(i)  = min( QME5, qlyr(i,k) )
-            tvly(i,k) = Statein%tgrs(i,k) * (1.0 + fvirt*qlyr(i,k)) ! virtual T (K)
+            tvly(i,k) = tgrs(i,k) * (1.0 + fvirt*qlyr(i,k)) ! virtual T (K)
             delp(i,k) = plvl(i,k) - plvl(i,k+1)
           enddo
         enddo
@@ -521,11 +541,10 @@
 
 !check  print *,' in grrad : calling setaer '
 
-      call setaer (plvl, plyr, prslk1, tvly, rhly, Sfcprop%slmsk, & !  ---  inputs
-                   tracer1, Tbd%aer_nm,                            &
-                   Grid%xlon, Grid%xlat, IM, LMK, LMP,             &
-                   Model%lsswr,Model%lslwr,                        &
-                   faersw,faerlw,aerodp)                              !  ---  outputs
+      call setaer (plvl, plyr, prslk1, tvly, rhly, slmsk,    & !  ---  inputs
+                   tracer1, aer_nm, xlon, xlat, IM, LMK, LMP,&
+                   lsswr,lslwr,                              &
+                   faersw,faerlw,aerodp)                       !  ---  outputs
 
 ! CCPP
       do j = 1,NBDSW
@@ -563,20 +582,20 @@
 
 !      if (ntcw > 0) then                            ! prognostic cloud schemes
         ccnd = 0.0_kind_phys
-        if (Model%ncnd == 1) then                                 ! Zhao_Carr_Sundqvist
+        if (ncnd == 1) then                          ! Zhao_Carr_Sundqvist
           do k=1,LMK
             do i=1,IM
-              ccnd(i,k,1) = tracer1(i,k,ntcw)                     ! liquid water/ice
+              ccnd(i,k,1) = tracer1(i,k,ntcw)        ! liquid water/ice
             enddo
           enddo
-        elseif (Model%ncnd == 2) then                             ! MG or F-A
+        elseif (ncnd == 2) then                      ! MG or F-A
           do k=1,LMK
             do i=1,IM
-              ccnd(i,k,1) = tracer1(i,k,ntcw)                     ! liquid water
-              ccnd(i,k,2) = tracer1(i,k,ntiw)                     ! ice water
+              ccnd(i,k,1) = tracer1(i,k,ntcw)        ! liquid water
+              ccnd(i,k,2) = tracer1(i,k,ntiw)        ! ice water
             enddo
           enddo
-        elseif (Model%ncnd == 4) then                             ! MG2
+        elseif (ncnd == 4) then                      ! MG2
           do k=1,LMK
             do i=1,IM
               ccnd(i,k,1) = tracer1(i,k,ntcw)                     ! liquid water
@@ -585,7 +604,7 @@
               ccnd(i,k,4) = tracer1(i,k,ntsw)                     ! snow water
             enddo
           enddo
-        elseif (Model%ncnd == 5) then                             ! GFDL MP, Thompson, MG3
+        elseif (ncnd == 5) then                         ! GFDL MP, Thompson, MG3
           do k=1,LMK
             do i=1,IM
               ccnd(i,k,1) = tracer1(i,k,ntcw)                     ! liquid water
@@ -595,10 +614,10 @@
             enddo
           enddo
           ! for Thompson MP - prepare variables for calc_effr
-          if (Model%imp_physics == Model%imp_physics_thompson .and. Model%ltaerosol) then
+          if (imp_physics == imp_physics_thompson .and. ltaerosol) then
             do k=1,LMK
               do i=1,IM
-                qvs = Statein%qgrs(i,k,1)
+                qvs = qgrs(i,k,ntqv)
                 qv_mp (i,k) = qvs/(1.-qvs)
                 qc_mp (i,k) = tracer1(i,k,ntcw)/(1.-qvs)
                 qi_mp (i,k) = tracer1(i,k,ntiw)/(1.-qvs)
@@ -608,10 +627,10 @@
                 nwfa  (i,k) = tracer1(i,k,ntwa)
               enddo
             enddo
-          elseif (Model%imp_physics == Model%imp_physics_thompson) then
+          elseif (imp_physics == imp_physics_thompson) then
             do k=1,LMK
               do i=1,IM
-                qvs = Statein%qgrs(i,k,1)
+                qvs = qgrs(i,k,ntqv)
                 qv_mp (i,k) = qvs/(1.-qvs)
                 qc_mp (i,k) = tracer1(i,k,ntcw)/(1.-qvs)
                 qi_mp (i,k) = tracer1(i,k,ntiw)/(1.-qvs)
@@ -629,17 +648,17 @@
             enddo
           enddo
         enddo
-        if (Model%imp_physics == Model%imp_physics_gfdl ) then
-          if (.not. Model%lgfdlmprad) then
+        if (imp_physics == imp_physics_gfdl ) then
+          if (.not. lgfdlmprad) then
 
 
 ! rsun the  summation methods and order make the difference in calculation
 
-!            clw(:,:) = clw(:,:) + tracer1(:,1:LMK,Model%ntcw)   &
-!                                + tracer1(:,1:LMK,Model%ntiw)   &
-!                                + tracer1(:,1:LMK,Model%ntrw)   &
-!                                + tracer1(:,1:LMK,Model%ntsw)   &
-!                                + tracer1(:,1:LMK,Model%ntgl)
+!            clw(:,:) = clw(:,:) + tracer1(:,1:LMK,ntcw)   &
+!                                + tracer1(:,1:LMK,ntiw)   &
+!                                + tracer1(:,1:LMK,ntrw)   &
+!                                + tracer1(:,1:LMK,ntsw)   &
+!                                + tracer1(:,1:LMK,ntgl)
             ccnd(:,:,1) =               tracer1(:,1:LMK,ntcw)
             ccnd(:,:,1) = ccnd(:,:,1) + tracer1(:,1:LMK,ntrw)
             ccnd(:,:,1) = ccnd(:,:,1) + tracer1(:,1:LMK,ntiw)
@@ -647,7 +666,7 @@
             ccnd(:,:,1) = ccnd(:,:,1) + tracer1(:,1:LMK,ntgl)
 
 !          else
-!            do j=1,Model%ncld
+!            do j=1,ncld
 !              ccnd(:,:,1) = ccnd(:,:,1) + tracer1(:,1:LMK,ntcw+j-1) ! cloud condensate amount
 !            enddo
           endif
@@ -658,34 +677,34 @@
           enddo
         endif
 !
-        if (Model%uni_cld) then
-          if (Model%effr_in) then
+        if (uni_cld) then
+          if (effr_in) then
             do k=1,lm
               k1 = k + kd
               do i=1,im
-                cldcov(i,k1) = Tbd%phy_f3d(i,k,Model%indcld)
-                effrl(i,k1)  = Tbd%phy_f3d(i,k,2)
-                effri(i,k1)  = Tbd%phy_f3d(i,k,3)
-                effrr(i,k1)  = Tbd%phy_f3d(i,k,4)
-                effrs(i,k1)  = Tbd%phy_f3d(i,k,5)
+                cldcov(i,k1) = phy_f3d_mg_cld(i,k)
+                effrl(i,k1)  = phy_f3d_leffr(i,k)
+                effri(i,k1)  = phy_f3d_ieffr(i,k)
+                effrr(i,k1)  = phy_f3d_reffr(i,k)
+                effrs(i,k1)  = phy_f3d_seffr(i,k)
               enddo
             enddo
           else
             do k=1,lm
               k1 = k + kd
               do i=1,im
-                cldcov(i,k1) = Tbd%phy_f3d(i,k,Model%indcld)
+                cldcov(i,k1) = phy_f3d_mg_cld(i,k)
               enddo
             enddo
           endif
-        elseif (Model%imp_physics == Model%imp_physics_gfdl) then                          ! GFDL MP
-          if (Model%do_mynnedmf .and. Model%kdt>1) THEN
+        elseif (imp_physics == imp_physics_gfdl) then            ! GFDL MP
+          if (do_mynnedmf .and. kdt>1) THEN
             do k=1,lm
               k1 = k + kd
               do i=1,im
                 if (tracer1(i,k1,ntrw)>1.0e-7 .OR. tracer1(i,k1,ntsw)>1.0e-7) then
                 ! GFDL cloud fraction
-                  cldcov(i,k1) = tracer1(I,k1,Model%ntclamt)           
+                  cldcov(i,k1) = tracer1(I,k1,ntclamt)
                 else
                 ! MYNN sub-grid cloud fraction
                   cldcov(i,k1) = clouds1(i,k1)
@@ -694,37 +713,37 @@
             enddo
           else
             ! GFDL cloud fraction
-            cldcov(1:IM,1+kd:LM+kd) = tracer1(1:IM,1:LM,Model%ntclamt)
+            cldcov(1:IM,1+kd:LM+kd) = tracer1(1:IM,1:LM,ntclamt)
           endif
-          if(Model%effr_in) then
+          if(effr_in) then
             do k=1,lm
               k1 = k + kd
               do i=1,im
-                effrl(i,k1) = Tbd%phy_f3d(i,k,1)
-                effri(i,k1) = Tbd%phy_f3d(i,k,2)
-                effrr(i,k1) = Tbd%phy_f3d(i,k,3)
-                effrs(i,k1) = Tbd%phy_f3d(i,k,4)
-!                if(Model%me==0) then
+                effrl(i,k1) = phy_f3d_leffr(i,k)
+                effri(i,k1) = phy_f3d_ieffr(i,k)
+                effrr(i,k1) = phy_f3d_reffr(i,k)
+                effrs(i,k1) = phy_f3d_seffr(i,k)
+!                if(me==0) then
 !                  if(effrl(i,k1)> 5.0) then
-!                    write(6,*) 'rad driver:cloud radii:',Model%kdt, i,k1,       &
+!                    write(6,*) 'rad driver:cloud radii:',kdt, i,k1,       &
 !                    effrl(i,k1)
 !                  endif
 !                  if(effrs(i,k1)==0.0) then
-!                    write(6,*) 'rad driver:snow mixing ratio:',Model%kdt, i,k1,        &
+!                    write(6,*) 'rad driver:snow mixing ratio:',kdt, i,k1, &
 !                    tracer1(i,k,ntsw)
 !                  endif
 !                endif
               enddo
             enddo
           endif
-        elseif (Model%imp_physics == Model%imp_physics_thompson) then                     !  Thompson MP
+        elseif (imp_physics == imp_physics_thompson) then       !  Thompson MP
           !
           ! Compute effective radii for QC, QI, QS with (GF, MYNN) or without (all others) sub-grid clouds
           !
           ! Update number concentration, consistent with sub-grid clouds (GF, MYNN) or without (all others)
           do k=1,lm
             do i=1,im
-              if (Model%ltaerosol .and. qc_mp(i,k)>1.e-12 .and. nc_mp(i,k)<100.) then
+              if (ltaerosol .and. qc_mp(i,k)>1.e-12 .and. nc_mp(i,k)<100.) then
                 nc_mp(i,k) = make_DropletNumber(qc_mp(i,k)*rho(i,k), nwfa(i,k)) * orho(i,k)
               endif
               if (qi_mp(i,k)>1.e-12 .and. ni_mp(i,k)<100.) then
@@ -763,9 +782,9 @@
           do k=1,lm
             k1 = k + kd
             do i=1,im
-              Tbd%phy_f3d(i,k,Model%nleffr) = effrl(i,k1)
-              Tbd%phy_f3d(i,k,Model%nieffr) = effri(i,k1)
-              Tbd%phy_f3d(i,k,Model%nseffr) = effrs(i,k1)
+              phy_f3d_leffr(i,k) = effrl(i,k1)
+              phy_f3d_ieffr(i,k) = effri(i,k1)
+              phy_f3d_seffr(i,k) = effrs(i,k1)
             enddo
           enddo
         else                                                           ! all other cases
@@ -779,25 +798,27 @@
 !      for zhao/moorthi's (imp_phys=99) &
 !          ferrier's (imp_phys=5) microphysics schemes
 
-        if ((Model%num_p3d == 4) .and. (Model%npdf3d == 3)) then       ! same as Model%imp_physics = 99
+        if ((num_p3d == 4) .and. (npdf3d == 3)) then       ! same as imp_physics = 98
           do k=1,lm
             k1 = k + kd
             do i=1,im
-              deltaq(i,k1) = Tbd%phy_f3d(i,k,5)
-              cnvw  (i,k1) = Tbd%phy_f3d(i,k,6)
-              cnvc  (i,k1) = Tbd%phy_f3d(i,k,7)
+              !GJF: this is not consistent with GFS_typedefs,
+              !     but it looks like the Zhao-Carr-PDF scheme is not in the CCPP
+              deltaq(i,k1) = 0.0!Tbd%phy_f3d(i,k,5)      !GJF: this variable is not in phy_f3d anymore
+              cnvw  (i,k1) = phy_f3d_cnvw(i,k)
+              cnvc  (i,k1) = phy_f3d_cnvc(i,k)
             enddo
           enddo
-        elseif ((Model%npdf3d == 0) .and. (Model%ncnvcld3d == 1)) then ! same as MOdel%imp_physics=98
+        elseif ((npdf3d == 0) .and. (ncnvcld3d == 1)) then ! same as imp_physics=99
           do k=1,lm
             k1 = k + kd
             do i=1,im
               deltaq(i,k1) = 0.0
-              cnvw  (i,k1) = Tbd%phy_f3d(i,k,Model%num_p3d+1)
+              cnvw  (i,k1) = phy_f3d_cnvw(i,k)
               cnvc  (i,k1) = 0.0
             enddo
           enddo
-        else                                                           ! all the rest
+        else                                                      ! all the rest
           do k=1,lmk
             do i=1,im
               deltaq(i,k) = 0.0
@@ -814,7 +835,7 @@
             cnvw  (i,lyb) = cnvw  (i,lya)
             cnvc  (i,lyb) = cnvc  (i,lya)
           enddo
-          if (Model%effr_in) then
+          if (effr_in) then
             do i=1,im
               effrl(i,lyb) = effrl(i,lya)
               effri(i,lyb) = effri(i,lya)
@@ -824,93 +845,82 @@
           endif
         endif
 
-        if (Model%imp_physics == 99) then
+        if (imp_physics == imp_physics_zhao_carr) then
           ccnd(1:IM,1:LMK,1) = ccnd(1:IM,1:LMK,1) + cnvw(1:IM,1:LMK)
         endif
 
 
-        if (Model%imp_physics == 99 .or. Model%imp_physics == 10) then           ! zhao/moorthi's prognostic cloud scheme
+        if (imp_physics == imp_physics_zhao_carr .or. imp_physics == imp_physics_mg) then ! zhao/moorthi's prognostic cloud scheme
                                          ! or unified cloud and/or with MG microphysics
 
-          if (Model%uni_cld .and. Model%ncld >= 2) then
-            call progclduni (plyr, plvl, tlyr, tvly, ccnd, ncndl,           & !  ---  inputs
-                             Grid%xlat, Grid%xlon, Sfcprop%slmsk,dz,delp,   &
-                             IM, LMK, LMP, cldcov,                          &
-                             effrl, effri, effrr, effrs, Model%effr_in,     &
-                             dzb, Grid%xlat_d, Model%julian, Model%yearlen, &
-                             clouds, cldsa, mtopa, mbota, de_lgth, alpha)     !  ---  outputs
+          if (uni_cld .and. ncld >= 2) then
+            call progclduni (plyr, plvl, tlyr, tvly, ccnd, ncndl,         & !  ---  inputs
+                             xlat, xlon, slmsk, dz, delp,                 &
+                             IM, LMK, LMP, cldcov,                        &
+                             effrl, effri, effrr, effrs, effr_in,         &
+                             dzb, xlat_d, julian, yearlen,                &
+                             clouds, cldsa, mtopa, mbota, de_lgth, alpha)   !  ---  outputs
           else
-            call progcld1 (plyr ,plvl, tlyr, tvly, qlyr, qstl, rhly,        & !  ---  inputs
-                           ccnd(1:IM,1:LMK,1), Grid%xlat,Grid%xlon,         &
-                           Sfcprop%slmsk, dz, delp, IM, LMK, LMP,           &
-                           Model%uni_cld, Model%lmfshal,                    &
-                           Model%lmfdeep2, cldcov,                          &
-                           effrl, effri, effrr, effrs, Model%effr_in,       &
-                           dzb, Grid%xlat_d, Model%julian, Model%yearlen,   &
-                           clouds, cldsa, mtopa, mbota, de_lgth, alpha)       !  ---  outputs
+            call progcld1 (plyr ,plvl, tlyr, tvly, qlyr, qstl, rhly,      & !  ---  inputs
+                           ccnd(1:IM,1:LMK,1), xlat, xlon, slmsk, dz,     &
+                           delp, IM, LMK, LMP, uni_cld, lmfshal, lmfdeep2,&
+                           cldcov, effrl, effri, effrr, effrs, effr_in,   &
+                           dzb, xlat_d, julian, yearlen,                  &
+                           clouds, cldsa, mtopa, mbota, de_lgth, alpha)     !  ---  outputs
           endif
 
-        elseif(Model%imp_physics == 98) then      ! zhao/moorthi's prognostic cloud+pdfcld
+        elseif(imp_physics == imp_physics_zhao_carr_pdf) then      ! zhao/moorthi's prognostic cloud+pdfcld
 
-          call progcld3 (plyr, plvl, tlyr, tvly, qlyr, qstl, rhly,      &    !  ---  inputs
-                         ccnd(1:IM,1:LMK,1),                            &
-                         cnvw, cnvc, Grid%xlat, Grid%xlon,              &
-                         Sfcprop%slmsk, dz, delp, im, lmk, lmp, deltaq, &
-                         Model%sup, Model%kdt, me,                      &
-                         dzb, Grid%xlat_d, Model%julian, Model%yearlen, &
+          call progcld3 (plyr, plvl, tlyr, tvly, qlyr, qstl, rhly,        &  !  ---  inputs
+                         ccnd(1:IM,1:LMK,1), cnvw, cnvc, xlat, xlon,      &
+                         slmsk, dz, delp, im, lmk, lmp, deltaq, sup, kdt, &
+                         me, dzb, xlat_d, julian, yearlen,                &
                          clouds, cldsa, mtopa, mbota, de_lgth, alpha)        !  ---  outputs
 
+        elseif (imp_physics == imp_physics_gfdl) then           ! GFDL cloud scheme
 
-        elseif (Model%imp_physics == 11) then           ! GFDL cloud scheme
-
-          if (.not.Model%lgfdlmprad) then
+          if (.not. lgfdlmprad) then
             call progcld4 (plyr, plvl, tlyr, tvly, qlyr, qstl, rhly,      &    !  ---  inputs
-                           ccnd(1:IM,1:LMK,1), cnvw, cnvc,                &
-                           Grid%xlat, Grid%xlon, Sfcprop%slmsk,           &
-                           cldcov, dz, delp, im, lmk, lmp,                &
-                           dzb, Grid%xlat_d, Model%julian, Model%yearlen, &
+                           ccnd(1:IM,1:LMK,1), cnvw, cnvc, xlat, xlon,    &
+                           slmsk, cldcov, dz, delp, im, lmk, lmp,         &
+                           dzb, xlat_d, julian, yearlen,                  &
                            clouds, cldsa, mtopa, mbota, de_lgth, alpha)        !  ---  outputs
           else
 
-            call progclduni (plyr, plvl, tlyr, tvly, ccnd, ncndl,         &    !  ---  inputs
-                            Grid%xlat, Grid%xlon, Sfcprop%slmsk, dz,delp, &
-                            IM, LMK, LMP, cldcov,                         &
-                            effrl, effri, effrr, effrs, Model%effr_in,    &
-                            dzb, Grid%xlat_d, Model%julian, Model%yearlen,&
-                            clouds, cldsa, mtopa, mbota, de_lgth, alpha)        !  ---  outputs
+            call progclduni (plyr, plvl, tlyr, tvly, ccnd, ncndl, xlat,   &    !  ---  inputs
+                            xlon, slmsk, dz,delp, IM, LMK, LMP, cldcov,   &
+                            effrl, effri, effrr, effrs, effr_in,          &
+                            dzb, xlat_d, julian, yearlen,                 &
+                            clouds, cldsa, mtopa, mbota, de_lgth, alpha)       !  ---  outputs
 !           call progcld4o (plyr, plvl, tlyr, tvly, qlyr, qstl, rhly,       &   !  ---  inputs
-!                           tracer1, Grid%xlat, Grid%xlon, Sfcprop%slmsk,   &
-!                           dz, delp,                                       &
-!                           ntrac-1, Model%ntcw-1,Model%ntiw-1,Model%ntrw-1,&
-!                           Model%ntsw-1,Model%ntgl-1,Model%ntclamt-1,      &
+!                           tracer1, xlat, xlon, slmsk, dz, delp,           &
+!                           ntrac-1, ntcw-1,ntiw-1,ntrw-1,                  &
+!                           ntsw-1,ntgl-1,ntclamt-1,                        &
 !                           im, lmk, lmp,                                   &
-!                           dzb, Grid%xlat_d, Model%julian, Model%yearlen,  &
+!                           dzb, xlat_d, julian, yearlen,                   &
 !                           clouds, cldsa, mtopa, mbota, de_lgth, alpha)        !  ---  outputs
           endif
 
-        elseif(Model%imp_physics == 6 .or. Model%imp_physics == 15) then
-          if (Model%kdt == 1) then
-            Tbd%phy_f3d(:,:,Model%nleffr) = 10.
-            Tbd%phy_f3d(:,:,Model%nieffr) = 50.
-            Tbd%phy_f3d(:,:,Model%nseffr) = 250.
+        elseif(imp_physics == imp_physics_wsm6 .or. imp_physics == imp_physics_fer_hires) then
+          if (kdt == 1) then
+            phy_f3d_leffr(:,:) = 10.
+            phy_f3d_ieffr(:,:) = 50.
+            phy_f3d_seffr(:,:) = 250.
           endif
 
-          call progcld5 (plyr,plvl,tlyr,qlyr,qstl,rhly,tracer1,        &  !  --- inputs
-                         Grid%xlat,Grid%xlon,Sfcprop%slmsk,dz,delp,    &
-                         ntrac-1, ntcw-1,ntiw-1,ntrw-1,                &
-                         ntsw-1,ntgl-1,                                &
-                         im, lmk, lmp, Model%uni_cld,                  &
-                         Model%lmfshal,Model%lmfdeep2,                 &
-                         cldcov(:,1:LMK),Tbd%phy_f3d(:,:,1),           &
-                         Tbd%phy_f3d(:,:,2), Tbd%phy_f3d(:,:,3),       &
-                         dzb, Grid%xlat_d, Model%julian, Model%yearlen,&
-                         clouds,cldsa,mtopa,mbota, de_lgth, alpha)        !  --- outputs
+          call progcld5 (plyr,plvl,tlyr,qlyr,qstl,rhly,tracer1,     &  !  --- inputs
+                         xlat,xlon,slmsk,dz,delp,                   &
+                         ntrac-1, ntcw-1,ntiw-1,ntrw-1,             &
+                         ntsw-1,ntgl-1,                             &
+                         im, lmk, lmp, uni_cld, lmfshal, lmfdeep2,  &
+                         cldcov(:,1:LMK),phy_f3d_leffr(:,:),        &
+                         phy_f3d_ieffr(:,:), phy_f3d_seffr(:,:),    &
+                         dzb, xlat_d, julian, yearlen,              &
+                         clouds,cldsa,mtopa,mbota, de_lgth, alpha)     !  --- outputs
 
+        elseif(imp_physics == imp_physics_thompson) then                              ! Thompson MP
 
-        elseif(Model%imp_physics == Model%imp_physics_thompson) then                              ! Thompson MP
-
-          if(Model%do_mynnedmf .or.                                 & 
-                           Model%imfdeepcnv == Model%imfdeepcnv_gf ) then ! MYNN PBL or GF conv
+          if(do_mynnedmf .or. imfdeepcnv == imfdeepcnv_gf ) then ! MYNN PBL or GF conv
               !-- MYNN PBL or convective GF
               !-- use cloud fractions with SGS clouds
               do k=1,lmk
@@ -922,29 +932,28 @@
                 ! --- use clduni as with the GFDL microphysics.
                 ! --- make sure that effr_in=.true. in the input.nml!
                 call progclduni (plyr, plvl, tlyr, tvly, ccnd, ncndl,   & !  ---  inputs
-                         Grid%xlat, Grid%xlon, Sfcprop%slmsk, dz,delp,  &
-                         IM, LMK, LMP, clouds(:,1:LMK,1),               &
-                         effrl, effri, effrr, effrs, Model%effr_in ,    &
-                         dzb, Grid%xlat_d, Model%julian, Model%yearlen, &
-                         clouds, cldsa, mtopa, mbota, de_lgth, alpha)        !  ---  outputs
+                         xlat, xlon, slmsk, dz, delp, IM, LMK, LMP,     &
+                         clouds(:,1:LMK,1),                             &
+                         effrl, effri, effrr, effrs, effr_in ,          &
+                         dzb, xlat_d, julian, yearlen,                  &
+                         clouds, cldsa, mtopa, mbota, de_lgth, alpha)     !  ---  outputs
 
           else
             ! MYNN PBL or GF convective are not used
-            call progcld5 (plyr,plvl,tlyr,qlyr,qstl,rhly,tracer1,      & !  --- inputs
-                         Grid%xlat,Grid%xlon,Sfcprop%slmsk,dz,delp,    &
-                         ntrac-1, ntcw-1,ntiw-1,ntrw-1,                &
-                         ntsw-1,ntgl-1,                                &
-                         im, lmk, lmp, Model%uni_cld,                  &
-                         Model%lmfshal,Model%lmfdeep2,                 &
-                         cldcov(:,1:LMK),Tbd%phy_f3d(:,:,1),           &
-                         Tbd%phy_f3d(:,:,2), Tbd%phy_f3d(:,:,3),       &
-                         dzb, Grid%xlat_d, Model%julian, Model%yearlen,&
-                         clouds,cldsa,mtopa,mbota, de_lgth, alpha)        !  --- outputs
+            call progcld5 (plyr,plvl,tlyr,qlyr,qstl,rhly,tracer1,   & !  --- inputs
+                         xlat,xlon,slmsk,dz,delp,                   &
+                         ntrac-1, ntcw-1,ntiw-1,ntrw-1,             &
+                         ntsw-1,ntgl-1,                             &
+                         im, lmk, lmp, uni_cld, lmfshal, lmfdeep2,  &
+                         cldcov(:,1:LMK), phy_f3d_leffr(:,:),       &
+                         phy_f3d_ieffr(:,:), phy_f3d_seffr(:,:),    &
+                         dzb, xlat_d, julian, yearlen,              &
+                         clouds, cldsa, mtopa ,mbota, de_lgth, alpha) !  --- outputs
           endif ! MYNN PBL or GF
 
         endif                            ! end if_imp_physics
 
-!      endif                                ! end_if_ntcw
+!      endif                             ! end_if_ntcw
 
        do k = 1, LMK
          do i = 1, IM
@@ -966,12 +975,12 @@
 !  perturbation size
 !  ---  turn vegetation fraction pattern into percentile pattern
       alb1d(:) = 0.
-      if (Model%lndp_type==1) then
-          do k =1,Model%n_var_lndp
-            if (Model%lndp_var_list(k) == 'alb') then
+      if (lndp_type==1) then
+          do k =1,n_var_lndp
+            if (lndp_var_list(k) == 'alb') then
               do i=1,im
-                call cdfnor(Coupling%sfc_wts(i,k),alb1d(i)) 
-                !lndp_alb = Model%lndp_prt_list(k)
+                call cdfnor(sfc_wts(i,k),alb1d(i))
+                !lndp_alb = lndp_prt_list(k)
               enddo
             endif
           enddo

--- a/physics/GFS_rrtmg_pre.F90
+++ b/physics/GFS_rrtmg_pre.F90
@@ -22,10 +22,10 @@
         ntclamt, nleffr, nieffr, nseffr, lndp_type, kdt, imp_physics,          &
         imp_physics_thompson, imp_physics_gfdl, imp_physics_zhao_carr,         &
         imp_physics_zhao_carr_pdf, imp_physics_mg, imp_physics_wsm6,           &
-        imp_physics_fer_hires, lndp_var_list, lsswr, lslwr,                    &
+        imp_physics_fer_hires, julian, yearlen, lndp_var_list, lsswr, lslwr,   &
         ltaerosol, lgfdlmprad, uni_cld, effr_in, do_mynnedmf, lmfshal,         &
         lmfdeep2, fhswr, fhlwr, solhr, sup, eps, epsm1, fvirt,                 &
-        rog, rocp, con_rd, xlat, xlon, coslat, sinlat, tsfc, slmsk,            &
+        rog, rocp, con_rd, xlat_d, xlat, xlon, coslat, sinlat, tsfc, slmsk,    &
         prsi, prsl, prslk, tgrs, sfc_wts, phy_f3d_mg_cld, phy_f3d_reffr,       &
         phy_f3d_cnvw, phy_f3d_cnvc, qgrs, aer_nm,                              & !inputs from here and above
         coszen, coszdg, phy_f3d_leffr, phy_f3d_ieffr, phy_f3d_seffr,           &
@@ -83,7 +83,8 @@
                                            imp_physics_zhao_carr,              &
                                            imp_physics_zhao_carr_pdf,          &
                                            imp_physics_mg, imp_physics_wsm6,   &
-                                           imp_physics_fer_hires
+                                           imp_physics_fer_hires,              &
+                                           yearlen
 
       character(len=3), dimension(:), intent(in) :: lndp_var_list
 
@@ -91,10 +92,10 @@
                                           uni_cld, effr_in, do_mynnedmf,       &
                                           lmfshal, lmfdeep2
 
-      real(kind=kind_phys), intent(in) :: fhswr, fhlwr, solhr, sup
+      real(kind=kind_phys), intent(in) :: fhswr, fhlwr, solhr, sup, julian
       real(kind=kind_phys), intent(in) :: eps, epsm1, fvirt, rog, rocp, con_rd
 
-      real(kind=kind_phys), dimension(:), intent(in) :: xlat, xlon,   &
+      real(kind=kind_phys), dimension(:), intent(in) :: xlat_d, xlat, xlon,    &
                                                         coslat, sinlat, tsfc,  &
                                                         slmsk
 

--- a/physics/GFS_rrtmg_pre.meta
+++ b/physics/GFS_rrtmg_pre.meta
@@ -1,132 +1,33 @@
 [ccpp-table-properties]
   name = GFS_rrtmg_pre
   type = scheme
-  dependencies = funcphys.f90,iounitdef.f,machine.F,module_bfmicrophysics.f,module_mp_radar.F90,module_mp_thompson.F90,module_mp_thompson_make_number_concentrations.F90,physcons.F90,physparam.f,radcons.f90,radiation_aerosols.f,radiation_astronomy.f,radiation_clouds.f,radiation_gases.f,radlw_param.f,radsw_param.f,surface_perturbation.F90
+  dependencies = funcphys.f90,iounitdef.f,machine.F,module_bfmicrophysics.f,module_mp_radar.F90,module_mp_thompson.F90
+  dependencies = module_mp_thompson_make_number_concentrations.F90,physcons.F90,physparam.f,radcons.f90,radiation_aerosols.f
+  dependencies = radiation_astronomy.f,radiation_clouds.f,radiation_gases.f,radlw_param.f,radsw_param.f,surface_perturbation.F90
 
 ########################################################################
 [ccpp-arg-table]
   name = GFS_rrtmg_pre_run
   type = scheme
-[Model]
-  standard_name = GFS_control_type_instance
-  long_name = Fortran DDT containing FV3-GFS model control parameters
-  units = DDT
-  dimensions = ()
-  type = GFS_control_type
-  intent = in
-  optional = F
-[Grid]
-  standard_name = GFS_grid_type_instance
-  long_name = Fortran DDT containing FV3-GFS grid and interpolation related data
-  units = DDT
-  dimensions = ()
-  type = GFS_grid_type
-  intent = in
-  optional = F
-[Sfcprop]
-  standard_name = GFS_sfcprop_type_instance
-  long_name = Fortran DDT containing FV3-GFS surface fields
-  units = DDT
-  dimensions = ()
-  type = GFS_sfcprop_type
-  intent = in
-  optional = F
-[Statein]
-  standard_name = GFS_statein_type_instance
-  long_name = Fortran DDT containing FV3-GFS prognostic state data in from dycore
-  units = DDT
-  dimensions = ()
-  type = GFS_statein_type
-  intent = in
-  optional = F
-[Tbd]
-  standard_name = GFS_tbd_type_instance
-  long_name = Fortran DDT containing FV3-GFS data not yet assigned to a defined container
-  units = DDT
-  dimensions = ()
-  type = GFS_tbd_type
-  intent = in
-  optional = F
-[Cldprop]
-  standard_name = GFS_cldprop_type_instance
-  long_name = Fortran DDT containing FV3-GFS cloud fields needed by radiation from physics
-  units = DDT
-  dimensions = ()
-  type = GFS_cldprop_type
-  intent = in
-  optional = F
-[Coupling]
-  standard_name = GFS_coupling_type_instance
-  long_name = Fortran DDT containing FV3-GFS fields needed for coupling
-  units = DDT
-  dimensions = ()
-  type = GFS_coupling_type
-  intent = in
-  optional = F
-[Radtend]
-  standard_name = GFS_radtend_type_instance
-  long_name = Fortran DDT containing FV3-GFS radiation tendencies
-  units = DDT
-  dimensions = ()
-  type = GFS_radtend_type
-  intent = inout
-  optional = F
-[f_ice]
-  standard_name = fraction_of_ice_water_cloud
-  long_name = fraction of ice water cloud
-  units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
-  type = real
-  kind = kind_phys
-  intent = in
-  optional = F
-[f_rain]
-  standard_name = fraction_of_rain_water_cloud
-  long_name = fraction of rain water cloud
-  units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
-  type = real
-  kind = kind_phys
-  intent = in
-  optional = F
-[f_rimef]
-  standard_name = rime_factor
-  long_name = rime factor
-  units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
-  type = real
-  kind = kind_phys
-  intent = in
-  optional = F
-[flgmin]
-  standard_name = minimum_large_ice_fraction
-  long_name = minimum large ice fraction in F-A mp scheme
-  units = frac
-  dimensions = (2)
-  type = real
-  kind = kind_phys
-  intent = in
-  optional = F
-[cwm]
-  standard_name = total_cloud_condensate_mixing_ratio_updated_by_physics
-  long_name = total cloud condensate mixing ratio (except water vapor) updated by physics
-  units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
-  type = real
-  kind = kind_phys
-  intent = out
-  optional = F
-[lm]
-  standard_name = number_of_vertical_layers_for_radiation_calculations
-  long_name = number of vertical layers for radiation calculation
+[im]
+  standard_name = horizontal_loop_extent
+  long_name = horizontal loop extent
   units = count
   dimensions = ()
   type = integer
   intent = in
   optional = F
-[im]
-  standard_name = horizontal_loop_extent
-  long_name = horizontal loop extent
+[levs]
+  standard_name = vertical_dimension
+  long_name = number of vertical levels
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lm]
+  standard_name = number_of_vertical_layers_for_radiation_calculations
+  long_name = number of vertical layers for radiation calculation
   units = count
   dimensions = ()
   type = integer
@@ -147,6 +48,692 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
+[n_var_lndp]
+  standard_name = number_of_land_surface_variables_perturbed
+  long_name = number of land surface variables perturbed
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[imfdeepcnv]
+  standard_name = flag_for_mass_flux_deep_convection_scheme
+  long_name = flag for mass-flux deep convection scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[imfdeepcnv_gf]
+  standard_name = flag_for_gf_deep_convection_scheme
+  long_name = flag for Grell-Freitas deep convection scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[me]
+  standard_name = mpi_rank
+  long_name = current MPI-rank
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ncnd]
+  standard_name = number_of_cloud_condensate_types
+  long_name = number of cloud condensate types
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ntrac]
+  standard_name = number_of_tracers
+  long_name = number of tracers
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[num_p3d]
+  standard_name = array_dimension_of_3d_arrays_for_microphysics
+  long_name = number of 3D arrays needed for microphysics
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[npdf3d]
+  standard_name = number_of_3d_arrays_associated_with_pdf_based_clouds
+  long_name = number of 3d arrays associated with pdf based clouds/mp
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ncnvcld3d]
+  standard_name = number_of_convective_3d_cloud_fields
+  long_name = number of convective 3d clouds fields
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ntqv]
+  standard_name = index_for_water_vapor
+  long_name = tracer index for water vapor (specific humidity)
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ntcw]
+  standard_name = index_for_liquid_cloud_condensate
+  long_name = tracer index for cloud condensate (or liquid water)
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ntiw]
+  standard_name = index_for_ice_cloud_condensate
+  long_name = tracer index for  ice water
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ntlnc]
+  standard_name = index_for_liquid_cloud_number_concentration
+  long_name = tracer index for liquid number concentration
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ntinc]
+  standard_name = index_for_ice_cloud_number_concentration
+  long_name = tracer index for ice    number concentration
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ncld]
+  standard_name = number_of_hydrometeors
+  long_name = choice of cloud scheme / number of hydrometeors
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ntrw]
+  standard_name = index_for_rain_water
+  long_name = tracer index for rain water
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ntsw]
+  standard_name = index_for_snow_water
+  long_name = tracer index for snow water
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ntgl]
+  standard_name = index_for_graupel
+  long_name = tracer index for graupel
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ntwa]
+  standard_name = index_for_water_friendly_aerosols
+  long_name = tracer index for water friendly aerosol
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ntoz]
+  standard_name = index_for_ozone
+  long_name = tracer index for ozone mixing ratio
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ntclamt]
+  standard_name = index_for_cloud_amount
+  long_name = tracer index for cloud amount integer
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[nleffr]
+  standard_name = index_for_cloud_liquid_water_effective_radius
+  long_name = the index of cloud liquid water effective radius in phy_f3d
+  units = 
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[nieffr]
+  standard_name = index_for_ice_effective_radius
+  long_name = the index of ice effective radius in phy_f3d
+  units = 
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[nseffr]
+  standard_name = index_for_snow_effective_radius
+  long_name = the index of snow effective radius in phy_f3d
+  units = 
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lndp_type]
+  standard_name = index_for_stochastic_land_surface_perturbation_type
+  long_name = index for stochastic land surface perturbations type
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[kdt]
+  standard_name = index_of_time_step
+  long_name = current forecast iteration
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[imp_physics]
+  standard_name = flag_for_microphysics_scheme
+  long_name = choice of microphysics scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[imp_physics_thompson]
+  standard_name = flag_for_thompson_microphysics_scheme
+  long_name = choice of Thompson microphysics scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[imp_physics_gfdl]
+  standard_name = flag_for_gfdl_microphysics_scheme
+  long_name = choice of GFDL microphysics scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[imp_physics_zhao_carr]
+  standard_name = flag_for_zhao_carr_microphysics_scheme
+  long_name = choice of Zhao-Carr microphysics scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[imp_physics_zhao_carr_pdf]
+  standard_name = flag_for_zhao_carr_pdf_microphysics_scheme
+  long_name = choice of Zhao-Carr microphysics scheme with PDF clouds
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[imp_physics_mg]
+  standard_name = flag_for_morrison_gettelman_microphysics_scheme
+  long_name = choice of Morrison-Gettelman microphysics scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[imp_physics_wsm6]
+  standard_name = flag_for_wsm6_microphysics_scheme
+  long_name = choice of WSM6 microphysics scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[imp_physics_fer_hires]
+  standard_name = flag_for_fer_hires_microphysics_scheme
+  long_name = choice of Ferrier-Aligo microphysics scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lndp_var_list]
+  standard_name = variables_to_be_perturbed_for_landperts
+  long_name = variables to be perturbed for landperts
+  units = none
+  dimensions =  (number_of_land_surface_variables_perturbed) 
+  type = character
+  kind = len=3
+  intent = in
+  optional = F
+[lsswr]
+  standard_name = flag_to_calc_sw
+  long_name = logical flags for sw radiation calls
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[lslwr]
+  standard_name = flag_to_calc_lw
+  long_name = logical flags for lw radiation calls
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[ltaerosol]
+  standard_name = flag_for_aerosol_physics
+  long_name = flag for aerosol physics
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[lgfdlmprad]
+  standard_name = flag_for_GFDL_microphysics_radiation_interaction
+  long_name = flag for GFDL microphysics-radiation interaction
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[uni_cld]
+  standard_name = flag_for_uni_cld
+  long_name = flag for uni_cld
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[effr_in]
+  standard_name = flag_for_cloud_effective_radii
+  long_name = flag for cloud effective radii calculations in GFDL microphysics
+  units = 
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[do_mynnedmf]
+  standard_name = do_mynnedmf
+  long_name = flag to activate MYNN-EDMF
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[lmfshal]
+  standard_name = flag_for_lmfshal
+  long_name = flag for lmfshal
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[lmfdeep2]
+  standard_name = flag_for_scale_aware_mass_flux_convection
+  long_name = flag for some scale-aware mass-flux convection scheme active
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[fhswr]
+  standard_name = frequency_for_shortwave_radiation
+  long_name = frequency for shortwave radiation
+  units = s
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[fhlwr]
+  standard_name = frequency_for_longwave_radiation
+  long_name = frequency for longwave radiation
+  units = s
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[solhr]
+  standard_name = forecast_hour_of_the_day
+  long_name = time in hours after 00z at the current timestep
+  units = h
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[sup]
+  standard_name = ice_supersaturation_threshold
+  long_name = ice supersaturation parameter for PDF clouds
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[eps]
+  standard_name = ratio_of_dry_air_to_water_vapor_gas_constants
+  long_name = rd/rv
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[epsm1]
+  standard_name = ratio_of_dry_air_to_water_vapor_gas_constants_minus_one
+  long_name = (rd/rv) - 1
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[fvirt]
+  standard_name = ratio_of_vapor_to_dry_air_gas_constants_minus_one
+  long_name = (rv/rd) - 1 (rv = ideal gas constant for water vapor)
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[rog]
+  standard_name = ratio_of_gas_constant_dry_air_to_gravitational_acceleration
+  long_name = (rd/g)
+  units = J s2 K-1 kg-1 m-1
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[rocp]
+  standard_name = ratio_of_gas_constant_dry_air_to_specific_heat_of_dry_air_at_constant_pressure
+  long_name = (rd/cp)
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[con_rd]
+  standard_name = gas_constant_dry_air
+  long_name = ideal gas constant for dry air
+  units = J kg-1 K-1
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[xlat]
+  standard_name = latitude
+  long_name = latitude
+  units = radian
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[xlon]
+  standard_name = longitude
+  long_name = longitude
+  units = radian
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[coslat]
+  standard_name = cosine_of_latitude
+  long_name = cosine of latitude
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[sinlat]
+  standard_name = sine_of_latitude
+  long_name = sine of latitude
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[tsfc]
+  standard_name = surface_skin_temperature
+  long_name = surface skin temperature
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[slmsk]
+  standard_name = sea_land_ice_mask_real
+  long_name = landmask: sea/land/ice=0/1/2
+  units = flag
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[prsi]
+  standard_name = air_pressure_at_interface
+  long_name = air pressure at model layer interfaces
+  units = Pa
+  dimensions = (horizontal_loop_extent,vertical_dimension_plus_one)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[prsl]
+  standard_name = air_pressure
+  long_name = mean layer pressure
+  units = Pa
+  dimensions = (horizontal_loop_extent,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[prslk]
+  standard_name = dimensionless_exner_function_at_model_layers
+  long_name = dimensionless Exner function at model layer centers
+  units = none
+  dimensions = (horizontal_loop_extent,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[tgrs]
+  standard_name = air_temperature
+  long_name = model layer mean temperature
+  units = K
+  dimensions = (horizontal_loop_extent,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[sfc_wts]
+  standard_name = weights_for_stochastic_surface_physics_perturbation
+  long_name = weights for stochastic surface physics perturbation
+  units = none
+  dimensions = (horizontal_loop_extent,number_of_surface_perturbations)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[phy_f3d_mg_cld]
+  standard_name = cloud_fraction_for_MG
+  long_name = cloud fraction used by Morrison-Gettelman MP
+  units = frac
+  dimensions = (horizontal_loop_extent,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[phy_f3d_reffr]
+  standard_name = effective_radius_of_stratiform_cloud_rain_particle_in_um
+  long_name = effective radius of cloud rain particle in micrometers
+  units = um
+  dimensions = (horizontal_loop_extent,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[phy_f3d_cnvw]
+  standard_name = convective_cloud_water_mixing_ratio_in_phy_f3d
+  long_name = convective cloud water mixing ratio in the phy_f3d array
+  units = kg kg-1
+  dimensions = (horizontal_loop_extent,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[phy_f3d_cnvc]
+  standard_name = convective_cloud_cover_in_phy_f3d
+  long_name = convective cloud cover in the phy_f3d array
+  units = frac
+  dimensions = (horizontal_loop_extent,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[qgrs]
+  standard_name = tracer_concentration
+  long_name = model layer mean tracer concentration
+  units = kg kg-1
+  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_tracers)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[aer_nm]
+  standard_name = aerosol_number_concentration_from_gocart_aerosol_climatology
+  long_name = GOCART aerosol climatology number concentration
+  units = kg-1?
+  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_aerosol_tracers_MG)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[coszen]
+  standard_name = cosine_of_zenith_angle
+  long_name = mean cos of zenith angle over rad call period
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[coszdg]
+  standard_name = daytime_mean_cosz_over_rad_call_period
+  long_name = daytime mean cosz over rad call period
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[phy_f3d_leffr]
+  standard_name = effective_radius_of_stratiform_cloud_liquid_water_particle_in_um
+  long_name = eff. radius of cloud liquid water particle in micrometer
+  units = um
+  dimensions = (horizontal_loop_extent,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[phy_f3d_ieffr]
+  standard_name = effective_radius_of_stratiform_cloud_ice_particle_in_um
+  long_name = eff. radius of cloud ice water particle in micrometer
+  units = um
+  dimensions = (horizontal_loop_extent,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[phy_f3d_seffr]
+  standard_name = effective_radius_of_stratiform_cloud_snow_particle_in_um
+  long_name = effective radius of cloud snow particle in micrometers
+  units = um
+  dimensions = (horizontal_loop_extent,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[clouds1]
+  standard_name = total_cloud_fraction
+  long_name = layer total cloud fraction
+  units = frac
+  dimensions = (horizontal_loop_extent,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[clouds2]
+  standard_name = cloud_liquid_water_path
+  long_name = layer cloud liquid water path
+  units = g m-2
+  dimensions = (horizontal_loop_extent,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[clouds3]
+  standard_name = mean_effective_radius_for_liquid_cloud
+  long_name = mean effective radius for liquid cloud
+  units = micron
+  dimensions = (horizontal_loop_extent,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[clouds4]
+  standard_name = cloud_ice_water_path
+  long_name = layer cloud ice water path
+  units = g m-2
+  dimensions = (horizontal_loop_extent,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[clouds5]
+  standard_name = mean_effective_radius_for_ice_cloud
+  long_name = mean effective radius for ice cloud
+  units = micron
+  dimensions = (horizontal_loop_extent,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
   optional = F
 [kd]
   standard_name = vertical_index_difference_between_inout_and_local
@@ -172,11 +759,63 @@
   type = integer
   intent = out
   optional = F
+[mtopa]
+  standard_name = model_layer_number_at_cloud_top
+  long_name = vertical indices for low, middle and high cloud tops
+  units = index
+  dimensions = (horizontal_loop_extent,3)
+  type = integer
+  intent = out
+  optional = F
+[mbota]
+  standard_name = model_layer_number_at_cloud_base
+  long_name = vertical indices for low, middle and high cloud bases
+  units = index
+  dimensions = (horizontal_loop_extent,3)
+  type = integer
+  intent = out
+  optional = F
 [raddt]
   standard_name = time_step_for_radiation
   long_name = radiation time step
   units = s
   dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = out
+  optional = F
+[tsfg]
+  standard_name = surface_ground_temperature_for_radiation
+  long_name = surface ground temperature for radiation
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+  optional = F
+[tsfa]
+  standard_name = surface_air_temperature_for_radiation
+  long_name = lowest model layer air temperature for radiation
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+  optional = F
+[de_lgth]
+  standard_name = cloud_decorrelation_length
+  long_name = cloud decorrelation length
+  units = km
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+  optional = F
+[alb1d]
+  standard_name = surface_albedo_perturbation
+  long_name = surface albedo perturbation
+  units = frac
+  dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
   intent = out
@@ -235,24 +874,6 @@
   kind = kind_phys
   intent = out
   optional = F
-[tsfg]
-  standard_name = surface_ground_temperature_for_radiation
-  long_name = surface ground temperature for radiation
-  units = K
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = out
-  optional = F
-[tsfa]
-  standard_name = surface_air_temperature_for_radiation
-  long_name = lowest model layer air temperature for radiation
-  units = K
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = out
-  optional = F
 [qlyr]
   standard_name = water_vapor_specific_humidity_at_layer_for_radiation
   long_name = water vapor specific humidity at vertical layer for radiation calculation
@@ -270,22 +891,6 @@
   type = real
   kind = kind_phys
   intent = out
-  optional = F
-[imfdeepcnv]
-  standard_name = flag_for_mass_flux_deep_convection_scheme
-  long_name = flag for mass-flux deep convection scheme
-  units = flag
-  dimensions = ()
-  type = integer
-  intent = in
-  optional = F
-[imfdeepcnv_gf]
-  standard_name = flag_for_gf_deep_convection_scheme
-  long_name = flag for Grell-Freitas deep convection scheme
-  units = flag
-  dimensions = ()
-  type = integer
-  intent = in
   optional = F
 [gasvmr_co2]
   standard_name = volume_mixing_ratio_co2
@@ -377,60 +982,6 @@
   kind = kind_phys
   intent = out
   optional = F
-[faersw1]
-  standard_name = aerosol_optical_depth_for_shortwave_bands_01_16
-  long_name = aerosol optical depth for shortwave bands 01-16
-  units = none
-  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation,number_of_aerosol_bands_for_shortwave_radiation)
-  type = real
-  kind = kind_phys
-  intent = out
-  optional = F
-[faersw2]
-  standard_name = aerosol_single_scattering_albedo_for_shortwave_bands_01_16
-  long_name = aerosol single scattering albedo for shortwave bands 01-16
-  units = frac
-  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation,number_of_aerosol_bands_for_shortwave_radiation)
-  type = real
-  kind = kind_phys
-  intent = out
-  optional = F
-[faersw3]
-  standard_name = aerosol_asymmetry_parameter_for_shortwave_bands_01_16
-  long_name = aerosol asymmetry parameter for shortwave bands 01-16
-  units = none
-  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation,number_of_aerosol_bands_for_shortwave_radiation)
-  type = real
-  kind = kind_phys
-  intent = out
-  optional = F
-[faerlw1]
-  standard_name = aerosol_optical_depth_for_longwave_bands_01_16
-  long_name = aerosol optical depth for longwave bands 01-16
-  units = none
-  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation,number_of_aerosol_bands_for_longwave_radiation)
-  type = real
-  kind = kind_phys
-  intent = out
-  optional = F
-[faerlw2]
-  standard_name = aerosol_single_scattering_albedo_for_longwave_bands_01_16
-  long_name = aerosol single scattering albedo for longwave bands 01-16
-  units = frac
-  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation,number_of_aerosol_bands_for_longwave_radiation)
-  type = real
-  kind = kind_phys
-  intent = out
-  optional = F
-[faerlw3]
-  standard_name = aerosol_asymmetry_parameter_for_longwave_bands_01_16
-  long_name = aerosol asymmetry parameter for longwave bands 01-16
-  units = none
-  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation,number_of_aerosol_bands_for_longwave_radiation)
-  type = real
-  kind = kind_phys
-  intent = out
-  optional = F
 [aerodp]
   standard_name = atmosphere_optical_thickness_due_to_ambient_aerosol_particles
   long_name = vertical integrated optical depth for various aerosol species
@@ -439,51 +990,6 @@
   type = real
   kind = kind_phys
   intent = out
-  optional = F
-[clouds1]
-  standard_name = total_cloud_fraction
-  long_name = layer total cloud fraction
-  units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
-  type = real
-  kind = kind_phys
-  intent = inout
-  optional = F
-[clouds2]
-  standard_name = cloud_liquid_water_path
-  long_name = layer cloud liquid water path
-  units = g m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
-  type = real
-  kind = kind_phys
-  intent = inout
-  optional = F
-[clouds3]
-  standard_name = mean_effective_radius_for_liquid_cloud
-  long_name = mean effective radius for liquid cloud
-  units = micron
-  dimensions = (horizontal_loop_extent,vertical_dimension)
-  type = real
-  kind = kind_phys
-  intent = inout
-  optional = F
-[clouds4]
-  standard_name = cloud_ice_water_path
-  long_name = layer cloud ice water path
-  units = g m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
-  type = real
-  kind = kind_phys
-  intent = inout
-  optional = F
-[clouds5]
-  standard_name = mean_effective_radius_for_ice_cloud
-  long_name = mean effective radius for ice cloud
-  units = micron
-  dimensions = (horizontal_loop_extent,vertical_dimension)
-  type = real
-  kind = kind_phys
-  intent = inout
   optional = F
 [clouds6]
   standard_name = cloud_rain_water_path
@@ -539,27 +1045,56 @@
   kind = kind_phys
   intent = out
   optional = F
-[mtopa]
-  standard_name = model_layer_number_at_cloud_top
-  long_name = vertical indices for low, middle and high cloud tops
-  units = index
-  dimensions = (horizontal_loop_extent,3)
-  type = integer
+[faersw1]
+  standard_name = aerosol_optical_depth_for_shortwave_bands_01_16
+  long_name = aerosol optical depth for shortwave bands 01-16
+  units = none
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation,number_of_aerosol_bands_for_shortwave_radiation)
+  type = real
+  kind = kind_phys
   intent = out
   optional = F
-[mbota]
-  standard_name = model_layer_number_at_cloud_base
-  long_name = vertical indices for low, middle and high cloud bases
-  units = index
-  dimensions = (horizontal_loop_extent,3)
-  type = integer
+[faersw2]
+  standard_name = aerosol_single_scattering_albedo_for_shortwave_bands_01_16
+  long_name = aerosol single scattering albedo for shortwave bands 01-16
+  units = frac
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation,number_of_aerosol_bands_for_shortwave_radiation)
+  type = real
+  kind = kind_phys
   intent = out
   optional = F
-[de_lgth]
-  standard_name = cloud_decorrelation_length
-  long_name = cloud decorrelation length
-  units = km
-  dimensions = (horizontal_loop_extent)
+[faersw3]
+  standard_name = aerosol_asymmetry_parameter_for_shortwave_bands_01_16
+  long_name = aerosol asymmetry parameter for shortwave bands 01-16
+  units = none
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation,number_of_aerosol_bands_for_shortwave_radiation)
+  type = real
+  kind = kind_phys
+  intent = out
+  optional = F
+[faerlw1]
+  standard_name = aerosol_optical_depth_for_longwave_bands_01_16
+  long_name = aerosol optical depth for longwave bands 01-16
+  units = none
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation,number_of_aerosol_bands_for_longwave_radiation)
+  type = real
+  kind = kind_phys
+  intent = out
+  optional = F
+[faerlw2]
+  standard_name = aerosol_single_scattering_albedo_for_longwave_bands_01_16
+  long_name = aerosol single scattering albedo for longwave bands 01-16
+  units = frac
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation,number_of_aerosol_bands_for_longwave_radiation)
+  type = real
+  kind = kind_phys
+  intent = out
+  optional = F
+[faerlw3]
+  standard_name = aerosol_asymmetry_parameter_for_longwave_bands_01_16
+  long_name = aerosol asymmetry parameter for longwave bands 01-16
+  units = none
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation,number_of_aerosol_bands_for_longwave_radiation)
   type = real
   kind = kind_phys
   intent = out
@@ -569,15 +1104,6 @@
   long_name = cloud overlap decorrelation parameter
   units = frac
   dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
-  type = real
-  kind = kind_phys
-  intent = out
-  optional = F
-[alb1d]
-  standard_name = surface_albedo_perturbation
-  long_name = surface albedo perturbation
-  units = frac
-  dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
   intent = out

--- a/physics/GFS_rrtmg_pre.meta
+++ b/physics/GFS_rrtmg_pre.meta
@@ -321,6 +321,23 @@
   type = integer
   intent = in
   optional = F
+[julian]
+  standard_name = julian_day
+  long_name = julian day
+  units = days
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[yearlen]
+  standard_name = number_of_days_in_year
+  long_name = number of days in a year
+  units = days
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
 [lndp_var_list]
   standard_name = variables_to_be_perturbed_for_landperts
   long_name = variables to be perturbed for landperts
@@ -488,6 +505,15 @@
   long_name = ideal gas constant for dry air
   units = J kg-1 K-1
   dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[xlat_d]
+  standard_name = latitude_in_degree
+  long_name = latitude in degree north
+  units = degree_north
+  dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
   intent = in

--- a/physics/GFS_rrtmg_pre.meta
+++ b/physics/GFS_rrtmg_pre.meta
@@ -720,7 +720,7 @@
   standard_name = total_cloud_fraction
   long_name = layer total cloud fraction
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
   intent = inout
@@ -729,7 +729,7 @@
   standard_name = cloud_liquid_water_path
   long_name = layer cloud liquid water path
   units = g m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
   intent = inout
@@ -737,8 +737,8 @@
 [clouds3]
   standard_name = mean_effective_radius_for_liquid_cloud
   long_name = mean effective radius for liquid cloud
-  units = micron
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  units = um
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
   intent = inout
@@ -747,7 +747,7 @@
   standard_name = cloud_ice_water_path
   long_name = layer cloud ice water path
   units = g m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
   intent = inout
@@ -755,8 +755,8 @@
 [clouds5]
   standard_name = mean_effective_radius_for_ice_cloud
   long_name = mean effective radius for ice cloud
-  units = micron
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  units = um
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
   intent = inout
@@ -1021,7 +1021,7 @@
   standard_name = cloud_rain_water_path
   long_name = cloud rain water path
   units = g m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
   intent = out
@@ -1029,8 +1029,8 @@
 [clouds7]
   standard_name = mean_effective_radius_for_rain_drop
   long_name = mean effective radius for rain drop
-  units = micron
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  units = um
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
   intent = out
@@ -1039,7 +1039,7 @@
   standard_name = cloud_snow_water_path
   long_name = cloud snow water path
   units = g m-2
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
   intent = out
@@ -1047,8 +1047,8 @@
 [clouds9]
   standard_name = mean_effective_radius_for_snow_flake
   long_name = mean effective radius for snow flake
-  units = micron
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  units = um
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
   intent = out
@@ -1066,7 +1066,7 @@
   standard_name = instantaneous_3d_cloud_fraction
   long_name = instantaneous 3D cloud fraction for all MPs
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
   type = real
   kind = kind_phys
   intent = out

--- a/physics/GFS_rrtmg_pre.meta
+++ b/physics/GFS_rrtmg_pre.meta
@@ -220,7 +220,7 @@
 [nleffr]
   standard_name = index_for_cloud_liquid_water_effective_radius
   long_name = the index of cloud liquid water effective radius in phy_f3d
-  units = 
+  units = index
   dimensions = ()
   type = integer
   intent = in
@@ -228,7 +228,7 @@
 [nieffr]
   standard_name = index_for_ice_effective_radius
   long_name = the index of ice effective radius in phy_f3d
-  units = 
+  units = index
   dimensions = ()
   type = integer
   intent = in
@@ -236,7 +236,7 @@
 [nseffr]
   standard_name = index_for_snow_effective_radius
   long_name = the index of snow effective radius in phy_f3d
-  units = 
+  units = index
   dimensions = ()
   type = integer
   intent = in
@@ -390,7 +390,7 @@
 [effr_in]
   standard_name = flag_for_cloud_effective_radii
   long_name = flag for cloud effective radii calculations in GFDL microphysics
-  units = 
+  units = flag
   dimensions = ()
   type = logical
   intent = in
@@ -665,7 +665,7 @@
 [aer_nm]
   standard_name = aerosol_number_concentration_from_gocart_aerosol_climatology
   long_name = GOCART aerosol climatology number concentration
-  units = kg-1?
+  units = kg-1
   dimensions = (horizontal_loop_extent,vertical_dimension,number_of_aerosol_tracers_MG)
   type = real
   kind = kind_phys

--- a/physics/GFS_rrtmgp_gfdlmp_pre.meta
+++ b/physics/GFS_rrtmgp_gfdlmp_pre.meta
@@ -58,7 +58,7 @@
 [effr_in]
   standard_name = flag_for_cloud_effective_radii
   long_name = flag for cloud effective radii calculations in GFDL microphysics
-  units = 
+  units = flag
   dimensions = ()
   type = logical  
   intent = in
@@ -275,7 +275,7 @@
 [cld_reliq]
   standard_name = mean_effective_radius_for_liquid_cloud
   long_name = mean effective radius for liquid cloud
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
@@ -293,7 +293,7 @@
 [cld_reice]
   standard_name = mean_effective_radius_for_ice_cloud
   long_name = mean effective radius for ice cloud
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
@@ -311,7 +311,7 @@
 [cld_resnow]
   standard_name = mean_effective_radius_for_snow_flake
   long_name = mean effective radius for snow cloud
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
@@ -329,7 +329,7 @@
 [cld_rerain]
   standard_name = mean_effective_radius_for_rain_drop
   long_name = mean effective radius for rain cloud
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys

--- a/physics/GFS_rrtmgp_lw_post.F90
+++ b/physics/GFS_rrtmgp_lw_post.F90
@@ -26,8 +26,8 @@ contains
 !!
   subroutine GFS_rrtmgp_lw_post_run (nCol, nLev, lslwr, do_lw_clrsky_hr, save_diag, fhlwr, &
        p_lev, t_lay, tsfa, fluxlwUP_allsky, fluxlwDOWN_allsky, fluxlwUP_clrsky,            &
-       fluxlwDOWN_clrsky, raddt, aerodp, cldsa, mtopa, mbota, cld_frac, cldtaulw, sfcdlw,  &
-       sfcflw, tsflw, htrlw, topflw, flxprf_lw, htrlwc, errmsg, errflg)
+       fluxlwDOWN_clrsky, raddt, aerodp, cldsa, mtopa, mbota, cld_frac, cldtaulw, fluxr,   &
+       sfcdlw, sfcflw, tsflw, htrlw, topflw, flxprf_lw, htrlwc, errmsg, errflg)
 
     ! Inputs                    
     integer, intent(in) :: &
@@ -61,7 +61,9 @@ contains
     real(kind_phys), dimension(nCol,nLev), intent(in) :: &
          cld_frac,          & ! Total cloud fraction in each layer
          cldtaulw             ! approx 10.mu band layer cloud optical depth  
-
+    
+    real(kind=kind_phys), dimension(:,:), intent(inout) :: fluxr
+    
     ! Outputs (mandatory)
 	real(kind_phys), dimension(nCol), intent(out) :: &
 	     sfcdlw,            & ! Total sky sfc downward lw flux (W/m2)
@@ -168,42 +170,42 @@ contains
     ! - Collect the fluxr data for wrtsfc
     ! #######################################################################################
     if (save_diag) then
-!          do i=1,nCol
-!             ! LW all-sky fluxes
-!             Diag%fluxr(i,1 ) = Diag%fluxr(i,1 ) + fhlwr * fluxlwUP_allsky(  i,iTOA)   ! total sky top lw up
-!             Diag%fluxr(i,19) = Diag%fluxr(i,19) + fhlwr * fluxlwDOWN_allsky(i,iSFC)   ! total sky sfc lw dn
-!             Diag%fluxr(i,20) = Diag%fluxr(i,20) + fhlwr * fluxlwUP_allsky(  i,iSFC)   ! total sky sfc lw up
-!             ! LW clear-sky fluxes
-!             Diag%fluxr(i,28) = Diag%fluxr(i,28) + fhlwr * fluxlwUP_clrsky(  i,iTOA)   ! clear sky top lw up
-!             Diag%fluxr(i,30) = Diag%fluxr(i,30) + fhlwr * fluxlwDOWN_clrsky(i,iSFC)   ! clear sky sfc lw dn
-!             Diag%fluxr(i,33) = Diag%fluxr(i,33) + fhlwr * fluxlwUP_clrsky(  i,iSFC)   ! clear sky sfc lw up
-!          enddo
-!          
-!          do i=1,nCol
-!             Diag%fluxr(i,17) = Diag%fluxr(i,17) + raddt * cldsa(i,4)
-!             Diag%fluxr(i,18) = Diag%fluxr(i,18) + raddt * cldsa(i,5)
-!          enddo
-!          
-!          ! Save cld frac,toplyr,botlyr and top temp, note that the order of h,m,l cloud is reversed for 
-!          ! the fluxr output. save interface pressure (pa) of top/bot
-!          do j = 1, 3
-!             do i = 1, nCol
-!                tem0d = raddt * cldsa(i,j)
-!                itop  = mtopa(i,j)
-!                ibtc  = mbota(i,j)
-!                Diag%fluxr(i, 8-j) = Diag%fluxr(i, 8-j) + tem0d
-!                Diag%fluxr(i,11-j) = Diag%fluxr(i,11-j) + tem0d * p_lev(i,itop)
-!                Diag%fluxr(i,14-j) = Diag%fluxr(i,14-j) + tem0d * p_lev(i,ibtc)
-!                Diag%fluxr(i,17-j) = Diag%fluxr(i,17-j) + tem0d * t_lay(i,itop)
-!                
-!                ! Add optical depth and emissivity output
-!                tem2 = 0.
-!                do k=ibtc,itop
-!                   tem2 = tem2 + cldtaulw(i,k)      ! approx 10. mu channel
-!                enddo
-!                Diag%fluxr(i,46-j) = Diag%fluxr(i,46-j) + tem0d * (1.0-exp(-tem2))
-!             enddo
-!          enddo
+          do i=1,nCol
+             ! LW all-sky fluxes
+             fluxr(i,1 ) = fluxr(i,1 ) + fhlwr * fluxlwUP_allsky(  i,iTOA)   ! total sky top lw up
+             fluxr(i,19) = fluxr(i,19) + fhlwr * fluxlwDOWN_allsky(i,iSFC)   ! total sky sfc lw dn
+             fluxr(i,20) = fluxr(i,20) + fhlwr * fluxlwUP_allsky(  i,iSFC)   ! total sky sfc lw up
+             ! LW clear-sky fluxes
+             fluxr(i,28) = fluxr(i,28) + fhlwr * fluxlwUP_clrsky(  i,iTOA)   ! clear sky top lw up
+             fluxr(i,30) = fluxr(i,30) + fhlwr * fluxlwDOWN_clrsky(i,iSFC)   ! clear sky sfc lw dn
+             fluxr(i,33) = fluxr(i,33) + fhlwr * fluxlwUP_clrsky(  i,iSFC)   ! clear sky sfc lw up
+          enddo
+          
+          do i=1,nCol
+             fluxr(i,17) = fluxr(i,17) + raddt * cldsa(i,4)
+             fluxr(i,18) = fluxr(i,18) + raddt * cldsa(i,5)
+          enddo
+
+          ! Save cld frac,toplyr,botlyr and top temp, note that the order of h,m,l cloud is reversed for 
+          ! the fluxr output. save interface pressure (pa) of top/bot
+          do j = 1, 3
+             do i = 1, nCol
+                tem0d = raddt * cldsa(i,j)
+                itop  = mtopa(i,j)
+                ibtc  = mbota(i,j)
+                fluxr(i, 8-j) = fluxr(i, 8-j) + tem0d
+                fluxr(i,11-j) = fluxr(i,11-j) + tem0d * p_lev(i,itop)
+                fluxr(i,14-j) = fluxr(i,14-j) + tem0d * p_lev(i,ibtc)
+                fluxr(i,17-j) = fluxr(i,17-j) + tem0d * t_lay(i,itop)
+                
+                ! Add optical depth and emissivity output
+                tem2 = 0.
+                do k=ibtc,itop
+                   tem2 = tem2 + cldtaulw(i,k)      ! approx 10. mu channel
+                enddo
+                fluxr(i,46-j) = fluxr(i,46-j) + tem0d * (1.0-exp(-tem2))
+             enddo
+          enddo
     endif
 
   end subroutine GFS_rrtmgp_lw_post_run

--- a/physics/GFS_rrtmgp_lw_post.meta
+++ b/physics/GFS_rrtmgp_lw_post.meta
@@ -180,6 +180,15 @@
   kind = kind_phys
   intent = in
   optional = F
+[fluxr]
+  standard_name = cumulative_radiation_diagnostic
+  long_name = time-accumulated 2D radiation-related diagnostic fields
+  units = various
+  dimensions = (horizontal_loop_extent,number_of_radiation_diagnostic_variables)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
 [sfcdlw]
   standard_name = surface_downwelling_longwave_flux_on_radiation_time_step
   long_name = total sky sfc downward lw flux

--- a/physics/GFS_rrtmgp_sw_post.meta
+++ b/physics/GFS_rrtmgp_sw_post.meta
@@ -145,6 +145,14 @@
   kind = kind_phys
   intent = in
   optional = F
+[sw_gas_props]
+  standard_name = coefficients_for_sw_gas_optics
+  long_name = DDT containing spectral information for RRTMGP SW radiation scheme
+  units = DDT
+  dimensions = ()
+  type = ty_gas_optics_rrtmgp
+  intent = in
+  optional = F
 [fluxswUP_allsky]
   standard_name = RRTMGP_sw_flux_profile_upward_allsky
   long_name = RRTMGP upward shortwave all-sky flux profile
@@ -208,17 +216,17 @@
   kind = kind_phys
   intent = in
   optional = F
-[mtopa]
-  standard_name = model_layer_number_at_cloud_top
-  long_name = vertical indices for low, middle and high cloud tops
+[mbota]
+  standard_name = model_layer_number_at_cloud_base
+  long_name = vertical indices for low, middle and high cloud bases
   units = index
   dimensions = (horizontal_loop_extent,3)
   type = integer
   intent = in
   optional = F
-[mbota]
-  standard_name = model_layer_number_at_cloud_base
-  long_name = vertical indices for low, middle and high cloud bases
+[mtopa]
+  standard_name = model_layer_number_at_cloud_top
+  long_name = vertical indices for low, middle and high cloud tops
   units = index
   dimensions = (horizontal_loop_extent,3)
   type = integer
@@ -242,13 +250,14 @@
   kind = kind_phys
   intent = in
   optional = F
-[sw_gas_props]
-  standard_name = coefficients_for_sw_gas_optics
-  long_name = DDT containing spectral information for RRTMGP SW radiation scheme
-  units = DDT
-  dimensions = ()
-  type = ty_gas_optics_rrtmgp
-  intent = in
+[fluxr]
+  standard_name = cumulative_radiation_diagnostic
+  long_name = time-accumulated 2D radiation-related diagnostic fields
+  units = various
+  dimensions = (horizontal_loop_extent,number_of_radiation_diagnostic_variables)
+  type = real
+  kind = kind_phys
+  intent = inout
   optional = F
 [nirbmdi]
   standard_name = surface_downwelling_direct_near_infrared_shortwave_flux_on_radiation_time_step
@@ -340,14 +349,6 @@
   kind = kind_phys
   intent = out
   optional = F
-[sfcfsw]
-  standard_name = sw_fluxes_sfc
-  long_name = sw radiation fluxes at sfc
-  units = W m-2
-  dimensions = (horizontal_loop_extent)
-  type = sfcfsw_type
-  intent = out
-  optional = F
 [htrsw]
   standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_time_step
   long_name = total sky sw heating rate
@@ -355,6 +356,14 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+  intent = out
+  optional = F
+[sfcfsw]
+  standard_name = sw_fluxes_sfc
+  long_name = sw radiation fluxes at sfc
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = sfcfsw_type
   intent = out
   optional = F
 [topfsw]
@@ -373,15 +382,7 @@
   type = real
   kind = kind_phys
   intent = out
-  optional = T  
-[scmpsw]
-  standard_name = components_of_surface_downward_shortwave_fluxes
-  long_name = derived type for special components of surface downward shortwave fluxes
-  units = W m-2
-  dimensions = (horizontal_loop_extent)
-  type = cmpfsw_type
-  intent = in
-  optional = T   
+  optional = T
 [flxprf_sw]
   standard_name = RRTMGP_sw_fluxes
   long_name = sw fluxes total sky / csk and up / down at levels
@@ -389,7 +390,15 @@
   dimensions = (horizontal_loop_extent,adjusted_vertical_level_dimension_plus_one)
   type = profsw_type
   intent = out
-  optional = T      
+  optional = T
+[scmpsw]
+  standard_name = components_of_surface_downward_shortwave_fluxes
+  long_name = derived type for special components of surface downward shortwave fluxes
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = cmpfsw_type
+  intent = in
+  optional = T
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP

--- a/physics/GFS_rrtmgp_zhaocarr_pre.meta
+++ b/physics/GFS_rrtmgp_zhaocarr_pre.meta
@@ -58,7 +58,7 @@
 [effr_in]
   standard_name = flag_for_cloud_effective_radii
   long_name = flag for cloud effective radii calculations in GFDL microphysics
-  units = 
+  units = flag
   dimensions = ()
   type = logical  
   intent = in
@@ -305,7 +305,7 @@
 [cld_reliq]
   standard_name = mean_effective_radius_for_liquid_cloud
   long_name = mean effective radius for liquid cloud
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
@@ -323,7 +323,7 @@
 [cld_reice]
   standard_name = mean_effective_radius_for_ice_cloud
   long_name = mean effective radius for ice cloud
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
@@ -341,7 +341,7 @@
 [cld_resnow]
   standard_name = mean_effective_radius_for_snow_flake
   long_name = mean effective radius for snow cloud
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
@@ -359,7 +359,7 @@
 [cld_rerain]
   standard_name = mean_effective_radius_for_rain_drop
   long_name = mean effective radius for rain cloud
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys

--- a/physics/GFS_time_vary_pre.fv3.meta
+++ b/physics/GFS_time_vary_pre.fv3.meta
@@ -228,7 +228,7 @@
 [ipt]
   standard_name = index_for_diagnostic_printout
   long_name = horizontal index for point used for diagnostic printout
-  units = 
+  units = index
   dimensions = ()
   type = integer
   intent = out

--- a/physics/GFS_time_vary_pre.fv3.meta
+++ b/physics/GFS_time_vary_pre.fv3.meta
@@ -159,7 +159,7 @@
 [nscyc]
   standard_name = number_of_timesteps_between_surface_cycling_calls
   long_name = number of timesteps between surface cycling calls
-  units = 
+  units = count
   dimensions = ()
   type = integer
   intent = in

--- a/physics/GFS_time_vary_pre.scm.meta
+++ b/physics/GFS_time_vary_pre.scm.meta
@@ -143,7 +143,7 @@
 [nscyc]
   standard_name = number_of_timesteps_between_surface_cycling_calls
   long_name = number of timesteps between surface cycling calls
-  units = 
+  units = count
   dimensions = ()
   type = integer
   intent = in

--- a/physics/gfdl_cloud_microphys.meta
+++ b/physics/gfdl_cloud_microphys.meta
@@ -427,7 +427,7 @@
 [effr_in]
   standard_name = flag_for_cloud_effective_radii
   long_name = flag for cloud effective radii calculations in GFDL microphysics
-  units = 
+  units = flag
   dimensions = ()
   type = logical
   intent = in

--- a/physics/gscond.meta
+++ b/physics/gscond.meta
@@ -105,8 +105,8 @@
   intent = inout
   optional = F
 [tp]
-  standard_name = air_temperature_two_time_steps_back
-  long_name = air temperature two time steps back
+  standard_name = air_temperature_two_timesteps_back
+  long_name = air temperature two timesteps back
   units = K
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
@@ -114,8 +114,8 @@
   intent = inout
   optional = F
 [qp]
-  standard_name = water_vapor_specific_humidity_two_time_steps_back
-  long_name = water vapor specific humidity two time steps back
+  standard_name = water_vapor_specific_humidity_two_timesteps_back
+  long_name = water vapor specific humidity two timesteps back
   units = kg kg-1
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
@@ -123,8 +123,8 @@
   intent = inout
   optional = F
 [psp]
-  standard_name = surface_air_pressure_two_time_steps_back
-  long_name = surface air pressure two time steps back
+  standard_name = surface_air_pressure_two_timesteps_back
+  long_name = surface air pressure two timesteps back
   units = Pa
   dimensions = (horizontal_loop_extent)
   type = real
@@ -132,8 +132,8 @@
   intent = inout
   optional = F
 [tp1]
-  standard_name = air_temperature_at_previous_time_step
-  long_name = air temperature at previous time step
+  standard_name = air_temperature_at_previous_timestep
+  long_name = air temperature at previous timestep
   units = K
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
@@ -141,8 +141,8 @@
   intent = inout
   optional = F
 [qp1]
-  standard_name = water_vapor_specific_humidity_at_previous_time_step
-  long_name = water vapor specific humidity at previous time step
+  standard_name = water_vapor_specific_humidity_at_previous_timestep
+  long_name = water vapor specific humidity at previous timestep
   units = kg kg-1
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
@@ -150,8 +150,8 @@
   intent = inout
   optional = F
 [psp1]
-  standard_name = surface_air_pressure_at_previous_time_step
-  long_name = surface air surface pressure at previous time step
+  standard_name = surface_air_pressure_at_previous_timestep
+  long_name = surface air surface pressure at previous timestep
   units = Pa
   dimensions = (horizontal_loop_extent)
   type = real

--- a/physics/m_micro.meta
+++ b/physics/m_micro.meta
@@ -777,25 +777,25 @@
 [aerfld_i]
   standard_name = aerosol_number_concentration_from_gocart_aerosol_climatology
   long_name = GOCART aerosol climatology number concentration
-  units = kg-1?
+  units = kg-1
   dimensions = (horizontal_loop_extent,vertical_dimension,number_of_aerosol_tracers_MG)
   type = real
   kind = kind_phys
   intent = in
   optional = F
 [naai_i]
-  standard_name = in_number_concentration
-  long_name = IN number concentration
-  units = kg-1?
+  standard_name = ice_nucleation_number
+  long_name = ice nucleation number in MG MP
+  units = kg-1
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
   intent = in
   optional = F
 [npccn_i]
-  standard_name = ccn_number_concentration
-  long_name = CCN number concentration
-  units = kg-1?
+  standard_name = tendency_of_ccn_activated_number
+  long_name = tendency of ccn activated number
+  units = kg-1 s-1
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys

--- a/physics/module_SGSCloud_RadPre.meta
+++ b/physics/module_SGSCloud_RadPre.meta
@@ -211,7 +211,7 @@
 [clouds3]
   standard_name = mean_effective_radius_for_liquid_cloud
   long_name = mean effective radius for liquid cloud
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
@@ -229,7 +229,7 @@
 [clouds5]
   standard_name = mean_effective_radius_for_ice_cloud
   long_name = mean effective radius for ice cloud
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys

--- a/physics/radlw_main.meta
+++ b/physics/radlw_main.meta
@@ -326,7 +326,7 @@
 [cld_ref_liq]
   standard_name = mean_effective_radius_for_liquid_cloud
   long_name = mean effective radius for liquid cloud
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
@@ -344,7 +344,7 @@
 [cld_ref_ice]
   standard_name = mean_effective_radius_for_ice_cloud
   long_name = mean effective radius for ice cloud
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
@@ -362,7 +362,7 @@
 [cld_ref_rain]
   standard_name = mean_effective_radius_for_rain_drop
   long_name = mean effective radius for rain drop
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
@@ -380,7 +380,7 @@
 [cld_ref_snow]
   standard_name = mean_effective_radius_for_snow_flake
   long_name = mean effective radius for snow flake
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys

--- a/physics/radsw_main.meta
+++ b/physics/radsw_main.meta
@@ -395,7 +395,7 @@
 [cld_ref_liq]
   standard_name = mean_effective_radius_for_liquid_cloud
   long_name = mean effective radius for liquid cloud
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
@@ -413,7 +413,7 @@
 [cld_ref_ice]
   standard_name = mean_effective_radius_for_ice_cloud
   long_name = mean effective radius for ice cloud
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
@@ -431,7 +431,7 @@
 [cld_ref_rain]
   standard_name = mean_effective_radius_for_rain_drop
   long_name = mean effective radius for rain drop
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
@@ -449,7 +449,7 @@
 [cld_ref_snow]
   standard_name = mean_effective_radius_for_snow_flake
   long_name = mean effective radius for snow flake
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys

--- a/physics/rrtmg_lw_post.F90
+++ b/physics/rrtmg_lw_post.F90
@@ -11,24 +11,28 @@
 !> \section arg_table_rrtmg_lw_post_run Argument Table
 !! \htmlinclude rrtmg_lw_post_run.html
 !!
-      subroutine rrtmg_lw_post_run (Model, Grid, Radtend, Coupling,   &
-                 im, ltp, lm, kd, tsfa, htlwc, htlw0, errmsg, errflg)
+      subroutine rrtmg_lw_post_run (im, levs, ltp, lm, kd, lslwr, lwhtr,       &
+                 tsfa, htlwc, htlw0, sfcflw, tsflw, sfcdlw, htrlw, lwhc,       &
+                 errmsg, errflg)
     
       use machine,                   only: kind_phys
-      use GFS_typedefs,              only: GFS_coupling_type,          &
-                                           GFS_control_type,           &
-                                           GFS_grid_type,              &
-                                           GFS_radtend_type
+      use module_radlw_parameters,   only: sfcflw_type
+      
       implicit none
-      type(GFS_control_type),         intent(in)    :: Model
-      type(GFS_coupling_type),        intent(inout) :: Coupling
-      type(GFS_grid_type),            intent(in)    :: Grid
-      type(GFS_radtend_type),         intent(inout) :: Radtend
-      integer,                        intent(in)    :: im, ltp, LM, kd
-      real(kind=kind_phys), dimension(size(Grid%xlon,1), lm+LTP), intent(in) :: htlwc, htlw0
-      real(kind=kind_phys), dimension(size(Grid%xlon,1)),         intent(in) :: tsfa
-      character(len=*), intent(out) :: errmsg
-      integer,          intent(out) :: errflg
+      
+      integer,                                     intent(in) :: im, levs, ltp, lm, kd
+      logical,                                     intent(in) :: lslwr, lwhtr
+      real(kind=kind_phys), dimension(im),         intent(in) ::  tsfa
+      real(kind=kind_phys), dimension(im, LM+LTP), intent(in) ::  htlwc
+      real(kind=kind_phys), dimension(im, LM+LTP), intent(in) ::  htlw0
+      
+      type(sfcflw_type), dimension(im),            intent(in) :: sfcflw
+      
+      real(kind=kind_phys), dimension(im),         intent(inout) ::  tsflw, sfcdlw
+      real(kind=kind_phys), dimension(im, levs),   intent(inout) ::  htrlw, lwhc
+      character(len=*),                            intent(out) :: errmsg
+      integer,                                     intent(out) :: errflg
+      
       ! local variables
       integer :: k1, k
 
@@ -36,38 +40,38 @@
       errmsg = ''
       errflg = 0
 
-      if (Model%lslwr) then
+      if (lslwr) then
 !> -# Save calculation results
 !>  - Save surface air temp for diurnal adjustment at model t-steps
 
-        Radtend%tsflw (:) = tsfa(:)
+        tsflw (:) = tsfa(:)
 
         do k = 1, LM
           k1 = k + kd
-            Radtend%htrlw(1:im,k) = htlwc(1:im,k1)
+            htrlw(1:im,k) = htlwc(1:im,k1)
         enddo
         ! --- repopulate the points above levr
-        if (lm < Model%levs) then
-          do k = lm+1,Model%levs
-            Radtend%htrlw (1:im,k) = Radtend%htrlw (1:im,LM)
+        if (lm < levs) then
+          do k = lm+1, levs
+            htrlw (1:im,k) = htrlw (1:im,LM)
           enddo
         endif
 
-        if (Model%lwhtr) then
+        if (lwhtr) then
           do k = 1, lm
             k1 = k + kd
-            Radtend%lwhc(1:im,k) = htlw0(1:im,k1)
+            lwhc(1:im,k) = htlw0(1:im,k1)
           enddo
           ! --- repopulate the points above levr
-          if (lm < Model%levs) then
-            do k = lm+1,Model%levs
-              Radtend%lwhc(1:im,k) = Radtend%lwhc(1:im,LM)
+          if (lm < levs) then
+            do k = lm+1, levs
+              lwhc(1:im,k) = lwhc(1:im,LM)
             enddo
           endif
         endif
 
 ! --- radiation fluxes for other physics processes
-        Coupling%sfcdlw(:) = Radtend%sfcflw(:)%dnfxc
+        sfcdlw(:) = sfcflw(:)%dnfxc
 
       endif                                ! end_if_lslwr
 

--- a/physics/rrtmg_lw_post.meta
+++ b/physics/rrtmg_lw_post.meta
@@ -7,41 +7,17 @@
 [ccpp-arg-table]
   name = rrtmg_lw_post_run
   type = scheme
-[Model]
-  standard_name = GFS_control_type_instance
-  long_name = Fortran DDT containing FV3-GFS model control parameters
-  units = DDT
-  dimensions = ()
-  type = GFS_control_type
-  intent = in
-  optional = F
-[Grid]
-  standard_name = GFS_grid_type_instance
-  long_name = Fortran DDT containing FV3-GFS grid and interpolation related data
-  units = DDT
-  dimensions = ()
-  type = GFS_grid_type
-  intent = in
-  optional = F
-[Radtend]
-  standard_name = GFS_radtend_type_instance
-  long_name = Fortran DDT containing FV3-GFS fields targetted for diagnostic output
-  units = DDT
-  dimensions = ()
-  type = GFS_radtend_type
-  intent = inout
-  optional = F
-[Coupling]
-  standard_name = GFS_coupling_type_instance
-  long_name = Fortran DDT containing FV3-GFS fields to/from coupling with other components
-  units = DDT
-  dimensions = ()
-  type = GFS_coupling_type
-  intent = inout
-  optional = F
 [im]
   standard_name = horizontal_loop_extent
   long_name = horizontal loop extent
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[levs]
+  standard_name = vertical_dimension
+  long_name = number of vertical levels
   units = count
   dimensions = ()
   type = integer
@@ -71,6 +47,22 @@
   type = integer
   intent = in
   optional = F
+[lslwr]
+  standard_name = flag_to_calc_lw
+  long_name = logical flags for lw radiation calls
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[lwhtr]
+  standard_name = flag_for_output_of_longwave_heating_rate
+  long_name = flag to output lw heating rate (Radtend%lwhc)
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
 [tsfa]
   standard_name = surface_air_temperature_for_radiation
   long_name = lowest model layer air temperature for radiation
@@ -97,6 +89,50 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
+[sfcflw]
+  standard_name = lw_fluxes_sfc
+  long_name = lw radiation fluxes at sfc
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = sfcflw_type
+  intent = in
+  optional = F
+[tsflw]
+  standard_name = surface_midlayer_air_temperature_in_longwave_radiation
+  long_name = surface air temp during lw calculation
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[sfcdlw]
+  standard_name = surface_downwelling_longwave_flux_on_radiation_time_step
+  long_name = total sky sfc downward lw flux
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[htrlw]
+  standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_time_step
+  long_name = total sky lw heating rate
+  units = K s-1
+  dimensions = (horizontal_loop_extent,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[lwhc]
+  standard_name = tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_on_radiation_time_step
+  long_name = clear sky lw heating rates
+  units = K s-1
+  dimensions = (horizontal_loop_extent,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
   optional = F
 [errmsg]
   standard_name = ccpp_error_message

--- a/physics/rrtmg_lw_pre.F90
+++ b/physics/rrtmg_lw_pre.F90
@@ -12,37 +12,32 @@
 !> \section arg_table_rrtmg_lw_pre_run Argument Table
 !! \htmlinclude rrtmg_lw_pre_run.html
 !!
-      subroutine rrtmg_lw_pre_run (Model, Grid, Sfcprop, Radtend, im, tsfg, tsfa, errmsg, errflg)
+      subroutine rrtmg_lw_pre_run (im, lslwr, xlat, xlon, slmsk, snowd, sncovr,&
+        zorl, hprime, tsfg, tsfa, semis, errmsg, errflg)
     
       use machine,                   only: kind_phys
-
-      use GFS_typedefs,              only: GFS_control_type,           &
-                                           GFS_grid_type,              &
-                                           GFS_radtend_type,           &
-                                           GFS_sfcprop_type         
       use module_radiation_surface,  only: setemis
 
       implicit none
-      type(GFS_control_type),         intent(in)    :: Model
-      type(GFS_radtend_type),         intent(inout) :: Radtend
-      type(GFS_sfcprop_type),         intent(in)    :: Sfcprop
-      type(GFS_grid_type),            intent(in)    :: Grid
-      integer, intent(in)                           :: im
-      real(kind=kind_phys), dimension(size(Grid%xlon,1)), intent(in) :: tsfa, tsfg
-      character(len=*), intent(out) :: errmsg
-      integer,          intent(out) :: errflg
+      
+      integer,                              intent(in)  :: im
+      logical,                              intent(in)  :: lslwr
+      real(kind=kind_phys), dimension(im),  intent(in)  :: xlat, xlon, slmsk,  &
+        snowd, sncovr, zorl, hprime, tsfg, tsfa 
+      real(kind=kind_phys), dimension(im),  intent(out) :: semis
+      character(len=*),                     intent(out) :: errmsg
+      integer,                              intent(out) :: errflg
 
       ! Initialize CCPP error handling variables
       errmsg = ''
       errflg = 0
 
-      if (Model%lslwr) then
+      if (lslwr) then
 !>  - Call module_radiation_surface::setemis(),to setup surface
 !! emissivity for LW radiation.
-        call setemis (Grid%xlon, Grid%xlat, Sfcprop%slmsk,        &        !  ---  inputs
-                     Sfcprop%snowd, Sfcprop%sncovr, Sfcprop%zorl, &
-                     tsfg, tsfa, Sfcprop%hprime(:,1), IM,         &
-                      Radtend%semis)                                       !  ---  outputs
+        call setemis (xlon, xlat, slmsk, snowd, sncovr, zorl, tsfg, tsfa,      &
+                      hprime, im,                                              & !  ---  inputs
+                      semis)                              !  ---  outputs
       endif
 
       end subroutine rrtmg_lw_pre_run

--- a/physics/rrtmg_lw_pre.meta
+++ b/physics/rrtmg_lw_pre.meta
@@ -7,44 +7,83 @@
 [ccpp-arg-table]
   name = rrtmg_lw_pre_run
   type = scheme
-[Model]
-  standard_name = GFS_control_type_instance
-  long_name = Fortran DDT containing FV3-GFS model control parameters
-  units = DDT
-  dimensions = ()
-  type = GFS_control_type
-  intent = in
-  optional = F
-[Grid]
-  standard_name = GFS_grid_type_instance
-  long_name = Fortran DDT containing FV3-GFS grid and interpolation related data
-  units = DDT
-  dimensions = ()
-  type = GFS_grid_type
-  intent = in
-  optional = F
-[Sfcprop]
-  standard_name = GFS_sfcprop_type_instance
-  long_name = Fortran DDT containing FV3-GFS surface fields
-  units = DDT
-  dimensions = ()
-  type = GFS_sfcprop_type
-  intent = in
-  optional = F
-[Radtend]
-  standard_name = GFS_radtend_type_instance
-  long_name = Fortran DDT containing FV3-GFS radiation tendencies
-  units = DDT
-  dimensions = ()
-  type = GFS_radtend_type
-  intent = inout
-  optional = F
 [im]
   standard_name = horizontal_loop_extent
   long_name = horizontal loop extent
   units = count
   dimensions = ()
   type = integer
+  intent = in
+  optional = F
+[lslwr]
+  standard_name = flag_to_calc_lw
+  long_name = logical flags for lw radiation calls
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[xlat]
+  standard_name = latitude
+  long_name = latitude
+  units = radian
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[xlon]
+  standard_name = longitude
+  long_name = longitude
+  units = radian
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[slmsk]
+  standard_name = sea_land_ice_mask_real
+  long_name = landmask: sea/land/ice=0/1/2
+  units = flag
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[snowd]
+  standard_name = surface_snow_thickness_water_equivalent
+  long_name = water equivalent snow depth
+  units = mm
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[sncovr]
+  standard_name = surface_snow_area_fraction_over_land
+  long_name = surface snow area fraction
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[zorl]
+  standard_name = surface_roughness_length
+  long_name = surface roughness length
+  units = cm
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[hprime]
+  standard_name = standard_deviation_of_subgrid_orography
+  long_name = standard deviation of subgrid orography
+  units = m
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
   intent = in
   optional = F
 [tsfg]
@@ -64,6 +103,15 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
+[semis]
+  standard_name = surface_longwave_emissivity
+  long_name = surface lw emissivity in fraction
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
   optional = F
 [errmsg]
   standard_name = ccpp_error_message

--- a/physics/rrtmg_sw_post.F90
+++ b/physics/rrtmg_sw_post.F90
@@ -11,29 +11,36 @@
 !> \section arg_table_rrtmg_sw_post_run Argument Table
 !! \htmlinclude rrtmg_sw_post_run.html
 !!
-      subroutine rrtmg_sw_post_run (Model, Grid, Diag, Radtend, Coupling,  &
-                 im, ltp, nday, lm, kd, htswc, htsw0,                      &
-                 sfcalb1, sfcalb2, sfcalb3, sfcalb4, scmpsw, errmsg, errflg)
+      subroutine rrtmg_sw_post_run (im, levr, levs, ltp, nday, lm, kd, lsswr,  &
+                 swhtr, sfcalb1, sfcalb2, sfcalb3, sfcalb4, htswc, htsw0,      &
+                 nirbmdi, nirdfdi, visbmdi, visdfdi, nirbmui, nirdfui, visbmui,&
+                 visdfui, sfcdsw, sfcnsw, htrsw, swhc, scmpsw, sfcfsw, topfsw, &
+                 errmsg, errflg)
 
       use machine,                   only: kind_phys
       use module_radsw_parameters,   only: topfsw_type, sfcfsw_type,   &
                                            cmpfsw_type
-      use GFS_typedefs,              only: GFS_coupling_type,          &
-                                           GFS_control_type,           &
-                                           GFS_grid_type,              &
-                                           GFS_radtend_type,           &
-                                           GFS_diag_type
 
       implicit none
-      type(GFS_control_type),         intent(in)    :: Model
-      type(GFS_coupling_type),        intent(inout) :: Coupling
-      type(GFS_radtend_type),         intent(inout) :: Radtend
-      type(GFS_grid_type),            intent(in)    :: Grid
-      type(GFS_diag_type),            intent(inout) :: Diag
-      integer,                        intent(in)    :: im, lm, kd, nday, ltp
-      type(cmpfsw_type),    dimension(size(Grid%xlon,1)), intent(inout) :: scmpsw
-      real(kind=kind_phys), dimension(Size(Grid%xlon,1), lm+LTP), intent(in) ::  htswc, htsw0
-      real(kind=kind_phys), dimension(size(Grid%xlon,1)), intent(in) :: sfcalb1, sfcalb2, sfcalb3, sfcalb4
+
+      integer,                              intent(in)    :: im, levr, levs,   &
+                                                             ltp, nday, lm, kd   
+      logical,                              intent(in)    :: lsswr, swhtr
+      real(kind=kind_phys), dimension(im),  intent(in)    :: sfcalb1, sfcalb2, &
+                                                             sfcalb3, sfcalb4
+      real(kind=kind_phys), dimension(im, levr+LTP), intent(in) ::  htswc, htsw0
+      
+      real(kind=kind_phys), dimension(im),  intent(inout) :: nirbmdi, nirdfdi, &
+                                                             visbmdi, visdfdi, &
+                                                             nirbmui, nirdfui, &
+                                                             visbmui, visdfui, &
+                                                             sfcdsw,  sfcnsw
+      real(kind=kind_phys), dimension(im,levs), intent(inout) :: htrsw, swhc
+
+      type(cmpfsw_type), dimension(im),     intent(inout) :: scmpsw
+      type(sfcfsw_type), dimension(im),     intent(inout) :: sfcfsw
+      type(topfsw_type), dimension(im),     intent(inout) :: topfsw
+
       character(len=*), intent(out) :: errmsg
       integer,          intent(out) :: errflg
       ! Local variables
@@ -43,29 +50,29 @@
       errmsg = ''
       errflg = 0
 
-      if (Model%lsswr) then
+      if (lsswr) then
         if (nday > 0) then
           do k = 1, LM
             k1 = k + kd
-            Radtend%htrsw(1:im,k) = htswc(1:im,k1)
+            htrsw(1:im,k) = htswc(1:im,k1)
           enddo
           ! We are assuming that radiative tendencies are from bottom to top 
           ! --- repopulate the points above levr i.e. LM
-          if (lm < Model%levs) then
-            do k = lm+1,Model%levs
-              Radtend%htrsw (1:im,k) = Radtend%htrsw (1:im,LM)
+          if (lm < levs) then
+            do k = lm+1, levs
+              htrsw (1:im,k) = htrsw (1:im,LM)
             enddo
           endif
 
-          if (Model%swhtr) then
+          if (swhtr) then
             do k = 1, lm
                k1 = k + kd
-               Radtend%swhc(1:im,k) = htsw0(1:im,k1)
+               swhc(1:im,k) = htsw0(1:im,k1)
              enddo
              ! --- repopulate the points above levr i.e. LM
-             if (lm < Model%levs) then
-               do k = lm+1,Model%levs
-                 Radtend%swhc(1:im,k) = Radtend%swhc(1:im,LM)
+             if (lm < levs) then
+               do k = lm+1, levs
+                 swhc(1:im,k) = swhc(1:im,LM)
                enddo
              endif
           endif
@@ -75,47 +82,47 @@
 !!    output.
 
           do i=1,im
-            Coupling%nirbmdi(i) = scmpsw(i)%nirbm
-            Coupling%nirdfdi(i) = scmpsw(i)%nirdf
-            Coupling%visbmdi(i) = scmpsw(i)%visbm
-            Coupling%visdfdi(i) = scmpsw(i)%visdf
+            nirbmdi(i) = scmpsw(i)%nirbm
+            nirdfdi(i) = scmpsw(i)%nirdf
+            visbmdi(i) = scmpsw(i)%visbm
+            visdfdi(i) = scmpsw(i)%visdf
 
-            Coupling%nirbmui(i) = scmpsw(i)%nirbm * sfcalb1(i)
-            Coupling%nirdfui(i) = scmpsw(i)%nirdf * sfcalb2(i)
-            Coupling%visbmui(i) = scmpsw(i)%visbm * sfcalb3(i)
-            Coupling%visdfui(i) = scmpsw(i)%visdf * sfcalb4(i)
+            nirbmui(i) = scmpsw(i)%nirbm * sfcalb1(i)
+            nirdfui(i) = scmpsw(i)%nirdf * sfcalb2(i)
+            visbmui(i) = scmpsw(i)%visbm * sfcalb3(i)
+            visdfui(i) = scmpsw(i)%visdf * sfcalb4(i)
           enddo
 
         else                   ! if_nday_block
 
-          Radtend%htrsw(:,:) = 0.0
+          htrsw(:,:) = 0.0
 
-          Radtend%sfcfsw = sfcfsw_type( 0.0, 0.0, 0.0, 0.0 )
-          Diag%topfsw    = topfsw_type( 0.0, 0.0, 0.0 )
-          scmpsw         = cmpfsw_type( 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 )
+          sfcfsw = sfcfsw_type( 0.0, 0.0, 0.0, 0.0 )
+          topfsw = topfsw_type( 0.0, 0.0, 0.0 )
+          scmpsw = cmpfsw_type( 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 )
 
           do i=1,im
-            Coupling%nirbmdi(i) = 0.0
-            Coupling%nirdfdi(i) = 0.0
-            Coupling%visbmdi(i) = 0.0
-            Coupling%visdfdi(i) = 0.0
+            nirbmdi(i) = 0.0
+            nirdfdi(i) = 0.0
+            visbmdi(i) = 0.0
+            visdfdi(i) = 0.0
 
-            Coupling%nirbmui(i) = 0.0
-            Coupling%nirdfui(i) = 0.0
-            Coupling%visbmui(i) = 0.0
-            Coupling%visdfui(i) = 0.0
+            nirbmui(i) = 0.0
+            nirdfui(i) = 0.0
+            visbmui(i) = 0.0
+            visdfui(i) = 0.0
           enddo
 
-          if (Model%swhtr) then
-            Radtend%swhc(:,:) = 0
+          if (swhtr) then
+            swhc(:,:) = 0
           endif
 
         endif                  ! end_if_nday
 
 ! --- radiation fluxes for other physics processes
         do i=1,im
-          Coupling%sfcnsw(i) = Radtend%sfcfsw(i)%dnfxc - Radtend%sfcfsw(i)%upfxc
-          Coupling%sfcdsw(i) = Radtend%sfcfsw(i)%dnfxc
+          sfcnsw(i) = sfcfsw(i)%dnfxc - sfcfsw(i)%upfxc
+          sfcdsw(i) = sfcfsw(i)%dnfxc
         enddo
 
       endif                                ! end_if_lsswr

--- a/physics/rrtmg_sw_post.meta
+++ b/physics/rrtmg_sw_post.meta
@@ -7,49 +7,25 @@
 [ccpp-arg-table]
   name = rrtmg_sw_post_run
   type = scheme
-[Model]
-  standard_name = GFS_control_type_instance
-  long_name = Fortran DDT containing FV3-GFS model control parameters
-  units = DDT
-  dimensions = ()
-  type = GFS_control_type
-  intent = in
-  optional = F
-[Grid]
-  standard_name = GFS_grid_type_instance
-  long_name = Fortran DDT containing FV3-GFS grid and interpolation related data
-  units = DDT
-  dimensions = ()
-  type = GFS_grid_type
-  intent = in
-  optional = F
-[Diag]
-  standard_name = GFS_diag_type_instance
-  long_name = Fortran DDT containing FV3-GFS diagnotics data
-  units = DDT
-  dimensions = ()
-  type = GFS_diag_type
-  intent = inout
-  optional = F
-[Radtend]
-  standard_name = GFS_radtend_type_instance
-  long_name = Fortran DDT containing FV3-GFS fields targetted for diagnostic output
-  units = DDT
-  dimensions = ()
-  type = GFS_radtend_type
-  intent = inout
-  optional = F
-[Coupling]
-  standard_name = GFS_coupling_type_instance
-  long_name = Fortran DDT containing FV3-GFS fields to/from coupling with other components
-  units = DDT
-  dimensions = ()
-  type = GFS_coupling_type
-  intent = inout
-  optional = F
 [im]
   standard_name = horizontal_loop_extent
-  long_name = horizontal loop extent
+  long_name = horizontal loop extents
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[levr]
+  standard_name = adjusted_vertical_layer_dimension_for_radiation
+  long_name = adjusted number of vertical layers for radiation
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[levs]
+  standard_name = vertical_dimension
+  long_name = number of vertical levels
   units = count
   dimensions = ()
   type = integer
@@ -87,22 +63,20 @@
   type = integer
   intent = in
   optional = F
-[htswc]
-  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_time_step_and_radiation_levels
-  long_name = total sky heating rate due to shortwave radiation
-  units = K s-1
-  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
-  type = real
-  kind = kind_phys
+[lsswr]
+  standard_name = flag_to_calc_sw
+  long_name = logical flags for sw radiation calls
+  units = flag
+  dimensions = ()
+  type = logical
   intent = in
   optional = F
-[htsw0]
-  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_on_radiation_time_step_and_radiation_levels
-  long_name = clear sky heating rates due to shortwave radiation
-  units = K s-1
-  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
-  type = real
-  kind = kind_phys
+[swhtr]
+  standard_name = flag_for_output_of_shortwave_heating_rate
+  long_name = flag to output sw heating rate (Radtend%swhc)
+  units = flag
+  dimensions = ()
+  type = logical
   intent = in
   optional = F
 [sfcalb1]
@@ -141,12 +115,154 @@
   kind = kind_phys
   intent = in
   optional = F
+[htswc]
+  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_time_step_and_radiation_levels
+  long_name = total sky heating rate due to shortwave radiation
+  units = K s-1
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[htsw0]
+  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_on_radiation_time_step_and_radiation_levels
+  long_name = clear sky heating rates due to shortwave radiation
+  units = K s-1
+  dimensions = (horizontal_loop_extent,adjusted_vertical_layer_dimension_for_radiation)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[nirbmdi]
+  standard_name = surface_downwelling_direct_near_infrared_shortwave_flux_on_radiation_time_step
+  long_name = sfc nir beam sw downward flux
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[nirdfdi]
+  standard_name = surface_downwelling_diffuse_near_infrared_shortwave_flux_on_radiation_time_step
+  long_name = sfc nir diff sw downward flux
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[visbmdi]
+  standard_name = surface_downwelling_direct_ultraviolet_and_visible_shortwave_flux_on_radiation_time_step
+  long_name = sfc uv+vis beam sw downward flux
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[visdfdi]
+  standard_name = surface_downwelling_diffuse_ultraviolet_and_visible_shortwave_flux_on_radiation_time_step
+  long_name = sfc uv+vis diff sw downward flux
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[nirbmui]
+  standard_name = surface_upwelling_direct_near_infrared_shortwave_flux_on_radiation_time_step
+  long_name = sfc nir beam sw upward flux
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[nirdfui]
+  standard_name = surface_upwelling_diffuse_near_infrared_shortwave_flux_on_radiation_time_step
+  long_name = sfc nir diff sw upward flux
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[visbmui]
+  standard_name = surface_upwelling_direct_ultraviolet_and_visible_shortwave_flux_on_radiation_time_step
+  long_name = sfc uv+vis beam sw upward flux
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[visdfui]
+  standard_name = surface_upwelling_diffuse_ultraviolet_and_visible_shortwave_flux_on_radiation_time_step
+  long_name = sfc uv+vis diff sw upward flux
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[sfcdsw]
+  standard_name = surface_downwelling_shortwave_flux_on_radiation_time_step
+  long_name = total sky sfc downward sw flux
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[sfcnsw]
+  standard_name = surface_net_downwelling_shortwave_flux_on_radiation_time_step
+  long_name = total sky sfc netsw flx into ground
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[htrsw]
+  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_time_step
+  long_name = total sky sw heating rate
+  units = K s-1
+  dimensions = (horizontal_loop_extent,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[swhc]
+  standard_name = tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_on_radiation_time_step
+  long_name = clear sky sw heating rates
+  units = K s-1
+  dimensions = (horizontal_loop_extent,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
 [scmpsw]
   standard_name = components_of_surface_downward_shortwave_fluxes
   long_name = derived type for special components of surface downward shortwave fluxes
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = cmpfsw_type
+  intent = inout
+  optional = F
+[sfcfsw]
+  standard_name = sw_fluxes_sfc
+  long_name = sw radiation fluxes at sfc
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = sfcfsw_type
+  intent = inout
+  optional = F
+[topfsw]
+  standard_name = sw_fluxes_top_atmosphere
+  long_name = sw radiation fluxes at toa
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = topfsw_type
   intent = inout
   optional = F
 [errmsg]

--- a/physics/rrtmg_sw_pre.F90
+++ b/physics/rrtmg_sw_pre.F90
@@ -12,35 +12,40 @@
 !> \section arg_table_rrtmg_sw_pre_run Argument Table
 !! \htmlinclude rrtmg_sw_pre_run.html
 !!
-      subroutine rrtmg_sw_pre_run (Model, Grid, Sfcprop, Radtend, im, &
-        nday, idxday, tsfg, tsfa, sfcalb1, sfcalb2, sfcalb3, sfcalb4, &
-        alb1d, errmsg, errflg)
+      subroutine rrtmg_sw_pre_run (im, lndp_type, n_var_lndp, lsswr, lndp_var_list, lndp_prt_list, tsfg, tsfa, coszen,     &
+        alb1d, slmsk, snowd, sncovr, snoalb, zorl, hprime, alvsf, alnsf, alvwf,&
+        alnwf, facsf, facwf, fice, tisfc, sfalb, nday, idxday, sfcalb1,        &
+        sfcalb2, sfcalb3, sfcalb4, errmsg, errflg)
 
       use machine,                   only: kind_phys
 
-      use GFS_typedefs,              only: GFS_control_type,           &
-                                           GFS_grid_type,              &
-                                           GFS_radtend_type,           &
-                                           GFS_sfcprop_type
       use module_radiation_surface,  only: NF_ALBD, setalb
 
       implicit none
 
-      type(GFS_control_type),         intent(in)    :: Model
-      type(GFS_radtend_type),         intent(inout) :: Radtend
-      type(GFS_sfcprop_type),         intent(in)    :: Sfcprop
-      type(GFS_grid_type),            intent(in)    :: Grid
-      integer,                        intent(in)    :: im
-      integer,                        intent(out)   :: nday
-      integer, dimension(size(Grid%xlon,1)), intent(out) :: idxday
-      real(kind=kind_phys), dimension(size(Grid%xlon,1)), intent(in)  :: tsfa, tsfg
-      real(kind=kind_phys), dimension(size(Grid%xlon,1)), intent(out) :: sfcalb1, sfcalb2, sfcalb3, sfcalb4
-      real(kind=kind_phys), dimension(size(Grid%xlon,1)), intent(in)  :: alb1d
-      character(len=*), intent(out) :: errmsg
-      integer,          intent(out) :: errflg
+      integer,                              intent(in)    :: im, lndp_type, n_var_lndp
+      character(len=3)    , dimension(:),   intent(in)    :: lndp_var_list
+      logical,                              intent(in)    :: lsswr
+      real(kind=kind_phys), dimension(:),   intent(in)    :: lndp_prt_list
+      real(kind=kind_phys), dimension(im),  intent(in)    :: tsfg, tsfa, coszen
+      real(kind=kind_phys), dimension(im),  intent(in)    :: alb1d
+      real(kind=kind_phys), dimension(im),  intent(in)    :: slmsk, snowd,     &
+                                                             sncovr, snoalb,   &
+                                                             zorl, hprime,     &
+                                                             alvsf, alnsf,     &
+                                                             alvwf, alnwf,     &
+                                                             facsf, facwf,     &
+                                                             fice, tisfc
+      real(kind=kind_phys), dimension(im),  intent(inout) :: sfalb
+      integer,                              intent(out)   :: nday
+      integer, dimension(im),               intent(out)   :: idxday
+      real(kind=kind_phys), dimension(im),  intent(out)   :: sfcalb1, sfcalb2, &
+                                                             sfcalb3, sfcalb4
+      character(len=*),                     intent(out)   :: errmsg
+      integer,                              intent(out)   :: errflg
       ! Local variables
       integer :: i
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),NF_ALBD) :: sfcalb
+      real(kind=kind_phys), dimension(im,NF_ALBD) :: sfcalb
 
       real(kind=kind_phys) :: lndp_alb
 
@@ -51,13 +56,13 @@
 !  --- ...  start radiation calculations
 !           remember to set heating rate unit to k/sec!
 !> -# Start SW radiation calculations
-      if (Model%lsswr) then
+      if (lsswr) then
 
 !>  - Check for daytime points for SW radiation.
         nday = 0
         idxday = 0
         do i = 1, IM
-          if (Radtend%coszen(i) >= 0.0001) then
+          if (coszen(i) >= 0.0001) then
             nday = nday + 1
             idxday(nday) = i
           endif
@@ -65,10 +70,10 @@
 
 ! set albedo pert, if requested.
         lndp_alb = -999.
-        if (Model%lndp_type==1) then
-          do i =1,Model%n_var_lndp
-            if (Model%lndp_var_list(i) == 'alb') then
-                lndp_alb = Model%lndp_prt_list(i)
+        if (lndp_type==1) then
+          do i =1,n_var_lndp
+            if (lndp_var_list(i) == 'alb') then
+                lndp_alb = lndp_prt_list(i)
             endif
           enddo
         endif
@@ -76,17 +81,13 @@
 !>  - Call module_radiation_surface::setalb() to setup surface albedo.
 !!  for SW radiation.
 
-        call setalb (Sfcprop%slmsk, Sfcprop%snowd, Sfcprop%sncovr,   &  !  ---  inputs:
-                     Sfcprop%snoalb, Sfcprop%zorl, Radtend%coszen,   &
-                     tsfg, tsfa, Sfcprop%hprime(:,1), Sfcprop%alvsf, &
-                     Sfcprop%alnsf, Sfcprop%alvwf, Sfcprop%alnwf,    &
-                     Sfcprop%facsf, Sfcprop%facwf, Sfcprop%fice,     &
-                     Sfcprop%tisfc, IM,                              &
-                     alb1d, lndp_alb,                           &  !  mg, sfc-perts
+        call setalb (slmsk, snowd, sncovr, snoalb, zorl,  coszen, tsfg, tsfa,  &  !  ---  inputs
+                     hprime, alvsf, alnsf, alvwf, alnwf, facsf, facwf, fice,   &
+                     tisfc, IM, alb1d, lndp_alb,                               &  !  mg, sfc-perts
                      sfcalb)                                           !  ---  outputs
 
 !> -# Approximate mean surface albedo from vis- and nir-  diffuse values.
-        Radtend%sfalb(:) = max(0.01, 0.5 * (sfcalb(:,2) + sfcalb(:,4)))
+        sfalb(:) = max(0.01, 0.5 * (sfcalb(:,2) + sfcalb(:,4)))
       else
         nday   = 0
         idxday = 0

--- a/physics/rrtmg_sw_pre.meta
+++ b/physics/rrtmg_sw_pre.meta
@@ -7,38 +7,6 @@
 [ccpp-arg-table]
   name = rrtmg_sw_pre_run
   type = scheme
-[Model]
-  standard_name = GFS_control_type_instance
-  long_name = Fortran DDT containing FV3-GFS model control parameters
-  units = DDT
-  dimensions = ()
-  type = GFS_control_type
-  intent = in
-  optional = F
-[Grid]
-  standard_name = GFS_grid_type_instance
-  long_name = Fortran DDT containing FV3-GFS grid and interpolation related data
-  units = DDT
-  dimensions = ()
-  type = GFS_grid_type
-  intent = in
-  optional = F
-[Sfcprop]
-  standard_name = GFS_sfcprop_type_instance
-  long_name = Fortran DDT containing FV3-GFS surface fields
-  units = DDT
-  dimensions = ()
-  type = GFS_sfcprop_type
-  intent = in
-  optional = F
-[Radtend]
-  standard_name = GFS_radtend_type_instance
-  long_name = Fortran DDT containing FV3-GFS radiation tendencies
-  units = DDT
-  dimensions = ()
-  type = GFS_radtend_type
-  intent = inout
-  optional = F
 [im]
   standard_name = horizontal_loop_extent
   long_name = horizontal loop extent
@@ -47,21 +15,47 @@
   type = integer
   intent = in
   optional = F
-[nday]
-  standard_name = daytime_points_dimension
-  long_name = daytime points dimension
+[lndp_type]
+  standard_name = index_for_stochastic_land_surface_perturbation_type
+  long_name = index for stochastic land surface perturbations type
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[n_var_lndp]
+  standard_name = number_of_land_surface_variables_perturbed
+  long_name = number of land surface variables perturbed
   units = count
   dimensions = ()
   type = integer
-  intent = out
+  intent = in
   optional = F
-[idxday]
-  standard_name = daytime_points
-  long_name = daytime points
-  units = index
-  dimensions = (horizontal_loop_extent)
-  type = integer
-  intent = out
+[lsswr]
+  standard_name = flag_to_calc_sw
+  long_name = logical flags for sw radiation calls
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[lndp_var_list]
+  standard_name = variables_to_be_perturbed_for_landperts
+  long_name = variables to be perturbed for landperts
+  units = none
+  dimensions =  (number_of_land_surface_variables_perturbed) 
+  type = character
+  kind = len=3
+  intent = in
+  optional = F
+[lndp_prt_list]
+  standard_name = magnitude_of_perturbations_for_landperts
+  long_name = magnitude of perturbations for landperts
+  units = variable
+  dimensions = (number_of_land_surface_variables_perturbed) 
+  type = real
+  kind = kind_phys
+  intent = in
   optional = F
 [tsfg]
   standard_name = surface_ground_temperature_for_radiation
@@ -80,6 +74,175 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
+[coszen]
+  standard_name = cosine_of_zenith_angle
+  long_name = mean cos of zenith angle over rad call period
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[alb1d]
+  standard_name = surface_albedo_perturbation
+  long_name = surface albedo perturbation
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[slmsk]
+  standard_name = sea_land_ice_mask_real
+  long_name = landmask: sea/land/ice=0/1/2
+  units = flag
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[snowd]
+  standard_name = surface_snow_thickness_water_equivalent
+  long_name = water equivalent snow depth
+  units = mm
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[sncovr]
+  standard_name = surface_snow_area_fraction_over_land
+  long_name = surface snow area fraction
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[snoalb]
+  standard_name = upper_bound_on_max_albedo_over_deep_snow
+  long_name = maximum snow albedo
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[zorl]
+  standard_name = surface_roughness_length
+  long_name = surface roughness length
+  units = cm
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[hprime]
+  standard_name = standard_deviation_of_subgrid_orography
+  long_name = standard deviation of subgrid orography
+  units = m
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[alvsf]
+  standard_name = mean_vis_albedo_with_strong_cosz_dependency
+  long_name = mean vis albedo with strong cosz dependency
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[alnsf]
+  standard_name = mean_nir_albedo_with_strong_cosz_dependency
+  long_name = mean nir albedo with strong cosz dependency
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[alvwf]
+  standard_name = mean_vis_albedo_with_weak_cosz_dependency
+  long_name = mean vis albedo with weak cosz dependency
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[alnwf]
+  standard_name = mean_nir_albedo_with_weak_cosz_dependency
+  long_name = mean nir albedo with weak cosz dependency
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[facsf]
+  standard_name = fractional_coverage_with_strong_cosz_dependency
+  long_name = fractional coverage with strong cosz dependency
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[facwf]
+  standard_name = fractional_coverage_with_weak_cosz_dependency
+  long_name = fractional coverage with weak cosz dependency
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[fice]
+  standard_name = sea_ice_concentration
+  long_name = ice fraction over open water
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[tisfc]
+  standard_name = sea_ice_temperature
+  long_name = sea ice surface skin temperature
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[sfalb]
+  standard_name = surface_diffused_shortwave_albedo
+  long_name = mean surface diffused sw albedo
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[nday]
+  standard_name = daytime_points_dimension
+  long_name = daytime points dimension
+  units = count
+  dimensions = ()
+  type = integer
+  intent = out
+  optional = F
+[idxday]
+  standard_name = daytime_points
+  long_name = daytime points
+  units = index
+  dimensions = (horizontal_loop_extent)
+  type = integer
+  intent = out
   optional = F
 [sfcalb1]
   standard_name = surface_albedo_due_to_near_IR_direct
@@ -116,15 +279,6 @@
   type = real
   kind = kind_phys
   intent = out
-  optional = F
-[alb1d]
-  standard_name = surface_albedo_perturbation
-  long_name = surface albedo perturbation
-  units = frac
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = in
   optional = F
 [errmsg]
   standard_name = ccpp_error_message

--- a/physics/rrtmgp_lw_aerosol_optics.meta
+++ b/physics/rrtmgp_lw_aerosol_optics.meta
@@ -113,7 +113,7 @@
 [aerfld]
   standard_name = aerosol_number_concentration_from_gocart_aerosol_climatology
   long_name = GOCART aerosol climatology number concentration
-  units = kg-1?
+  units = kg-1
   dimensions = (horizontal_loop_extent,vertical_dimension,number_of_aerosol_tracers_MG)
   type = real
   kind = kind_phys

--- a/physics/rrtmgp_lw_cloud_optics.meta
+++ b/physics/rrtmgp_lw_cloud_optics.meta
@@ -186,7 +186,7 @@
 [cld_reliq]
   standard_name = mean_effective_radius_for_liquid_cloud
   long_name = mean effective radius for liquid cloud
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   intent = in
@@ -202,7 +202,7 @@
 [cld_reice]
   standard_name = mean_effective_radius_for_ice_cloud
   long_name = mean effective radius for ice cloud
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   intent = in
@@ -218,7 +218,7 @@
 [cld_resnow]
   standard_name = mean_effective_radius_for_snow_flake
   long_name = mean effective radius for snow flake
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   intent = in
@@ -234,7 +234,7 @@
 [cld_rerain]
   standard_name = mean_effective_radius_for_rain_drop
   long_name = mean effective radius for rain drop
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   intent = in

--- a/physics/rrtmgp_lw_pre.F90
+++ b/physics/rrtmgp_lw_pre.F90
@@ -2,12 +2,6 @@ module rrtmgp_lw_pre
   use physparam
   use machine, only: &
        kind_phys                   ! Working type
-  use GFS_typedefs, only:        &
-       GFS_control_type,         & !
-       GFS_sfcprop_type,         & ! Surface fields
-       GFS_grid_type,            & ! Grid and interpolation related data
-       GFS_statein_type,         & !
-       GFS_radtend_type            ! Radiation tendencies needed in physics
   use module_radiation_surface,  only: &
        setemis                     ! Routine to compute surface-emissivity
   use mo_gas_optics_rrtmgp,  only: &

--- a/physics/rrtmgp_sw_aerosol_optics.meta
+++ b/physics/rrtmgp_sw_aerosol_optics.meta
@@ -129,7 +129,7 @@
 [aerfld]
   standard_name = aerosol_number_concentration_from_gocart_aerosol_climatology
   long_name = GOCART aerosol climatology number concentration
-  units = kg-1?
+  units = kg-1
   dimensions = (horizontal_loop_extent,vertical_dimension,number_of_aerosol_tracers_MG)
   type = real
   kind = kind_phys

--- a/physics/rrtmgp_sw_cloud_optics.meta
+++ b/physics/rrtmgp_sw_cloud_optics.meta
@@ -188,7 +188,7 @@
 [cld_reliq]
   standard_name = mean_effective_radius_for_liquid_cloud
   long_name = mean effective radius for liquid cloud
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
@@ -206,7 +206,7 @@
 [cld_reice]
   standard_name = mean_effective_radius_for_ice_cloud
   long_name = mean effective radius for ice cloud
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
@@ -224,7 +224,7 @@
 [cld_resnow]
   standard_name = mean_effective_radius_for_snow_flake
   long_name = mean effective radius for snow cloud
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
@@ -242,7 +242,7 @@
 [cld_rerain]
   standard_name = mean_effective_radius_for_rain_drop
   long_name = mean effective radius for rain cloud
-  units = micron
+  units = um
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys


### PR DESCRIPTION
This PR contains

- GFS DDT removal from radiation physics, https://github.com/NCAR/ccpp-physics/pull/493
- correct_unit branch, https://github.com/NCAR/ccpp-physics/pull/496

updated with the latest code in feature/transition-to-capgen-1

Associated PRs:

https://github.com/NCAR/ccpp-physics/pull/506
https://github.com/NCAR/ccpp-framework/pull/327
https://github.com/NCAR/fv3atm/pull/64
https://github.com/NCAR/ufs-weather-model/pull/65

For regression testing information, see https://github.com/NCAR/ufs-weather-model/pull/65.
