### PR TITLE
Bug fix: restart can reproduce with lake ice

### DIFF
--- a/physics/GFS_surface_composites.F90
+++ b/physics/GFS_surface_composites.F90
@@ -31,7 +31,7 @@ contains
                                  tprcp_lnd, tprcp_ice, uustar, uustar_wat, uustar_lnd, uustar_ice,              &
                                  weasd, weasd_wat, weasd_lnd, weasd_ice, ep1d_ice, tsfc, tsfco, tsfcl, tsfc_wat,&
                                  tsfc_lnd, tsfc_ice, tisfc, tice, tsurf, tsurf_wat, tsurf_lnd, tsurf_ice,       &
-                                 gflx_ice, tgice, islmsk, semis_rad, semis_wat, semis_lnd, semis_ice,           &
+                                 gflx_ice, tgice, islmsk, slmsk, semis_rad, semis_wat, semis_lnd, semis_ice,           &
                                  qss, qss_wat, qss_lnd, qss_ice, hflx, hflx_wat, hflx_lnd, hflx_ice,            &
                                  min_lakeice, min_seaice, errmsg, errflg)
 
@@ -57,7 +57,7 @@ contains
       real(kind=kind_phys),                intent(in   ) :: tgice
       integer,              dimension(im), intent(inout) :: islmsk
       real(kind=kind_phys), dimension(im), intent(in   ) :: semis_rad
-      real(kind=kind_phys), dimension(im), intent(inout) :: semis_wat, semis_lnd, semis_ice
+      real(kind=kind_phys), dimension(im), intent(inout) :: semis_wat, semis_lnd, semis_ice, slmsk
       real(kind=kind_phys),                intent(in   ) :: min_lakeice, min_seaice
 
       ! CCPP error handling
@@ -129,11 +129,12 @@ contains
                 islmsk(i)      = 0
               endif
             else
-              if (cice(i) > min_lakeice) then
+              if (cice(i) >= min_lakeice) then
                 icy(i) = .true.
               else
                 cice(i)   = zero
                 islmsk(i) = 0
+                slmsk(i)  = 0
               endif
             endif
             if (cice(i) < one) then
@@ -548,7 +549,7 @@ contains
               tisfc(i) = tice(i) ! over lake ice (and sea ice when uncoupled)
               zorl(i)  = cice(i) * zorl_ice(i)   + (one - cice(i)) * zorl_wat(i)
             elseif (wet(i)) then
-              if (cice(i) > min_seaice) then ! this was already done for lake ice in sfc_sice
+              if (cice(i) >= min_seaice) then ! this was already done for lake ice in sfc_sice
                 txi = cice(i)
                 txo = one - txi
                 evap(i)   = txi * evap_ice(i)   + txo * evap_wat(i)

--- a/physics/GFS_surface_composites.F90
+++ b/physics/GFS_surface_composites.F90
@@ -92,6 +92,7 @@ contains
                 icy(i) = .true.
                 if (cice(i) < one) wet(i) = .true. ! some open ocean/lake water exists
                 islmsk(i) = 2
+                 slmsk(i) = 2
               else
                 cice(i)   = zero
 !               islmsk(i) = 0
@@ -121,12 +122,13 @@ contains
           else
             frland(i) = zero
             if (flag_cice(i)) then
-              if (cice(i) > min_seaice) then
+              if (cice(i) >= min_seaice) then
                 icy(i) = .true.
               else
                 cice(i)        = zero
                 flag_cice(i)   = .false.
                 islmsk(i)      = 0
+                 slmsk(i)      = 0
               endif
             else
               if (cice(i) >= min_lakeice) then
@@ -134,7 +136,7 @@ contains
               else
                 cice(i)   = zero
                 islmsk(i) = 0
-                slmsk(i)  = 0
+                 slmsk(i) = 0
               endif
             endif
             if (cice(i) < one) then

--- a/physics/GFS_surface_composites.meta
+++ b/physics/GFS_surface_composites.meta
@@ -506,7 +506,16 @@
   units = flag
   dimensions = (horizontal_loop_extent)
   type = integer
-  intent = in
+  intent = inout
+  optional = F
+[slmsk]
+  standard_name = sea_land_ice_mask_real
+  long_name = landmask: sea/land/ice=0/1/2
+  units = flag
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
   optional = F
 [semis_rad]
   standard_name = surface_longwave_emissivity

--- a/physics/sfc_sice.f
+++ b/physics/sfc_sice.f
@@ -217,7 +217,7 @@
             else
               tem = min_lakeice
             endif
-            if (fice(i) > tem) then
+            if (fice(i) >= tem) then
               islmsk_local(i) = 2
               tice(i) =min( tice(i), tgice)
             endif


### PR DESCRIPTION
(1) changed islmsk to intent(inout) in meta file to be consistent with fortran code;
(2) updated slmsk whenever islmsk is updated.
This enables restart to reproduce when lake ice exists in the coupled model configuration of C96mx025 and C384mx025 . 

With this change, usf-weather-model passed its all 57 regression tests, see  /scratch1/BMC/gsd-fv3-dev/sun/wx_top_lake_bugfix/ on hera. 

This refers to Issue #510 