### PR TITLE
add units to index_for_diagnostic_printout metadata to avoid ccpp_prebuild.py error

### DIFF
--- a/physics/GFS_time_vary_pre.scm.meta
+++ b/physics/GFS_time_vary_pre.scm.meta
@@ -212,7 +212,7 @@
 [ipt]
   standard_name = index_for_diagnostic_printout
   long_name = horizontal index for point used for diagnostic printout
-  units = 
+  units = index
   dimensions = ()
   type = integer
   intent = out


### PR DESCRIPTION
A one line change that avoids an error in ccpp_prebuild.py.

(Note that ccpp_prebuild.py errors out ungracefully during units checking if one of the units is empty.)