### PR TITLE
release/public-v5: fix uninitialized variable in Thompson MP

### DIFF
--- a/physics/module_mp_thompson.F90
+++ b/physics/module_mp_thompson.F90
@@ -1797,6 +1797,7 @@ MODULE module_mp_thompson
          rho(k) = 0.622*pres(k)/(R*temp(k)*(qv(k)+0.622))
          nwfa(k) = MAX(11.1E6, MIN(9999.E6, nwfa1d(k)*rho(k)))
          nifa(k) = MAX(naIN1*0.01, MIN(9999.E6, nifa1d(k)*rho(k)))
+         mvd_r(k) = D0r
 
          if (qc1d(k) .gt. R1) then
             no_micro = .false.


### PR DESCRIPTION
This is a bugfix that was merged into master as part of the HWRF commit (cherry-picked). It fixes an uninitialized variable in `module_mp_thompson.F90`.

Associated PRs:

https://github.com/NCAR/ccpp-physics/pull/518
https://github.com/NOAA-GFDL/GFDL_atmos_cubed_sphere/pull/61
https://github.com/NOAA-EMC/fv3atm/pull/197
https://github.com/ufs-community/ufs-weather-model/pull/276

For regression testing, see https://github.com/ufs-community/ufs-weather-model/pull/276.
