### PR TITLE
Fix specified surface flux "scheme" (CCPP-SCM only!!!)

### DIFF
--- a/physics/gmtb_scm_sfc_flux_spec.F90
+++ b/physics/gmtb_scm_sfc_flux_spec.F90
@@ -15,7 +15,18 @@ module gmtb_scm_sfc_flux_spec
   CONTAINS
 !*******************************************************************************************
 
-  subroutine gmtb_scm_sfc_flux_spec_init()
+  subroutine gmtb_scm_sfc_flux_spec_init(lheatstrg, errmsg, errflg)
+    
+    logical, intent(in) :: lheatstrg
+    
+    character(len=*), intent(out) :: errmsg
+    integer,          intent(out) :: errflg
+    
+    if (lheatstrg) then
+      errmsg = 'Using specified surface fluxes is not compatible with canopy heat storage (lheatstrg) being true. Stopping.'
+      errflg = 1
+      return
+    end if
   end subroutine gmtb_scm_sfc_flux_spec_init
 
   subroutine gmtb_scm_sfc_flux_spec_finalize()
@@ -38,16 +49,17 @@ module gmtb_scm_sfc_flux_spec
 !!  -# Calculate the surface drag coefficient for heat and moisture.
 !!  -# Calculate the u and v wind at 10m.
   subroutine gmtb_scm_sfc_flux_spec_run (u1, v1, z1, t1, q1, p1, roughness_length, spec_sh_flux, spec_lh_flux, &
-    exner_inverse, T_surf, cp, grav, hvap, rd, fvirt, vonKarman, sh_flux, lh_flux, u_star, sfc_stress, cm, ch, &
+    exner_inverse, T_surf, cp, grav, hvap, rd, fvirt, vonKarman, sh_flux, lh_flux, sh_flux_chs, lh_flux_chs, u_star, sfc_stress, cm, ch, &
     fm, fh, rb, u10m, v10m, wind1, qss, t2m, q2m, errmsg, errflg)
 
     use machine,             only: kind_phys
-
+    
     real(kind=kind_phys), intent(in) :: u1(:), v1(:), z1(:), t1(:), q1(:), p1(:), roughness_length(:), &
       spec_sh_flux(:), spec_lh_flux(:), exner_inverse(:), T_surf(:)
     real(kind=kind_phys), intent(in) :: cp, grav, hvap, rd, fvirt, vonKarman
     real(kind=kind_phys), intent(out) :: sh_flux(:), lh_flux(:), u_star(:), sfc_stress(:), &
-      cm(:), ch(:), fm(:), fh(:), rb(:), u10m(:), v10m(:), wind1(:), qss(:), t2m(:), q2m(:)
+      cm(:), ch(:), fm(:), fh(:), rb(:), u10m(:), v10m(:), wind1(:), qss(:), t2m(:), q2m(:), &
+      sh_flux_chs(:), lh_flux_chs(:)
 
     character(len=*), intent(out) :: errmsg
     integer,          intent(out) :: errflg
@@ -60,12 +72,14 @@ module gmtb_scm_sfc_flux_spec
     ! Initialize CCPP error handling variables
     errmsg = ''
     errflg = 0
-
+  
 !     !--- set control properties (including namelist read)
   !calculate u_star from wind profiles (need roughness length, and wind and height at lowest model level)
   do i=1, size(z1)
     sh_flux(i) = spec_sh_flux(i)
     lh_flux(i) = spec_lh_flux(i)
+    sh_flux_chs(i) = sh_flux(i)
+    lh_flux_chs(i) = lh_flux(i)
 
     roughness_length_m = 0.01*roughness_length(i)
 

--- a/physics/gmtb_scm_sfc_flux_spec.meta
+++ b/physics/gmtb_scm_sfc_flux_spec.meta
@@ -5,6 +5,36 @@
 
 ########################################################################
 [ccpp-arg-table]
+  name = gmtb_scm_sfc_flux_spec_init
+  type = scheme
+[lheatstrg]
+  standard_name = flag_for_canopy_heat_storage
+  long_name = flag for canopy heat storage parameterization
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+  optional = F
+[errflg]
+  standard_name = ccpp_error_flag
+  long_name = error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+  optional = F
+
+#################################
+[ccpp-arg-table]
   name = gmtb_scm_sfc_flux_spec_run
   type = scheme
 [u1]
@@ -172,6 +202,24 @@
 [lh_flux]
   standard_name = kinematic_surface_upward_latent_heat_flux
   long_name = surface upward evaporation flux
+  units = kg kg-1 m s-1
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+  optional = F
+[sh_flux_chs]
+  standard_name = kinematic_surface_upward_sensible_heat_flux_reduced_by_surface_roughness
+  long_name = kinematic surface upward sensible heat flux reduced by surface roughness
+  units = K m s-1
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+  optional = F
+[lh_flux_chs]
+  standard_name = kinematic_surface_upward_latent_heat_flux_reduced_by_surface_roughness
+  long_name = kinematic surface upward latent heat flux reduced by surface roughness
   units = kg kg-1 m s-1
   dimensions = (horizontal_loop_extent)
   type = real


### PR DESCRIPTION
This PR is required for https://github.com/NCAR/gmtb-scm/pull/217.

The scheme that backs out required PBL etc. variables from specified surface fluxes when using the SCM was updated to additionally output new kinematic surface flux variables used by many (all?) PBL schemes. This is required to reinstate functionality for cases that use specified surface fluxes and recent versions of ccpp-physics. Without these updates, the surface fluxes seen by PBL and other physics are zero.