### PR TITLE
Final-final GFS v16 updates

### DIFF
--- a/physics/GFS_debug.F90
+++ b/physics/GFS_debug.F90
@@ -491,10 +491,10 @@
                      end if
                      ! CCPP/RUC only
                      if (Model%lsm == Model%lsm_ruc) then
+                        call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Model%zs',             Model%zs)
                         call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Sfcprop%sh2o',         Sfcprop%sh2o)
                         call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Sfcprop%smois',        Sfcprop%smois)
                         call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Sfcprop%tslb',         Sfcprop%tslb)
-                        call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Sfcprop%zs',           Sfcprop%zs)
                         call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Sfcprop%clw_surf',     Sfcprop%clw_surf)
                         call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Sfcprop%qwv_surf',     Sfcprop%qwv_surf)
                         call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Sfcprop%cndm_surf',    Sfcprop%cndm_surf)

--- a/physics/GFS_surface_composites.F90
+++ b/physics/GFS_surface_composites.F90
@@ -571,6 +571,7 @@ contains
             snowd(i)  = snowd_ice(i)
            !tprcp(i)  = cice(i)*tprcp_ice(i) + (one-cice(i))*tprcp_wat(i)
             qss(i)    = qss_ice(i)
+            tsfc(i)   = tsfc_ice(i)
             evap(i)   = evap_ice(i)
             hflx(i)   = hflx_ice(i)
             qss(i)    = qss_ice(i)


### PR DESCRIPTION
This PR:

- adds a one-line change to `GFS_surface_composites.F90` that allows us to reproduce the GFS v16 behavior so that the code can serve as reference for the GFS v17 development - contributed by @junwang-noaa and @yangfanglin

- fixes a small bug in `GFS_debug.F90` (not used by any of the suites by default, but useful for debugging), because `zs` is no longer in `GFS_sfcprop` but in `GFS_control`

Associated PRs:

https://github.com/NCAR/ccpp-physics/pull/531
https://github.com/NOAA-EMC/fv3atm/pull/212
https://github.com/ufs-community/ufs-weather-model/pull/325

For regression testing, see https://github.com/ufs-community/ufs-weather-model/pull/325