### PR TITLE
Minor bug fixes to unified_ugwp.F90 and drag_suite.F90

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,6 @@ For the use of CCPP with its Single Column Model, see the [Single Column Model U
 
 For the use of CCPP with NOAA's Unified Forecast System (UFS), see the [UFS Medium-Range Application User's Guide](https://ufs-mrweather-app.readthedocs.io/en/latest/) and the [UFS Weather Model User's Guide](https://ufs-weather-model.readthedocs.io/en/latest/).
 
+The Apache license will be in effect unless superseded by an existing license in specific files.
+
 Questions can be directed to the [CCPP Help Desk](mailto:gmtb-help@ucar.edu). When using the CCPP with NOAA's UFS, questions can be posted in the [UFS Weather Model](https://forums.ufscommunity.org/forum/ufs-weather-model) section of the [UFS Forum](https://forums.ufscommunity.org/)

--- a/physics/drag_suite.F90
+++ b/physics/drag_suite.F90
@@ -1260,7 +1260,7 @@ IF ( (do_gsl_drag_ls_bl) .and.                                       &
             eng1 = 0.5*( (rcs*(u1(i,k)+(dtaux+dtauxb)*deltim))**2 + &
                          (rcs*(v1(i,k)+(dtauy+dtauyb)*deltim))**2 )
             ! Modify theta tendency
-            dtdt(i,k) = dtdt(i,k) + max((eng0-eng1),0.0)/cp/deltim/prslk(i,k)
+            dtdt(i,k) = dtdt(i,k) + max((eng0-eng1),0.0)/cp/deltim
          end if
 
          dusfc(i)   = dusfc(i) + taud_ls(i,k)*xn(i)*del(i,k) + taud_bl(i,k)*xn(i)*del(i,k)

--- a/physics/unified_ugwp.F90
+++ b/physics/unified_ugwp.F90
@@ -244,7 +244,8 @@ contains
     integer,                 intent(in) :: gwd_opt
     integer,                 intent(in), dimension(im)       :: kpbl
     real(kind=kind_phys),    intent(in), dimension(im)       :: oro, oro_uf, hprime, oc, theta, sigma, gamma
-    real(kind=kind_phys),    intent(in), dimension(im)       :: varss,oc1ss,oa4ss,ol4ss,dx
+    real(kind=kind_phys),    intent(in), dimension(im)       :: varss,oc1ss,dx
+    real(kind=kind_phys),    intent(in), dimension(im,4)     :: oa4ss,ol4ss
     logical,                 intent(in)                      :: flag_for_gwd_generic_tend
     ! elvmax is intent(in) for CIRES UGWP, but intent(inout) for GFS GWDPS
     real(kind=kind_phys),    intent(inout), dimension(im)    :: elvmax


### PR DESCRIPTION
Fixed two bugs:

1)  unified_ugwp.F90 -- the variables oa4ss and ol4ss are now correctly declared with dimensions (im,4).  Since these variables were just "passing through" unified_ugwp.F90 to get to the drag_suite_run subroutine, this bug had not effected the actual run-time results.  The results before and after the bug fix are bit-to-bit identical.

2)  drag_suite.F90 -- removed division by the dimensionless Exner function, which was appropriate for the WRF model theta-tendency, but not for the FV3GFS model TEMPERATURE tendency.

Fixes #533 (add one-liner regarding licenses in specific files overriding the overall Apache license).

Associated PRs:

https://github.com/NCAR/ccpp-physics/pull/532
https://github.com/NOAA-EMC/fv3atm/pull/216

These PRs will be tested together with https://github.com/ufs-community/ufs-weather-model/pull/319, for regression testing information see there.
