### PR TITLE
Implementation of CCPP timestep_init and timestep_final phases

### DIFF
--- a/physics/GFS_debug.F90
+++ b/physics/GFS_debug.F90
@@ -915,14 +915,10 @@
              do iomp=0,ompsize-1
                  if (mpirank==impi .and. omprank==iomp) then
                      ! Print static variables
-                     call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Interstitial%h2o_coeff           ', Interstitial%h2o_coeff               )
-                     call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Interstitial%h2o_pres            ', Interstitial%h2o_pres                )
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Interstitial%ipr                 ', Interstitial%ipr                     )
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Interstitial%itc                 ', Interstitial%itc                     )
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Interstitial%latidxprnt          ', Interstitial%latidxprnt              )
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Interstitial%levi                ', Interstitial%levi                    )
-                     call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Interstitial%levh2o              ', Interstitial%levh2o                  )
-                     call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Interstitial%levozp              ', Interstitial%levozp                  )
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Interstitial%lmk                 ', Interstitial%lmk                     )
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Interstitial%lmp                 ', Interstitial%lmp                     )
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Interstitial%nbdlw               ', Interstitial%nbdlw                   )
@@ -934,8 +930,6 @@
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Interstitial%nspc1               ', Interstitial%nspc1                   )
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Interstitial%ntiwx               ', Interstitial%ntiwx                   )
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Interstitial%nvdiff              ', Interstitial%nvdiff                  )
-                     call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Interstitial%oz_coeff            ', Interstitial%oz_coeff                )
-                     call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'sum(Interstitial%oz_pres)        ', Interstitial%oz_pres                 )
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Interstitial%phys_hydrostatic    ', Interstitial%phys_hydrostatic        )
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Interstitial%skip_macro          ', Interstitial%skip_macro              )
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Interstitial%trans_aero          ', Interstitial%trans_aero              )

--- a/physics/GFS_phys_time_vary.fv3.F90
+++ b/physics/GFS_phys_time_vary.fv3.F90
@@ -11,6 +11,10 @@
       use omp_lib
 #endif
 
+      use machine, only : kind_phys
+
+      use mersenne_twister, only: random_setseed, random_number
+
       use ozne_def, only : levozp, oz_coeff, oz_lat, oz_pres, oz_time, ozplin
       use ozinterp, only : read_o3data, setindxoz, ozinterpol
 
@@ -23,6 +27,8 @@
       use iccn_def,   only : ciplin, ccnin, ci_pres
       use iccninterp, only : read_cidata, setindxci, ciinterpol
 
+      use gcycle_mod, only : gcycle
+
 #if 0
       !--- variables needed for calculating 'sncovr'
       use namelist_soilveg, only: salp_data, snupx
@@ -32,9 +38,13 @@
 
       private
 
-      public GFS_phys_time_vary_init, GFS_phys_time_vary_run, GFS_phys_time_vary_finalize
+      public GFS_phys_time_vary_init, GFS_phys_time_vary_timestep_init, GFS_phys_time_vary_timestep_finalize, GFS_phys_time_vary_finalize
 
       logical :: is_initialized = .false.
+
+      real(kind=kind_phys), parameter :: con_hr  = 3600.0_kind_phys
+      real(kind=kind_phys), parameter :: con_99  =   99.0_kind_phys
+      real(kind=kind_phys), parameter :: con_100 =  100.0_kind_phys
 
       contains
 
@@ -43,236 +53,389 @@
 !!
 !>\section gen_GFS_phys_time_vary_init GFS_phys_time_vary_init General Algorithm
 !! @{
-      subroutine GFS_phys_time_vary_init (Data, Model, Interstitial, nthrds, errmsg, errflg)
-
-         use GFS_typedefs,          only: GFS_control_type, GFS_data_type, GFS_interstitial_type
+      subroutine GFS_phys_time_vary_init (                                                         &
+              me, master, ntoz, h2o_phys, iaerclm, iccn, iflip, im, nx, ny, idate, xlat_d, xlon_d, &
+              jindx1_o3, jindx2_o3, ddy_o3, ozpl, jindx1_h, jindx2_h, ddy_h, h2opl,                &
+              jindx1_aer, jindx2_aer, ddy_aer, iindx1_aer, iindx2_aer, ddx_aer, aer_nm,            &
+              jindx1_ci, jindx2_ci, ddy_ci, iindx1_ci, iindx2_ci, ddx_ci, imap, jmap,              &
+              nthrds, errmsg, errflg)
 
          implicit none
 
          ! Interface variables
-         type(GFS_data_type),              intent(inout) :: Data(:)
-         type(GFS_control_type),           intent(inout) :: Model
-         type(GFS_interstitial_type),      intent(inout) :: Interstitial(:)
-         integer,                          intent(in)    :: nthrds
-         character(len=*),                 intent(out)   :: errmsg
-         integer,                          intent(out)   :: errflg
+         integer,              intent(in)    :: me, master, ntoz, iccn, iflip, im, nx, ny
+         logical,              intent(in)    :: h2o_phys, iaerclm
+         integer,              intent(in)    :: idate(:)
+         real(kind_phys),      intent(in)    :: xlat_d(:), xlon_d(:)
+
+         integer,              intent(inout) :: jindx1_o3(:), jindx2_o3(:), jindx1_h(:), jindx2_h(:)
+         real(kind_phys),      intent(inout) :: ddy_o3(:),  ddy_h(:)
+         real(kind_phys),      intent(in)    :: ozpl(:,:,:), h2opl(:,:,:)
+         integer,              intent(inout) :: jindx1_aer(:), jindx2_aer(:), iindx1_aer(:), iindx2_aer(:)
+         real(kind_phys),      intent(inout) :: ddy_aer(:), ddx_aer(:)
+         real(kind_phys),      intent(in)    :: aer_nm(:,:,:)
+         integer,              intent(inout) :: jindx1_ci(:), jindx2_ci(:), iindx1_ci(:), iindx2_ci(:)
+         real(kind_phys),      intent(inout) :: ddy_ci(:), ddx_ci(:)
+         integer,              intent(inout) :: imap(:), jmap(:)
+
+         integer,              intent(in)    :: nthrds
+         character(len=*),     intent(out)   :: errmsg
+         integer,              intent(out)   :: errflg
 
          ! Local variables
-         integer :: nb, nblks, nt
          integer :: i, j, ix
-         logical :: non_uniform_blocks
+
          ! Initialize CCPP error handling variables
          errmsg = ''
          errflg = 0
 
          if (is_initialized) return
 
-         nblks = size(Model%blksz)
-
-         ! Non-uniform blocks require special handling: instead
-         ! of nthrds elements of the Interstitial array, there are
-         ! nthrds+1 elements. The extra Interstitial(nthrds+1) is
-         ! allocated for the smaller block length of the last block,
-         ! while all other elements are allocated to the maximum
-         ! block length (which is the same for all blocks except
-         ! the last block).
-         if (minval(Model%blksz)==maxval(Model%blksz)) then
-             non_uniform_blocks = .false.
-         else
-             non_uniform_blocks = .true.
-         end if
-
-         ! Consistency check - number of threads passed in via the argument list
-         ! has to match the size of the Interstitial data type.
-         if (.not. non_uniform_blocks .and. nthrds/=size(Interstitial)) then
-             write(errmsg,'(*(a))') 'Logic error: nthrds does not match size of Interstitial variable'
-             errflg = 1
-             return
-         else if (non_uniform_blocks .and. nthrds+1/=size(Interstitial)) then
-             write(errmsg,'(*(a))') 'Logic error: nthrds+1 does not match size of Interstitial variable ' // &
-                                    '(including extra last element for shorter blocksizes)'
-             errflg = 1
-             return
-         end if
-
-!$OMP parallel num_threads(nthrds) default(none)              &
-!$OMP          private (nt,nb)                                &
-!$OMP          shared (Model,Data,Interstitial,errmsg,errflg) &
-!$OMP          shared (levozp,oz_coeff,oz_pres)               &
-!$OMP          shared (levh2o,h2o_coeff,h2o_pres)             &
-!$OMP          shared (ntrcaer,nblks,nthrds,non_uniform_blocks)
-
-#ifdef OPENMP
-         nt = omp_get_thread_num()+1
-#else
-         nt = 1
-#endif
+!$OMP parallel num_threads(nthrds) default(none)                                    &
+!$OMP          shared (me,master,ntoz,h2o_phys,im)                                  &
+!$OMP          shared (xlat_d,xlon_d,imap,jmap,errmsg,errflg)                       &
+!$OMP          shared (levozp,oz_coeff,oz_pres,ozpl)                                &
+!$OMP          shared (levh2o,h2o_coeff,h2o_pres,h2opl)                             &
+!$OMP          shared (iaerclm,ntrcaer,aer_nm,iflip,iccn)                           &
+!$OMP          shared (jindx1_o3,jindx2_o3,ddy_o3,jindx1_h,jindx2_h,ddy_h)          &
+!$OMP          shared (jindx1_aer,jindx2_aer,ddy_aer,iindx1_aer,iindx2_aer,ddx_aer) &
+!$OMP          shared (jindx1_ci,jindx2_ci,ddy_ci,iindx1_ci,iindx2_ci,ddx_ci)       &
+!$OMP          private (ix,i,j)
 
 !$OMP sections
 
 !$OMP section
 !> - Call read_o3data() to read ozone data 
-         call read_o3data  (Model%ntoz, Model%me, Model%master)
+         call read_o3data (ntoz, me, master)
 
          ! Consistency check that the hardcoded values for levozp and
          ! oz_coeff in GFS_typedefs.F90 match what is set by read_o3data
-         ! in GFS_typedefs.F90: allocate (Tbd%ozpl  (IM,levozp,oz_coeff))
-         if (size(Data(1)%Tbd%ozpl, dim=2).ne.levozp) then
+         ! in GFS_typedefs.F90: allocate (Tbd%ozpl (IM,levozp,oz_coeff))
+         if (size(ozpl, dim=2).ne.levozp) then
             write(errmsg,'(2a,i0,a,i0)') "Value error in GFS_phys_time_vary_init: ",    &
                   "levozp from read_o3data does not match value in GFS_typedefs.F90: ", &
-                  levozp, " /= ", size(Data(1)%Tbd%ozpl, dim=2)
+                  levozp, " /= ", size(ozpl, dim=2)
             errflg = 1
          end if
-         if (size(Data(1)%Tbd%ozpl, dim=3).ne.oz_coeff) then
+         if (size(ozpl, dim=3).ne.oz_coeff) then
             write(errmsg,'(2a,i0,a,i0)') "Value error in GFS_phys_time_vary_init: ",      &
                   "oz_coeff from read_o3data does not match value in GFS_typedefs.F90: ", &
-                  oz_coeff, " /= ", size(Data(1)%Tbd%ozpl, dim=3)
+                  oz_coeff, " /= ", size(ozpl, dim=3)
             errflg = 1
          end if
 
 !$OMP section
 !> - Call read_h2odata() to read stratospheric water vapor data
-         call read_h2odata (Model%h2o_phys, Model%me, Model%master)
+         call read_h2odata (h2o_phys, me, master)
 
          ! Consistency check that the hardcoded values for levh2o and
          ! h2o_coeff in GFS_typedefs.F90 match what is set by read_o3data
          ! in GFS_typedefs.F90: allocate (Tbd%h2opl (IM,levh2o,h2o_coeff))
-         if (size(Data(1)%Tbd%h2opl, dim=2).ne.levh2o) then
+         if (size(h2opl, dim=2).ne.levh2o) then
             write(errmsg,'(2a,i0,a,i0)') "Value error in GFS_phys_time_vary_init: ",     &
                   "levh2o from read_h2odata does not match value in GFS_typedefs.F90: ", &
-                  levh2o, " /= ", size(Data(1)%Tbd%h2opl, dim=2)
+                  levh2o, " /= ", size(h2opl, dim=2)
             errflg = 1
          end if
-         if (size(Data(1)%Tbd%h2opl, dim=3).ne.h2o_coeff) then
+         if (size(h2opl, dim=3).ne.h2o_coeff) then
             write(errmsg,'(2a,i0,a,i0)') "Value error in GFS_phys_time_vary_init: ",       &
                   "h2o_coeff from read_h2odata does not match value in GFS_typedefs.F90: ", &
-                  h2o_coeff, " /= ", size(Data(1)%Tbd%h2opl, dim=3)
+                  h2o_coeff, " /= ", size(h2opl, dim=3)
             errflg = 1
          end if
 
 !$OMP section
 !> - Call read_aerdata() to read aerosol climatology
-         if (Model%iaerclm) then
+         if (iaerclm) then
             ! Consistency check that the value for ntrcaerm set in GFS_typedefs.F90
-            ! and used to allocate Tbd%aer_nm matches the value defined in aerclm_def
-            if (size(Data(1)%Tbd%aer_nm, dim=3).ne.ntrcaerm) then
+            ! and used to allocate aer_nm matches the value defined in aerclm_def
+            if (size(aer_nm, dim=3).ne.ntrcaerm) then
                write(errmsg,'(2a,i0,a,i0)') "Value error in GFS_phys_time_vary_init: ",     &
                      "ntrcaerm from aerclm_def does not match value in GFS_typedefs.F90: ", &
-                     ntrcaerm, " /= ", size(Data(1)%Tbd%aer_nm, dim=3)
+                     ntrcaerm, " /= ", size(aer_nm, dim=3)
                errflg = 1
             else
                ! Update the value of ntrcaer in aerclm_def with the value defined
                ! in GFS_typedefs.F90 that is used to allocate the Tbd DDT.
-               ! If Model%iaerclm is .true., then ntrcaer == ntrcaerm
-               ntrcaer = size(Data(1)%Tbd%aer_nm, dim=3)
+               ! If iaerclm is .true., then ntrcaer == ntrcaerm
+               ntrcaer = size(aer_nm, dim=3)
                ! Read aerosol climatology
-               call read_aerdata (Model%me,Model%master,Model%iflip,Model%idate,errmsg,errflg)
+               call read_aerdata (me,master,iflip,idate,errmsg,errflg)
             endif
          else
             ! Update the value of ntrcaer in aerclm_def with the value defined
             ! in GFS_typedefs.F90 that is used to allocate the Tbd DDT.
-            ! If Model%iaerclm is .false., then ntrcaer == 1
-            ntrcaer = size(Data(1)%Tbd%aer_nm, dim=3)
+            ! If iaerclm is .false., then ntrcaer == 1
+            ntrcaer = size(aer_nm, dim=3)
          endif
 
 !$OMP section
 !> - Call read_cidata() to read IN and CCN data
-         if (Model%iccn == 1) then
-           call read_cidata  ( Model%me, Model%master)
+         if (iccn == 1) then
+           call read_cidata (me,master)
            ! No consistency check needed for in/ccn data, all values are
            ! hardcoded in module iccn_def.F and GFS_typedefs.F90
          endif
 
-!$OMP end sections
+!$OMP barrier
 
-         ! Update values of oz_pres in Interstitial data type for all threads
-         if (Model%ntoz > 0) then
-            Interstitial(nt)%oz_pres = oz_pres
-!$OMP single
-            if (non_uniform_blocks) then
-               ! For non-uniform block sizes, set Interstitial(nthrds+1)%oz_pres
-               Interstitial(nthrds+1)%oz_pres = oz_pres
-            end if
-!$OMP end single nowait
-         end if
-
-         ! Update values of h2o_pres in Interstitial data type for all threads
-         if (Model%h2o_phys) then
-            Interstitial(nt)%h2o_pres = h2o_pres
-!$OMP single
-            if (non_uniform_blocks) then
-               ! For non-uniform block sizes, set Interstitial(nthrds+1)%oz_pres
-               Interstitial(nthrds+1)%h2o_pres = h2o_pres
-            end if
-!$OMP end single nowait
-         end if
-
-
+!$OMP section
 !> - Call setindxoz() to initialize ozone data
-         if (Model%ntoz > 0) then
-!$OMP do schedule (dynamic,1)
-           do nb = 1, nblks
-             call setindxoz (Model%blksz(nb), Data(nb)%Grid%xlat_d, Data(nb)%Grid%jindx1_o3, &
-                             Data(nb)%Grid%jindx2_o3, Data(nb)%Grid%ddy_o3)
-           enddo
-!$OMP end do
+         if (ntoz > 0) then
+           call setindxoz (im, xlat_d, jindx1_o3, jindx2_o3, ddy_o3)
          endif
 
+!$OMP section
 !> - Call setindxh2o() to initialize stratospheric water vapor data
-         if (Model%h2o_phys) then
-!$OMP do schedule (dynamic,1)
-           do nb = 1, nblks
-             call setindxh2o (Model%blksz(nb), Data(nb)%Grid%xlat_d, Data(nb)%Grid%jindx1_h, &
-                              Data(nb)%Grid%jindx2_h, Data(nb)%Grid%ddy_h)
-           enddo
-!$OMP end do
+         if (h2o_phys) then
+           call setindxh2o (im, xlat_d, jindx1_h, jindx2_h, ddy_h)
          endif
 
+!$OMP section
 !> - Call setindxaer() to initialize aerosols data
-         if (Model%iaerclm) then
-!$OMP do schedule (dynamic,1)
-           do nb = 1, nblks
-             call setindxaer (Model%blksz(nb), Data(nb)%Grid%xlat_d, Data(nb)%Grid%jindx1_aer,           &
-                              Data(nb)%Grid%jindx2_aer, Data(nb)%Grid%ddy_aer, Data(nb)%Grid%xlon_d,     &
-                              Data(nb)%Grid%iindx1_aer, Data(nb)%Grid%iindx2_aer, Data(nb)%Grid%ddx_aer, &
-                              Model%me, Model%master)
-           enddo
-!$OMP end do
+         if (iaerclm) then
+           call setindxaer (im, xlat_d, jindx1_aer,          &
+                            jindx2_aer, ddy_aer, xlon_d,     &
+                            iindx1_aer, iindx2_aer, ddx_aer, &
+                            me, master)
          endif
 
+!$OMP section
 !> - Call setindxci() to initialize IN and CCN data
-         if (Model%iccn == 1) then
-!$OMP do schedule (dynamic,1)
-           do nb = 1, nblks
-             call setindxci (Model%blksz(nb), Data(nb)%Grid%xlat_d, Data(nb)%Grid%jindx1_ci,       &
-                             Data(nb)%Grid%jindx2_ci, Data(nb)%Grid%ddy_ci, Data(nb)%Grid%xlon_d,  &
-                             Data(nb)%Grid%iindx1_ci, Data(nb)%Grid%iindx2_ci, Data(nb)%Grid%ddx_ci)
-           enddo
-!$OMP end do
+         if (iccn == 1) then
+           call setindxci (im, xlat_d, jindx1_ci,      &
+                           jindx2_ci, ddy_ci, xlon_d,  &
+                           iindx1_ci, iindx2_ci, ddx_ci)
          endif
+
+!$OMP section
+         !--- initial calculation of maps local ix -> global i and j
+         ix = 0
+         do j = 1,ny
+           do i = 1,nx
+             ix = ix + 1
+             jmap(ix) = j
+             imap(ix) = i
+           enddo
+         enddo
+
+!$OMP end sections
 
 !$OMP end parallel
 
-         !--- initial calculation of maps local ix -> global i and j, store in Tbd
-         ix = 0
-         nb = 1
-         do j = 1,Model%ny
-           do i = 1,Model%nx
-             ix = ix + 1
-             if (ix > Model%blksz(nb)) then
-               ix = 1
-               nb = nb + 1
-             endif
-             Data(nb)%Tbd%jmap(ix) = j
-             Data(nb)%Tbd%imap(ix) = i
-           enddo
-         enddo
+#if 0
+        !Calculate sncovr if it was read in but empty (from FV3/io/FV3GFS_io.F90/sfc_prop_restart_read)
+        if (first_time_step) then
+          if (nint(Data(1)%Sfcprop%sncovr(1)) == -9999) then
+            !--- compute sncovr from existing variables
+            !--- code taken directly from read_fix.f
+            do nb = 1, nblks
+              do ix = 1, Model%blksz(nb)
+                Data(nb)%Sfcprop%sncovr(ix) = 0.0
+                if (Data(nb)%Sfcprop%slmsk(ix) > 0.001) then
+                  vegtyp = Data(nb)%Sfcprop%vtype(ix)
+                  if (vegtyp == 0) vegtyp = 7
+                  rsnow  = 0.001*Data(nb)%Sfcprop%weasd(ix)/snupx(vegtyp)
+                  if (0.001*Data(nb)%Sfcprop%weasd(ix) < snupx(vegtyp)) then
+                    Data(nb)%Sfcprop%sncovr(ix) = 1.0 - (exp(-salp_data*rsnow) - rsnow*exp(-salp_data))
+                  else
+                    Data(nb)%Sfcprop%sncovr(ix) = 1.0
+                  endif
+                endif
+              enddo
+            enddo
+          endif
+        endif
+#endif
 
          is_initialized = .true.
 
       end subroutine GFS_phys_time_vary_init
 !! @}
 
+!> \section arg_table_GFS_phys_time_vary_timestep_init Argument Table
+!! \htmlinclude GFS_phys_time_vary_timestep_init.html
+!!
+!>\section gen_GFS_phys_time_vary_timestep_init GFS_phys_time_vary_timestep_init General Algorithm
+!! @{
+      subroutine GFS_phys_time_vary_timestep_init (                                                 &
+            me, master, cnx, cny, isc, jsc, nrcm, im, levs, kdt, idate, nsswr, fhswr, lsswr, fhour, &
+            imfdeepcnv, cal_pre, random_clds, nscyc, ntoz, h2o_phys, iaerclm, iccn, clstp,          &
+            jindx1_o3, jindx2_o3, ddy_o3, ozpl, jindx1_h, jindx2_h, ddy_h, h2opl,                   &
+            jindx1_aer, jindx2_aer, ddy_aer, iindx1_aer, iindx2_aer, ddx_aer, aer_nm,               &
+            jindx1_ci, jindx2_ci, ddy_ci, iindx1_ci, iindx2_ci, ddx_ci, in_nm, ccn_nm,              &
+            imap, jmap, prsl, seed0, rann, nthrds, nx, ny, nsst, tile_num, nlunit, lsoil, kice,     &
+            ialb, isot, ivegsrc, input_nml_file, use_ufo, nst_anl, frac_grid, fhcyc, phour,         &
+            lakefrac, min_seaice, min_lakeice, smc, slc, stc, tiice, tg3, tref, tsfc, tsfco, tisfc, &
+            hice, fice, facsf, facwf, alvsf, alvwf, alnsf, alnwf, zorli, zorll, zorlo, weasd,       &
+            slope, snoalb, canopy, vfrac, vtype, stype, shdmin, shdmax, snowd,                      &
+            cv, cvb, cvt, oro, oro_uf, xlat_d, xlon_d, slmsk, errmsg, errflg)
+
+         implicit none
+
+         ! Interface variables
+         integer,              intent(in)    :: me, master, cnx, cny, isc, jsc, nrcm, im, levs, kdt, &
+                                                nsswr, imfdeepcnv, iccn, nscyc, ntoz
+         integer,              intent(in)    :: idate(:)
+         real(kind_phys),      intent(in)    :: fhswr, fhour
+         logical,              intent(in)    :: lsswr, cal_pre, random_clds, h2o_phys, iaerclm
+         real(kind_phys),      intent(out)   :: clstp
+         integer,              intent(in)    :: jindx1_o3(:), jindx2_o3(:), jindx1_h(:), jindx2_h(:)
+         real(kind_phys),      intent(in)    :: ddy_o3(:),  ddy_h(:)
+         real(kind_phys),      intent(inout) :: ozpl(:,:,:), h2opl(:,:,:)
+         integer,              intent(in)    :: jindx1_aer(:), jindx2_aer(:), iindx1_aer(:), iindx2_aer(:)
+         real(kind_phys),      intent(in)    :: ddy_aer(:), ddx_aer(:)
+         real(kind_phys),      intent(inout) :: aer_nm(:,:,:)
+         integer,              intent(in)    :: jindx1_ci(:), jindx2_ci(:), iindx1_ci(:), iindx2_ci(:)
+         real(kind_phys),      intent(in)    :: ddy_ci(:), ddx_ci(:)
+         real(kind_phys),      intent(inout) :: in_nm(:,:), ccn_nm(:,:)
+         integer,              intent(in)    :: imap(:), jmap(:)
+         real(kind_phys),      intent(in)    :: prsl(:,:)
+         integer,              intent(in)    :: seed0
+         real(kind_phys),      intent(out)   :: rann(:,:)
+         ! For gcycle only
+         integer,              intent(in)    :: nthrds, nx, ny, nsst, tile_num, nlunit, lsoil, kice
+         integer,              intent(in)    :: ialb, isot, ivegsrc
+         character(len=*),     intent(in)    :: input_nml_file(:)
+         logical,              intent(in)    :: use_ufo, nst_anl, frac_grid
+         real(kind_phys),      intent(in)    :: fhcyc, phour, lakefrac(:), min_seaice, min_lakeice,  &
+                                                xlat_d(:), xlon_d(:)
+         !
+         real(kind_phys),      intent(inout) :: smc(:,:), slc(:,:), stc(:,:), tiice(:,:), tg3(:),    &
+                                      tref(:), tsfc(:), tsfco(:), tisfc(:), hice(:), fice(:),        &
+                                      facsf(:), facwf(:), alvsf(:), alvwf(:), alnsf(:), alnwf(:),    &
+                                      zorli(:), zorll(:), zorlo(:), weasd(:), slope(:), snoalb(:),   &
+                                      canopy(:), vfrac(:), vtype(:), stype(:), shdmin(:), shdmax(:), &
+                                      snowd(:), cv(:), cvb(:), cvt(:), oro(:), oro_uf(:), slmsk(:)
+         !
+         character(len=*),     intent(out)   :: errmsg
+         integer,              intent(out)   :: errflg
+
+         ! Local variables
+         integer :: i, j, k, iseed, iskip, ix
+         real(kind=kind_phys) :: wrk(1)
+         real(kind=kind_phys) :: rannie(cny)
+         real(kind=kind_phys) :: rndval(cnx*cny*nrcm)
+
+         ! Initialize CCPP error handling variables
+         errmsg = ''
+         errflg = 0
+
+         ! Check initialization status
+         if (.not.is_initialized) then
+            write(errmsg,'(*(a))') "Logic error: GFS_phys_time_vary_timestep_init called before GFS_phys_time_vary_init"
+            errflg = 1
+            return
+         end if
+
+         !--- switch for saving convective clouds - cnvc90.f
+         !--- aka Ken Campana/Yu-Tai Hou legacy
+         if ((mod(kdt,nsswr) == 0) .and. (lsswr)) then
+           !--- initialize,accumulate,convert
+           clstp = 1100 + min(fhswr/con_hr,fhour,con_99)
+         elseif (mod(kdt,nsswr) == 0) then
+           !--- accumulate,convert
+           clstp = 0100 + min(fhswr/con_hr,fhour,con_99)
+         elseif (lsswr) then
+           !--- initialize,accumulate
+           clstp = 1100
+         else
+           !--- accumulate
+           clstp = 0100
+         endif
+
+         !--- random number needed for RAS and old SAS and when cal_pre=.true.
+         !    imfdeepcnv < 0 when ras = .true.
+         if ( (imfdeepcnv <= 0 .or. cal_pre) .and. random_clds ) then
+
+           iseed = mod(con_100*sqrt(fhour*con_hr),1.0d9) + seed0
+           call random_setseed(iseed)
+           call random_number(wrk)
+           do i = 1,cnx*nrcm
+             iseed = iseed + nint(wrk(1)*1000.0) * i
+             call random_setseed(iseed)
+             call random_number(rannie)
+             rndval(1+(i-1)*cny:i*cny) = rannie(1:cny)
+           enddo
+
+          do k = 1,nrcm
+            iskip = (k-1)*cnx*cny
+            do ix=1,im
+              j = jmap(ix)
+              i = imap(ix)
+              rann(ix,k) = rndval(i+isc-1 + (j+jsc-2)*cnx + iskip)
+            enddo
+          enddo
+
+         endif  ! imfdeepcnv, cal_re, random_clds
+
+!> - Call ozinterpol() to make ozone interpolation
+         if (ntoz > 0) then
+           call ozinterpol (me, im, idate, fhour, &
+                            jindx1_o3, jindx2_o3, &
+                            ozpl, ddy_o3)
+         endif
+
+!> - Call h2ointerpol() to make stratospheric water vapor data interpolation
+         if (h2o_phys) then
+           call h2ointerpol (me, im, idate, fhour, &
+                             jindx1_h, jindx2_h,   &
+                             h2opl, ddy_h)
+         endif
+
+!> - Call aerinterpol() to make aerosol interpolation
+         if (iaerclm) then
+           call aerinterpol (me, master, im, idate, fhour, &
+                             jindx1_aer, jindx2_aer,       &
+                             ddy_aer, iindx1_aer,          &
+                             iindx2_aer, ddx_aer,          &
+                             levs, prsl, aer_nm)
+         endif
+
+!> - Call ciinterpol() to make IN and CCN data interpolation
+         if (iccn == 1) then
+           call ciinterpol (me, im, idate, fhour,    &
+                            jindx1_ci, jindx2_ci,    &
+                            ddy_ci, iindx1_ci,       &
+                            iindx2_ci, ddx_ci,       &
+                            levs, prsl, in_nm, ccn_nm)
+         endif
+
+!> - Call gcycle() to repopulate specific time-varying surface properties for AMIP/forecast runs
+         if (nscyc >  0) then
+           if (mod(kdt,nscyc) == 1) THEN
+             call gcycle (me, nthrds, nx, ny, isc, jsc, nsst, tile_num, nlunit,       &
+                 input_nml_file, lsoil, kice, idate, ialb, isot, ivegsrc, use_ufo,    &
+                 nst_anl, fhcyc, phour, lakefrac, min_seaice, min_lakeice, frac_grid, &
+                 smc, slc, stc, tiice, tg3, tref, tsfc, tsfco, tisfc, hice, fice,     &
+                 facsf, facwf, alvsf, alvwf, alnsf, alnwf, zorli, zorll, zorlo, weasd,&
+                 slope, snoalb, canopy, vfrac, vtype, stype, shdmin, shdmax, snowd,   &
+                 cv, cvb, cvt, oro, oro_uf, xlat_d, xlon_d, slmsk, imap, jmap)
+           endif
+         endif
+
+      end subroutine GFS_phys_time_vary_timestep_init
+!! @}
+
+!> \section arg_table_GFS_phys_time_vary_timestep_finalize Argument Table
+!! \htmlinclude GFS_phys_time_vary_timestep_finalize.html
+!!
+!>\section gen_GFS_phys_time_vary_timestep_finalize GFS_phys_time_vary_timestep_finalize General Algorithm
+!! @{
+      subroutine GFS_phys_time_vary_timestep_finalize (errmsg, errflg)
+
+         implicit none
+
+         ! Interface variables
+         character(len=*),                 intent(out)   :: errmsg
+         integer,                          intent(out)   :: errflg
+
+         ! Initialize CCPP error handling variables
+         errmsg = ''
+         errflg = 0
+
+      end subroutine GFS_phys_time_vary_timestep_finalize
+!! @}
 
 !> \section arg_table_GFS_phys_time_vary_finalize Argument Table
 !! \htmlinclude GFS_phys_time_vary_finalize.html
@@ -315,216 +478,6 @@
          is_initialized = .false.
 
       end subroutine GFS_phys_time_vary_finalize
-
-
-!> \section arg_table_GFS_phys_time_vary_run Argument Table
-!! \htmlinclude GFS_phys_time_vary_run.html
-!!
-!>\section gen_GFS_phys_time_vary_run GFS_phys_time_vary_run General Algorithm
-!> @{
-      subroutine GFS_phys_time_vary_run (Data, Model, nthrds, first_time_step, errmsg, errflg)
-
-        use mersenne_twister,      only: random_setseed, random_number
-        use machine,               only: kind_phys
-        use GFS_typedefs,          only: GFS_control_type, GFS_data_type
-
-        implicit none
-
-        ! Interface variables
-        type(GFS_data_type),              intent(inout) :: Data(:)
-        type(GFS_control_type),           intent(inout) :: Model
-        integer,                          intent(in)    :: nthrds
-        logical,                          intent(in)    :: first_time_step
-        character(len=*),                 intent(out)   :: errmsg
-        integer,                          intent(out)   :: errflg
-
-        ! Local variables
-        real(kind=kind_phys), parameter :: con_hr  = 3600.0_kind_phys
-        real(kind=kind_phys), parameter :: con_99  =   99.0_kind_phys
-        real(kind=kind_phys), parameter :: con_100 =  100.0_kind_phys
-
-        integer :: i, j, k, iseed, iskip, ix, nb, nblks, kdt_rad, vegtyp
-        real(kind=kind_phys) :: sec_zero, rsnow
-        real(kind=kind_phys) :: wrk(1)
-        real(kind=kind_phys) :: rannie(Model%cny)
-        real(kind=kind_phys) :: rndval(Model%cnx*Model%cny*Model%nrcm)
-
-        ! Initialize CCPP error handling variables
-        errmsg = ''
-        errflg = 0
-
-        ! Check initialization status
-        if (.not.is_initialized) then
-           write(errmsg,'(*(a))') "Logic error: GFS_phys_time_vary_run called before GFS_phys_time_vary_init"
-           errflg = 1
-           return
-        end if
-
-        nblks = size(Model%blksz)
-
-        !--- switch for saving convective clouds - cnvc90.f
-        !--- aka Ken Campana/Yu-Tai Hou legacy
-        if ((mod(Model%kdt,Model%nsswr) == 0) .and. (Model%lsswr)) then
-          !--- initialize,accumulate,convert
-          Model%clstp = 1100 + min(Model%fhswr/con_hr,Model%fhour,con_99)
-        elseif (mod(Model%kdt,Model%nsswr) == 0) then
-          !--- accumulate,convert
-          Model%clstp = 0100 + min(Model%fhswr/con_hr,Model%fhour,con_99)
-        elseif (Model%lsswr) then
-          !--- initialize,accumulate
-          Model%clstp = 1100
-        else
-          !--- accumulate
-          Model%clstp = 0100
-        endif
-
-!$OMP parallel num_threads(nthrds) default(none)              &
-!$OMP          private (nb,iskip,ix,i,j,k)                    &
-!$OMP          shared (Model,Data,iseed,wrk,rannie,rndval)    &
-!$OMP          shared (nblks)
-
-        !--- random number needed for RAS and old SAS and when cal_pre=.true.
-        !    Model%imfdeepcnv < 0 when Model%ras = .true.
-        if ( (Model%imfdeepcnv <= 0 .or. Model%cal_pre) .and. Model%random_clds ) then
-!$OMP single
-          iseed = mod(con_100*sqrt(Model%fhour*con_hr),1.0d9) + Model%seed0
-          call random_setseed(iseed)
-          call random_number(wrk)
-          do i = 1,Model%cnx*Model%nrcm
-            iseed = iseed + nint(wrk(1)*1000.0) * i
-            call random_setseed(iseed)
-            call random_number(rannie)
-            rndval(1+(i-1)*Model%cny:i*Model%cny) = rannie(1:Model%cny)
-          enddo
-!$OMP end single
-
-          do k = 1,Model%nrcm
-            iskip = (k-1)*Model%cnx*Model%cny
-!$OMP do schedule (dynamic,1)
-            do nb=1,nblks
-              do ix=1,Model%blksz(nb)
-                j = Data(nb)%Tbd%jmap(ix)
-                i = Data(nb)%Tbd%imap(ix)
-                Data(nb)%Tbd%rann(ix,k) = rndval(i+Model%isc-1 + (j+Model%jsc-2)*Model%cnx + iskip)
-              enddo
-            enddo
-!$OMP end do
-          enddo
-        endif  ! imfdeepcnv, cal_re, random_clds
-
-!> - Call ozinterpol() to make ozone interpolation
-        if (Model%ntoz > 0) then
-!$OMP do schedule (dynamic,1)
-          do nb = 1, nblks
-            call ozinterpol (Model%me, Model%blksz(nb), Model%idate, Model%fhour, &
-                             Data(nb)%Grid%jindx1_o3, Data(nb)%Grid%jindx2_o3,    &
-                             Data(nb)%Tbd%ozpl, Data(nb)%Grid%ddy_o3)
-          enddo
-!$OMP end do
-        endif
-
-!> - Call h2ointerpol() to make stratospheric water vapor data interpolation
-        if (Model%h2o_phys) then
-!$OMP do schedule (dynamic,1)
-          do nb = 1, nblks
-            call h2ointerpol (Model%me, Model%blksz(nb), Model%idate, Model%fhour, &
-                              Data(nb)%Grid%jindx1_h, Data(nb)%Grid%jindx2_h,      &
-                              Data(nb)%Tbd%h2opl, Data(nb)%Grid%ddy_h)
-          enddo
-!$OMP end do
-        endif
-
-!> - Call aerinterpol() to make aerosol interpolation
-        if (Model%iaerclm) then
-!$OMP do schedule (dynamic,1)
-         do nb = 1, nblks
-           call aerinterpol (Model%me, Model%master, Model%blksz(nb),             &
-                             Model%idate, Model%fhour,                            &
-                             Data(nb)%Grid%jindx1_aer, Data(nb)%Grid%jindx2_aer,  &
-                             Data(nb)%Grid%ddy_aer,Data(nb)%Grid%iindx1_aer,      &
-                             Data(nb)%Grid%iindx2_aer,Data(nb)%Grid%ddx_aer,      &
-                             Model%levs,Data(nb)%Statein%prsl,                    &
-                             Data(nb)%Tbd%aer_nm)
-         enddo
-!$OMP end do
-        endif
-
-!> - Call ciinterpol() to make IN and CCN data interpolation
-        if (Model%iccn == 1) then
-!$OMP do schedule (dynamic,1)
-          do nb = 1, nblks
-            call ciinterpol (Model%me, Model%blksz(nb), Model%idate, Model%fhour, &
-                             Data(nb)%Grid%jindx1_ci, Data(nb)%Grid%jindx2_ci,    &
-                             Data(nb)%Grid%ddy_ci,Data(nb)%Grid%iindx1_ci,        &
-                             Data(nb)%Grid%iindx2_ci,Data(nb)%Grid%ddx_ci,        &
-                             Model%levs,Data(nb)%Statein%prsl,                    &
-                             Data(nb)%Tbd%in_nm, Data(nb)%Tbd%ccn_nm)
-          enddo
-!$OMP end do
-        endif
-
-!$OMP end parallel
-
-!> - Call gcycle() to repopulate specific time-varying surface properties for AMIP/forecast runs
-        if (Model%nscyc >  0) then
-          if (mod(Model%kdt,Model%nscyc) == 1) THEN
-            call gcycle (nblks, nthrds, Model, Data(:)%Grid, Data(:)%Sfcprop, Data(:)%Cldprop)
-          endif
-        endif
-
-        !--- determine if diagnostics buckets need to be cleared
-        sec_zero = nint(Model%fhzero*con_hr)
-        if (sec_zero >= nint(max(Model%fhswr,Model%fhlwr))) then
-          if (mod(Model%kdt,Model%nszero) == 1) then
-            do nb = 1,nblks
-              call Data(nb)%Intdiag%rad_zero  (Model)
-              call Data(nb)%Intdiag%phys_zero (Model)
-        !!!!  THIS IS THE POINT AT WHICH DIAG%ZHOUR NEEDS TO BE UPDATED
-            enddo
-          endif
-        else
-          if (mod(Model%kdt,Model%nszero) == 1) then
-            do nb = 1,nblks
-              call Data(nb)%Intdiag%phys_zero (Model)
-        !!!!  THIS IS THE POINT AT WHICH DIAG%ZHOUR NEEDS TO BE UPDATED
-            enddo
-          endif
-          kdt_rad = nint(min(Model%fhswr,Model%fhlwr)/Model%dtp)
-          if (mod(Model%kdt, kdt_rad) == 1) then
-            do nb = 1,nblks
-              call Data(nb)%Intdiag%rad_zero  (Model)
-        !!!!  THIS IS THE POINT AT WHICH DIAG%ZHOUR NEEDS TO BE UPDATED
-            enddo
-          endif
-        endif
-
-#if 0
-        !Calculate sncovr if it was read in but empty (from FV3/io/FV3GFS_io.F90/sfc_prop_restart_read)
-        if (first_time_step) then
-          if (nint(Data(1)%Sfcprop%sncovr(1)) == -9999) then
-            !--- compute sncovr from existing variables
-            !--- code taken directly from read_fix.f
-            do nb = 1, nblks
-              do ix = 1, Model%blksz(nb)
-                Data(nb)%Sfcprop%sncovr(ix) = 0.0
-                if (Data(nb)%Sfcprop%slmsk(ix) > 0.001) then
-                  vegtyp = Data(nb)%Sfcprop%vtype(ix)
-                  if (vegtyp == 0) vegtyp = 7
-                  rsnow  = 0.001*Data(nb)%Sfcprop%weasd(ix)/snupx(vegtyp)
-                  if (0.001*Data(nb)%Sfcprop%weasd(ix) < snupx(vegtyp)) then
-                    Data(nb)%Sfcprop%sncovr(ix) = 1.0 - (exp(-salp_data*rsnow) - rsnow*exp(-salp_data))
-                  else
-                    Data(nb)%Sfcprop%sncovr(ix) = 1.0
-                  endif
-                endif
-              enddo
-            enddo
-          endif
-        endif
-#endif
-
-      end subroutine GFS_phys_time_vary_run
-!> @}
 
    end module GFS_phys_time_vary
 !> @}

--- a/physics/GFS_phys_time_vary.fv3.F90
+++ b/physics/GFS_phys_time_vary.fv3.F90
@@ -264,11 +264,11 @@
             jindx1_o3, jindx2_o3, ddy_o3, ozpl, jindx1_h, jindx2_h, ddy_h, h2opl,                   &
             jindx1_aer, jindx2_aer, ddy_aer, iindx1_aer, iindx2_aer, ddx_aer, aer_nm,               &
             jindx1_ci, jindx2_ci, ddy_ci, iindx1_ci, iindx2_ci, ddx_ci, in_nm, ccn_nm,              &
-            imap, jmap, prsl, seed0, rann, nthrds, nx, ny, nsst, tile_num, nlunit, lsoil, kice,     &
-            ialb, isot, ivegsrc, input_nml_file, use_ufo, nst_anl, frac_grid, fhcyc, phour,         &
-            lakefrac, min_seaice, min_lakeice, smc, slc, stc, tiice, tg3, tref, tsfc, tsfco, tisfc, &
-            hice, fice, facsf, facwf, alvsf, alvwf, alnsf, alnwf, zorli, zorll, zorlo, weasd,       &
-            slope, snoalb, canopy, vfrac, vtype, stype, shdmin, shdmax, snowd,                      &
+            imap, jmap, prsl, seed0, rann, nthrds, nx, ny, nsst, tile_num, nlunit, lsoil, lsoil_lsm,&
+            kice, ialb, isot, ivegsrc, input_nml_file, use_ufo, nst_anl, frac_grid, fhcyc, phour,   &
+            lakefrac, min_seaice, min_lakeice, smc, slc, stc, smois, sh2o, tslb, tiice, tg3, tref,  &
+            tsfc, tsfco, tisfc, hice, fice, facsf, facwf, alvsf, alvwf, alnsf, alnwf, zorli, zorll, &
+            zorlo, weasd, slope, snoalb, canopy, vfrac, vtype, stype, shdmin, shdmax, snowd,        &
             cv, cvb, cvt, oro, oro_uf, xlat_d, xlon_d, slmsk, errmsg, errflg)
 
          implicit none
@@ -294,15 +294,15 @@
          integer,              intent(in)    :: seed0
          real(kind_phys),      intent(out)   :: rann(:,:)
          ! For gcycle only
-         integer,              intent(in)    :: nthrds, nx, ny, nsst, tile_num, nlunit, lsoil, kice
-         integer,              intent(in)    :: ialb, isot, ivegsrc
+         integer,              intent(in)    :: nthrds, nx, ny, nsst, tile_num, nlunit, lsoil
+         integer,              intent(in)    :: lsoil_lsm, kice, ialb, isot, ivegsrc
          character(len=*),     intent(in)    :: input_nml_file(:)
          logical,              intent(in)    :: use_ufo, nst_anl, frac_grid
          real(kind_phys),      intent(in)    :: fhcyc, phour, lakefrac(:), min_seaice, min_lakeice,  &
                                                 xlat_d(:), xlon_d(:)
-         !
-         real(kind_phys),      intent(inout) :: smc(:,:), slc(:,:), stc(:,:), tiice(:,:), tg3(:),    &
-                                      tref(:), tsfc(:), tsfco(:), tisfc(:), hice(:), fice(:),        &
+         real(kind_phys),      intent(inout) :: smc(:,:), slc(:,:), stc(:,:), smois(:,:), sh2o(:,:), &
+                                      tslb(:,:), tiice(:,:), tg3(:), tref(:),                        &
+                                      tsfc(:), tsfco(:), tisfc(:), hice(:), fice(:),                 &
                                       facsf(:), facwf(:), alvsf(:), alvwf(:), alnsf(:), alnwf(:),    &
                                       zorli(:), zorll(:), zorlo(:), weasd(:), slope(:), snoalb(:),   &
                                       canopy(:), vfrac(:), vtype(:), stype(:), shdmin(:), shdmax(:), &
@@ -405,12 +405,13 @@
          if (nscyc >  0) then
            if (mod(kdt,nscyc) == 1) THEN
              call gcycle (me, nthrds, nx, ny, isc, jsc, nsst, tile_num, nlunit,       &
-                 input_nml_file, lsoil, kice, idate, ialb, isot, ivegsrc, use_ufo,    &
-                 nst_anl, fhcyc, phour, lakefrac, min_seaice, min_lakeice, frac_grid, &
-                 smc, slc, stc, tiice, tg3, tref, tsfc, tsfco, tisfc, hice, fice,     &
-                 facsf, facwf, alvsf, alvwf, alnsf, alnwf, zorli, zorll, zorlo, weasd,&
-                 slope, snoalb, canopy, vfrac, vtype, stype, shdmin, shdmax, snowd,   &
-                 cv, cvb, cvt, oro, oro_uf, xlat_d, xlon_d, slmsk, imap, jmap)
+                 input_nml_file, lsoil, lsoil_lsm, kice, idate, ialb, isot, ivegsrc,  &
+                 use_ufo, nst_anl, fhcyc, phour, lakefrac, min_seaice, min_lakeice,   &
+                 frac_grid, smc, slc, stc, smois, sh2o, tslb, tiice, tg3, tref, tsfc, &
+                 tsfco, tisfc, hice, fice, facsf, facwf, alvsf, alvwf, alnsf, alnwf,  &
+                 zorli, zorll, zorlo, weasd, slope, snoalb, canopy, vfrac, vtype,     &
+                 stype, shdmin, shdmax, snowd, cv, cvb, cvt, oro, oro_uf,             &
+                 xlat_d, xlon_d, slmsk, imap, jmap)
            endif
          endif
 

--- a/physics/GFS_phys_time_vary.fv3.F90
+++ b/physics/GFS_phys_time_vary.fv3.F90
@@ -296,7 +296,7 @@
          integer,              intent(in)    :: imap(:), jmap(:)
          real(kind_phys),      intent(in)    :: prsl(:,:)
          integer,              intent(in)    :: seed0
-         real(kind_phys),      intent(out)   :: rann(:,:)
+         real(kind_phys),      intent(inout) :: rann(:,:)
          ! For gcycle only
          integer,              intent(in)    :: nthrds, nx, ny, nsst, tile_num, nlunit, lsoil
          integer,              intent(in)    :: lsoil_lsm, kice, ialb, isot, ivegsrc

--- a/physics/GFS_phys_time_vary.fv3.F90
+++ b/physics/GFS_phys_time_vary.fv3.F90
@@ -92,7 +92,7 @@
          if (is_initialized) return
 
 !$OMP parallel num_threads(nthrds) default(none)                                    &
-!$OMP          shared (me,master,ntoz,h2o_phys,im)                                  &
+!$OMP          shared (me,master,ntoz,h2o_phys,im,nx,ny,idate)                      &
 !$OMP          shared (xlat_d,xlon_d,imap,jmap,errmsg,errflg)                       &
 !$OMP          shared (levozp,oz_coeff,oz_pres,ozpl)                                &
 !$OMP          shared (levh2o,h2o_coeff,h2o_pres,h2opl)                             &
@@ -177,7 +177,11 @@
            ! hardcoded in module iccn_def.F and GFS_typedefs.F90
          endif
 
-!$OMP barrier
+!$OMP end sections
+
+! Need an OpenMP barrier here (implicit in "end sections")
+
+!$OMP sections
 
 !$OMP section
 !> - Call setindxoz() to initialize ozone data

--- a/physics/GFS_phys_time_vary.fv3.meta
+++ b/physics/GFS_phys_time_vary.fv3.meta
@@ -7,28 +7,304 @@
 [ccpp-arg-table]
   name = GFS_phys_time_vary_init
   type = scheme
-[Data]
-  standard_name = GFS_data_type_instance_all_blocks
-  long_name = Fortran DDT containing FV3-GFS data
-  units = DDT
-  dimensions = (ccpp_block_count)
-  type = GFS_data_type
-  intent = inout
-  optional = F
-[Model]
-  standard_name = GFS_control_type_instance
-  long_name = Fortran DDT containing FV3-GFS model control parameters
-  units = DDT
+
+[me]
+  standard_name = mpi_rank
+  long_name = current MPI-rank
+  units = index
   dimensions = ()
-  type = GFS_control_type
+  type = integer
+  intent = in
+  optional = F
+[master]
+  standard_name = mpi_root
+  long_name = master MPI-rank
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ntoz]
+  standard_name = index_for_ozone
+  long_name = tracer index for ozone mixing ratio
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[h2o_phys]
+  standard_name = flag_for_stratospheric_water_vapor_physics
+  long_name = flag for stratospheric water vapor physics
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[iaerclm]
+  standard_name = flag_for_aerosol_input_MG_radiation
+  long_name = flag for using aerosols in Morrison-Gettelman MP_radiation
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[iccn]
+  standard_name = flag_for_in_ccn_forcing_for_morrison_gettelman_microphysics
+  long_name = flag for IN and CCN forcing for morrison gettelman microphysics
+  units = none
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[iflip]
+  standard_name = flag_for_vertical_index_direction_control
+  long_name = iflip - is not the same as flipv
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[im]
+  standard_name = horizontal_dimension
+  long_name = horizontal dimension
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[nx]
+  standard_name = number_of_points_in_x_direction_for_this_MPI_rank
+  long_name = number of points in x direction for this MPI rank
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ny]
+  standard_name = number_of_points_in_y_direction_for_this_MPI_rank
+  long_name = number of points in y direction for this MPI rank
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[idate]
+  standard_name = date_and_time_at_model_initialization_reordered
+  long_name = initial date with different size and ordering
+  units = none
+  dimensions = (4)
+  type = integer
+  intent = in
+  optional = F
+[xlat_d]
+  standard_name = latitude_in_degree
+  long_name = latitude in degree north
+  units = degree_north
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[xlon_d]
+  standard_name = longitude_in_degree
+  long_name = longitude in degree east
+  units = degree_east
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[jindx1_o3]
+  standard_name = lower_ozone_interpolation_index
+  long_name = interpolation low index for ozone
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
   intent = inout
   optional = F
-[Interstitial]
-  standard_name = GFS_interstitial_type_instance_all_threads
-  long_name = Fortran DDT containing FV3-GFS interstitial data
-  units = DDT
-  dimensions = (omp_threads)
-  type = GFS_interstitial_type
+[jindx2_o3]
+  standard_name = upper_ozone_interpolation_index
+  long_name = interpolation high index for ozone
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = inout
+  optional = F
+[ddy_o3]
+  standard_name = ozone_interpolation_weight
+  long_name = interpolation high index for ozone
+  units = none
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[ozpl]
+  standard_name = ozone_forcing
+  long_name = ozone forcing data
+  units = various
+  dimensions = (horizontal_dimension,vertical_dimension_of_ozone_forcing_data,number_of_coefficients_in_ozone_forcing_data)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[jindx1_h]
+  standard_name = lower_water_vapor_interpolation_index
+  long_name = interpolation low index for stratospheric water vapor
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = inout
+  optional = F
+[jindx2_h]
+  standard_name = upper_water_vapor_interpolation_index
+  long_name = interpolation high index for stratospheric water vapor
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = inout
+  optional = F
+[ddy_h]
+  standard_name = water_vapor_interpolation_weight
+  long_name = interpolation high index for stratospheric water vapor
+  units = none
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[h2opl]
+  standard_name = h2o_forcing
+  long_name = water forcing data
+  units = various
+  dimensions = (horizontal_dimension,vertical_dimension_of_h2o_forcing_data,number_of_coefficients_in_h2o_forcing_data)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[jindx1_aer]
+  standard_name = lower_aerosol_y_interpolation_index
+  long_name = interpolation low index for prescribed aerosols in the y direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = inout
+  optional = F
+[jindx2_aer]
+  standard_name = upper_aerosol_y_interpolation_index
+  long_name = interpolation high index for prescribed aerosols in the y direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = inout
+  optional = F
+[ddy_aer]
+  standard_name = aerosol_y_interpolation_weight
+  long_name = interpolation high index for prescribed aerosols in the y direction
+  units = none
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[iindx1_aer]
+  standard_name = lower_aerosol_x_interpolation_index
+  long_name = interpolation low index for prescribed aerosols in the x direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = inout
+  optional = F
+[iindx2_aer]
+  standard_name = upper_aerosol_x_interpolation_index
+  long_name = interpolation high index for prescribed aerosols in the x direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = inout
+  optional = F
+[ddx_aer]
+  standard_name = aerosol_x_interpolation_weight
+  long_name = interpolation high index for prescribed aerosols in the x direction
+  units = none
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[aer_nm]
+  standard_name = aerosol_number_concentration_from_gocart_aerosol_climatology
+  long_name = GOCART aerosol climatology number concentration
+  units = kg-1
+  dimensions = (horizontal_dimension,vertical_dimension,number_of_aerosol_tracers_MG)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[jindx1_ci]
+  standard_name = lower_cloud_nuclei_y_interpolation_index
+  long_name = interpolation low index for ice and cloud condensation nuclei in the y direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = inout
+  optional = F
+[jindx2_ci]
+  standard_name = upper_cloud_nuclei_y_interpolation_index
+  long_name = interpolation high index for ice and cloud condensation nuclei in the y direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = inout
+  optional = F
+[ddy_ci]
+  standard_name = cloud_nuclei_y_interpolation_weight
+  long_name = interpolation high index for ice and cloud condensation nuclei in the y direction
+  units = none
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[iindx1_ci]
+  standard_name = lower_cloud_nuclei_x_interpolation_index
+  long_name = interpolation low index for ice and cloud condensation nuclei in the x direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = inout
+  optional = F
+[iindx2_ci]
+  standard_name = upper_cloud_nuclei_x_interpolation_index
+  long_name = interpolation high index for ice and cloud condensation nuclei in the x direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = inout
+  optional = F
+[ddx_ci]
+  standard_name = cloud_nuclei_x_interpolation_weight
+  long_name = interpolation high index for ice and cloud condensation nuclei in the x direction
+  units = none
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[imap]
+  standard_name = map_of_block_column_number_to_global_i_index
+  long_name = map of local index ix to global index i for this block
+  units = none
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = inout
+  optional = F
+[jmap]
+  standard_name = map_of_block_column_number_to_global_j_index
+  long_name = map of local index ix to global index j for this block
+  units = none
+  dimensions = (horizontal_dimension)
+  type = integer
   intent = inout
   optional = F
 [nthrds]
@@ -81,23 +357,439 @@
 
 ########################################################################
 [ccpp-arg-table]
-  name = GFS_phys_time_vary_run
+  name = GFS_phys_time_vary_timestep_init
   type = scheme
-[Data]
-  standard_name = GFS_data_type_instance_all_blocks
-  long_name = Fortran DDT containing FV3-GFS data
-  units = DDT
-  dimensions = (ccpp_block_count)
-  type = GFS_data_type
+[me]
+  standard_name = mpi_rank
+  long_name = current MPI-rank
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[master]
+  standard_name = mpi_root
+  long_name = master MPI-rank
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[cnx]
+  standard_name = number_of_points_in_x_direction_for_this_cubed_sphere_face
+  long_name = number of points in x direction for this cubed sphere face
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[cny]
+  standard_name = number_of_points_in_y_direction_for_this_cubed_sphere_face
+  long_name = number of points in y direction for this cubed sphere face
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[isc]
+  standard_name = starting_x_index_for_this_MPI_rank
+  long_name = starting index in the x direction for this MPI rank
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[jsc]
+  standard_name = starting_y_index_for_this_MPI_rank
+  long_name = starting index in the y direction for this MPI rank
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[nrcm]
+  standard_name = array_dimension_of_random_number
+  long_name = second dimension of random number stream for RAS
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[im]
+  standard_name = horizontal_dimension
+  long_name = horizontal dimension
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[levs]
+  standard_name = vertical_dimension
+  long_name = number of vertical levels
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[kdt]
+  standard_name = index_of_time_step
+  long_name = current forecast iteration
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[idate]
+  standard_name = date_and_time_at_model_initialization_reordered
+  long_name = initial date with different size and ordering
+  units = none
+  dimensions = (4)
+  type = integer
+  intent = in
+  optional = F
+[nsswr]
+  standard_name = number_of_timesteps_between_shortwave_radiation_calls
+  long_name = number of timesteps between shortwave radiation calls
+  units = 
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[fhswr]
+  standard_name = frequency_for_shortwave_radiation
+  long_name = frequency for shortwave radiation
+  units = s
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[lsswr]
+  standard_name = flag_to_calc_sw
+  long_name = logical flags for sw radiation calls
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[fhour]
+  standard_name = forecast_time
+  long_name = current forecast time
+  units = h
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[imfdeepcnv]
+  standard_name = flag_for_mass_flux_deep_convection_scheme
+  long_name = flag for mass-flux deep convection scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[cal_pre]
+  standard_name = flag_for_precipitation_type_algorithm
+  long_name = flag controls precip type algorithm
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[random_clds]
+  standard_name = flag_for_random_clouds_for_RAS
+  long_name = flag for using random clouds with the RAS scheme
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[nscyc]
+  standard_name = number_of_timesteps_between_surface_cycling_calls
+  long_name = number of timesteps between surface cycling calls
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ntoz]
+  standard_name = index_for_ozone
+  long_name = tracer index for ozone mixing ratio
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[h2o_phys]
+  standard_name = flag_for_stratospheric_water_vapor_physics
+  long_name = flag for stratospheric water vapor physics
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[iaerclm]
+  standard_name = flag_for_aerosol_input_MG_radiation
+  long_name = flag for using aerosols in Morrison-Gettelman MP_radiation
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[iccn]
+  standard_name = flag_for_in_ccn_forcing_for_morrison_gettelman_microphysics
+  long_name = flag for IN and CCN forcing for morrison gettelman microphysics
+  units = none
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[clstp]
+  standard_name = convective_cloud_switch
+  long_name = index used by cnvc90 (for convective clouds)
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = out
+  optional = F
+[jindx1_o3]
+  standard_name = lower_ozone_interpolation_index
+  long_name = interpolation low index for ozone
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = in
+  optional = F
+[jindx2_o3]
+  standard_name = upper_ozone_interpolation_index
+  long_name = interpolation high index for ozone
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = in
+  optional = F
+[ddy_o3]
+  standard_name = ozone_interpolation_weight
+  long_name = interpolation high index for ozone
+  units = none
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[ozpl]
+  standard_name = ozone_forcing
+  long_name = ozone forcing data
+  units = various
+  dimensions = (horizontal_dimension,vertical_dimension_of_ozone_forcing_data,number_of_coefficients_in_ozone_forcing_data)
+  type = real
+  kind = kind_phys
   intent = inout
   optional = F
-[Model]
-  standard_name = GFS_control_type_instance
-  long_name = Fortran DDT containing FV3-GFS model control parameters
-  units = DDT
-  dimensions = ()
-  type = GFS_control_type
+[jindx1_h]
+  standard_name = lower_water_vapor_interpolation_index
+  long_name = interpolation low index for stratospheric water vapor
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = in
+  optional = F
+[jindx2_h]
+  standard_name = upper_water_vapor_interpolation_index
+  long_name = interpolation high index for stratospheric water vapor
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = in
+  optional = F
+[ddy_h]
+  standard_name = water_vapor_interpolation_weight
+  long_name = interpolation high index for stratospheric water vapor
+  units = none
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[h2opl]
+  standard_name = h2o_forcing
+  long_name = water forcing data
+  units = various
+  dimensions = (horizontal_dimension,vertical_dimension_of_h2o_forcing_data,number_of_coefficients_in_h2o_forcing_data)
+  type = real
+  kind = kind_phys
   intent = inout
+  optional = F
+[jindx1_aer]
+  standard_name = lower_aerosol_y_interpolation_index
+  long_name = interpolation low index for prescribed aerosols in the y direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = in
+  optional = F
+[jindx2_aer]
+  standard_name = upper_aerosol_y_interpolation_index
+  long_name = interpolation high index for prescribed aerosols in the y direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = in
+  optional = F
+[ddy_aer]
+  standard_name = aerosol_y_interpolation_weight
+  long_name = interpolation high index for prescribed aerosols in the y direction
+  units = none
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[iindx1_aer]
+  standard_name = lower_aerosol_x_interpolation_index
+  long_name = interpolation low index for prescribed aerosols in the x direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = in
+  optional = F
+[iindx2_aer]
+  standard_name = upper_aerosol_x_interpolation_index
+  long_name = interpolation high index for prescribed aerosols in the x direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = in
+  optional = F
+[ddx_aer]
+  standard_name = aerosol_x_interpolation_weight
+  long_name = interpolation high index for prescribed aerosols in the x direction
+  units = none
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[aer_nm]
+  standard_name = aerosol_number_concentration_from_gocart_aerosol_climatology
+  long_name = GOCART aerosol climatology number concentration
+  units = kg-1
+  dimensions = (horizontal_dimension,vertical_dimension,number_of_aerosol_tracers_MG)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[jindx1_ci]
+  standard_name = lower_cloud_nuclei_y_interpolation_index
+  long_name = interpolation low index for ice and cloud condensation nuclei in the y direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = in
+  optional = F
+[jindx2_ci]
+  standard_name = upper_cloud_nuclei_y_interpolation_index
+  long_name = interpolation high index for ice and cloud condensation nuclei in the y direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = in
+  optional = F
+[ddy_ci]
+  standard_name = cloud_nuclei_y_interpolation_weight
+  long_name = interpolation high index for ice and cloud condensation nuclei in the y direction
+  units = none
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[iindx1_ci]
+  standard_name = lower_cloud_nuclei_x_interpolation_index
+  long_name = interpolation low index for ice and cloud condensation nuclei in the x direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = in
+  optional = F
+[iindx2_ci]
+  standard_name = upper_cloud_nuclei_x_interpolation_index
+  long_name = interpolation high index for ice and cloud condensation nuclei in the x direction
+  units = index
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = in
+  optional = F
+[ddx_ci]
+  standard_name = cloud_nuclei_x_interpolation_weight
+  long_name = interpolation high index for ice and cloud condensation nuclei in the x direction
+  units = none
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[in_nm]
+  standard_name = ice_nucleation_number
+  long_name = ice nucleation number in MG MP
+  units = kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[ccn_nm]
+  standard_name = tendency_of_ccn_activated_number
+  long_name = tendency of ccn activated number
+  units = kg-1 s-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[imap]
+  standard_name = map_of_block_column_number_to_global_i_index
+  long_name = map of local index ix to global index i for this block
+  units = none
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = in
+  optional = F
+[jmap]
+  standard_name = map_of_block_column_number_to_global_j_index
+  long_name = map of local index ix to global index j for this block
+  units = none
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = in
+  optional = F
+[prsl]
+  standard_name = air_pressure
+  long_name = mean layer pressure
+  units = Pa
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[seed0]
+  standard_name = seed_random_numbers_RAS
+  long_name = random number seed for the RAS scheme
+  units = none
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[rann]
+  standard_name = random_number_array
+  long_name = random number array (0-1)
+  units = none
+  dimensions = (horizontal_dimension,array_dimension_of_random_number)
+  type = real
+  kind = kind_phys
+  intent = out
   optional = F
 [nthrds]
   standard_name = omp_threads
@@ -107,14 +799,529 @@
   type = integer
   intent = in
   optional = F
-[first_time_step]
-  standard_name = flag_for_first_time_step
-  long_name = flag for first time step for time integration loop (cold/warmstart)
+[nx]
+  standard_name = number_of_points_in_x_direction_for_this_MPI_rank
+  long_name = number of points in x direction for this MPI rank
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ny]
+  standard_name = number_of_points_in_y_direction_for_this_MPI_rank
+  long_name = number of points in y direction for this MPI rank
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[nsst]
+  standard_name = flag_for_nsstm_run
+  long_name = NSSTM flag: off/uncoupled/coupled=0/1/2
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[tile_num]
+  standard_name = number_of_tile
+  long_name = tile number
+  units = none
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[nlunit]
+  standard_name = iounit_namelist
+  long_name = fortran unit number for file opens
+  units = none
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lsoil]
+  standard_name = soil_vertical_dimension
+  long_name = number of soil layers
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[kice]
+  standard_name = ice_vertical_dimension
+  long_name = vertical loop extent for ice levels, start at 1
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ialb]
+  standard_name = flag_for_using_climatology_albedo
+  long_name = flag for using climatology alb, based on sfc type
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[isot]
+  standard_name = soil_type_dataset_choice
+  long_name = soil type dataset choice
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ivegsrc]
+  standard_name = vegetation_type_dataset_choice
+  long_name = land use dataset choice
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[input_nml_file]
+  standard_name = namelist_filename_for_internal_file_reads
+  long_name = namelist filename for internal file reads
+  units = none
+  dimensions = (number_of_lines_of_namelist_filename_for_internal_file_reads)
+  type = character
+  kind = len=256
+  intent = in
+  optional = F
+[use_ufo]
+  standard_name = flag_for_gcycle_surface_option
+  long_name = flag for gcycle surface option
   units = flag
   dimensions = ()
   type = logical
   intent = in
   optional = F
+[nst_anl]
+  standard_name = flag_for_nsstm_analysis_in_gcycle
+  long_name = flag for NSSTM analysis in gcycle/sfcsub
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[frac_grid]
+  standard_name = flag_for_fractional_grid
+  long_name = flag for fractional grid
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[fhcyc]
+  standard_name = frequency_for_surface_cycling_calls
+  long_name = frequency for surface cycling calls
+  units = h
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[phour]
+  standard_name = forecast_time_at_previous_timestep
+  long_name = forecast time at the previous timestep
+  units = h
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[lakefrac]
+  standard_name = lake_area_fraction
+  long_name = fraction of horizontal grid area occupied by lake
+  units = frac
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[min_seaice]
+  standard_name = sea_ice_minimum
+  long_name = minimum sea ice value
+  units = frac
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[min_lakeice]
+  standard_name = lake_ice_minimum
+  long_name = minimum lake ice value
+  units = frac
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[smc]
+  standard_name = volume_fraction_of_soil_moisture
+  long_name = total soil moisture
+  units = frac
+  dimensions = (horizontal_dimension,soil_vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[slc]
+  standard_name = volume_fraction_of_unfrozen_soil_moisture
+  long_name = liquid soil moisture
+  units = frac
+  dimensions = (horizontal_dimension,soil_vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[stc]
+  standard_name = soil_temperature
+  long_name = soil temperature
+  units = K
+  dimensions = (horizontal_dimension,soil_vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[tiice]
+  standard_name = internal_ice_temperature
+  long_name = sea ice internal temperature
+  units = K
+  dimensions = (horizontal_dimension,ice_vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[tg3]
+  standard_name = deep_soil_temperature
+  long_name = deep soil temperature
+  units = K
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[tref]
+  standard_name = sea_surface_reference_temperature
+  long_name = sea surface reference temperature
+  units = K
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  active = (flag_for_nsstm_run > 0)
+  intent = inout
+  optional = F
+[tsfc]
+  standard_name = surface_skin_temperature
+  long_name = surface skin temperature
+  units = K
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[tsfco]
+  standard_name = sea_surface_temperature
+  long_name = sea surface temperature
+  units = K
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[tisfc]
+  standard_name = sea_ice_temperature
+  long_name = sea ice surface skin temperature
+  units = K
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[hice]
+  standard_name = sea_ice_thickness
+  long_name = sea ice thickness
+  units = m
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[fice]
+  standard_name = sea_ice_concentration
+  long_name = ice fraction over open water
+  units = frac
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[facsf]
+  standard_name =fractional_coverage_with_strong_cosz_dependency
+  long_name = fractional coverage with strong cosz dependency
+  units = frac
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[facwf]
+  standard_name = fractional_coverage_with_weak_cosz_dependency
+  long_name = fractional coverage with weak cosz dependency
+  units = frac
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[alvsf]
+  standard_name = mean_vis_albedo_with_strong_cosz_dependency
+  long_name = mean vis albedo with strong cosz dependency
+  units = frac
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[alvwf]
+  standard_name = mean_vis_albedo_with_weak_cosz_dependency
+  long_name = mean vis albedo with weak cosz dependency
+  units = frac
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[alnsf]
+  standard_name = mean_nir_albedo_with_strong_cosz_dependency
+  long_name = mean nir albedo with strong cosz dependency
+  units = frac
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[alnwf]
+  standard_name = mean_nir_albedo_with_weak_cosz_dependency
+  long_name = mean nir albedo with weak cosz dependency
+  units = frac
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[zorli]
+  standard_name = surface_roughness_length_over_ice
+  long_name = surface roughness length over ice
+  units = cm
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[zorll]
+  standard_name = surface_roughness_length_over_land
+  long_name = surface roughness length over land
+  units = cm
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[zorlo]
+  standard_name = surface_roughness_length_over_ocean
+  long_name = surface roughness length over ocean
+  units = cm
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[weasd]
+  standard_name = water_equivalent_accumulated_snow_depth
+  long_name = water equiv of acc snow depth over land and sea ice
+  units = mm
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[slope]
+  standard_name = surface_slope_classification_real
+  long_name = sfc slope type for lsm
+  units = index
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[snoalb]
+  standard_name = upper_bound_on_max_albedo_over_deep_snow
+  long_name = maximum snow albedo
+  units = frac
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[canopy]
+  standard_name = canopy_water_amount
+  long_name = canopy water amount
+  units = kg m-2
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[vfrac]
+  standard_name = vegetation_area_fraction
+  long_name = areal fractional cover of green vegetation
+  units = frac
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[vtype]
+  standard_name = vegetation_type_classification_real
+  long_name = vegetation type for lsm
+  units = index
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[stype]
+  standard_name = soil_type_classification_real
+  long_name = soil type for lsm
+  units = index
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[shdmin]
+  standard_name = minimum_vegetation_area_fraction
+  long_name = min fractional coverage of green vegetation
+  units = frac
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[shdmax]
+  standard_name = maximum_vegetation_area_fraction
+  long_name = max fractional coverage of green vegetation
+  units = frac
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[snowd]
+  standard_name = surface_snow_thickness_water_equivalent
+  long_name = water equivalent snow depth
+  units = mm
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[cv]
+  standard_name = fraction_of_convective_cloud
+  long_name = fraction of convective cloud
+  units = frac
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[cvb]
+  standard_name = pressure_at_bottom_of_convective_cloud
+  long_name = convective cloud bottom pressure
+  units = Pa
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[cvt]
+  standard_name = pressure_at_top_of_convective_cloud
+  long_name = convective cloud top pressure
+  units = Pa
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[oro]
+  standard_name = orography
+  long_name = orography
+  units = m
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[oro_uf]
+  standard_name = orography_unfiltered
+  long_name = unfiltered orography
+  units = m
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[xlat_d]
+  standard_name = latitude_in_degree
+  long_name = latitude in degree north
+  units = degree_north
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[xlon_d]
+  standard_name = longitude_in_degree
+  long_name = longitude in degree east
+  units = degree_east
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[slmsk]
+  standard_name = sea_land_ice_mask_real
+  long_name = landmask: sea/land/ice=0/1/2
+  units = flag
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+  optional = F
+[errflg]
+  standard_name = ccpp_error_flag
+  long_name = error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+  optional = F
+
+########################################################################
+[ccpp-arg-table]
+  name = GFS_phys_time_vary_timestep_finalize
+  type = scheme
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP

--- a/physics/GFS_phys_time_vary.fv3.meta
+++ b/physics/GFS_phys_time_vary.fv3.meta
@@ -847,6 +847,14 @@
   type = integer
   intent = in
   optional = F
+[lsoil_lsm]
+  standard_name = soil_vertical_dimension_for_land_surface_model
+  long_name = number of soil layers internal to land surface model
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
 [kice]
   standard_name = ice_vertical_dimension
   long_name = vertical loop extent for ice levels, start at 1
@@ -980,6 +988,33 @@
   long_name = soil temperature
   units = K
   dimensions = (horizontal_dimension,soil_vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[smois]
+  standard_name = volume_fraction_of_soil_moisture_for_land_surface_model
+  long_name = volumetric fraction of soil moisture for lsm
+  units = frac
+  dimensions = (horizontal_loop_extent,soil_vertical_dimension_for_land_surface_model)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[sh2o]
+  standard_name = volume_fraction_of_unfrozen_soil_moisture_for_land_surface_model
+  long_name = volume fraction of unfrozen soil moisture for lsm
+  units = frac
+  dimensions = (horizontal_loop_extent,soil_vertical_dimension_for_land_surface_model)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[tslb]
+  standard_name = soil_temperature_for_land_surface_model
+  long_name = soil temperature for land surface model
+  units = K
+  dimensions = (horizontal_loop_extent,soil_vertical_dimension_for_land_surface_model)
   type = real
   kind = kind_phys
   intent = inout

--- a/physics/GFS_phys_time_vary.fv3.meta
+++ b/physics/GFS_phys_time_vary.fv3.meta
@@ -789,7 +789,7 @@
   dimensions = (horizontal_dimension,array_dimension_of_random_number)
   type = real
   kind = kind_phys
-  intent = out
+  intent = inout
   optional = F
 [nthrds]
   standard_name = omp_threads

--- a/physics/GFS_rad_time_vary.fv3.F90
+++ b/physics/GFS_rad_time_vary.fv3.F90
@@ -6,99 +6,87 @@
 
       private
 
-      public GFS_rad_time_vary_init, GFS_rad_time_vary_run, GFS_rad_time_vary_finalize
+      public GFS_rad_time_vary_timestep_init
 
       contains
 
-      subroutine GFS_rad_time_vary_init
-      end subroutine GFS_rad_time_vary_init
-
 !>\defgroup mod_GFS_rad_time_vary GFS Radiation Time Update
 !> @{
-!> \section arg_table_GFS_rad_time_vary_run Argument Table
-!! \htmlinclude GFS_rad_time_vary_run.html
+!> \section arg_table_GFS_rad_time_vary_timestep_init Argument Table
+!! \htmlinclude GFS_rad_time_vary_timestep_init.html
 !!
-      subroutine GFS_rad_time_vary_run (Model, Data, nthrds, errmsg, errflg)
+      subroutine GFS_rad_time_vary_timestep_init (                                     &
+              lslwr, lsswr, isubc_lw, isubc_sw, icsdsw, icsdlw, cnx, cny, isc, jsc,    &
+              imap, jmap, sec, kdt, imp_physics, imp_physics_zhao_carr, ps_2delt,      &
+              ps_1delt, t_2delt, t_1delt, qv_2delt, qv_1delt, t, qv, ps, errmsg, errflg)
 
          use physparam,                 only: ipsd0, ipsdlim, iaerflg
          use mersenne_twister,          only: random_setseed, random_index, random_stat
          use machine,                   only: kind_phys
-         use GFS_typedefs,              only: GFS_control_type, &
-                                              GFS_data_type
          use radcons,                   only: qmin, con_100
 
          implicit none
 
-         type(GFS_control_type), intent(inout) :: Model
-         type(GFS_data_type),    intent(inout) :: Data(:)
-         integer,                intent(in)    :: nthrds
+         ! Interface variables
+         integer,                intent(in)    :: isubc_lw, isubc_sw, cnx, cny, isc, jsc, kdt
+         integer,                intent(in)    :: imp_physics, imp_physics_zhao_carr
+         logical,                intent(in)    :: lslwr, lsswr
+         integer,                intent(inout) :: icsdsw(:), icsdlw(:)
+         integer,                intent(in)    :: imap(:), jmap(:)
+         real(kind_phys),        intent(in)    :: sec
+         real(kind_phys),        intent(inout) :: ps_2delt(:)
+         real(kind_phys),        intent(inout) :: ps_1delt(:)
+         real(kind_phys),        intent(inout) :: t_2delt(:,:)
+         real(kind_phys),        intent(inout) :: t_1delt(:,:)
+         real(kind_phys),        intent(inout) :: qv_2delt(:,:)
+         real(kind_phys),        intent(inout) :: qv_1delt(:,:)
+         real(kind_phys),        intent(in)    :: t(:,:), qv(:,:), ps(:)
          character(len=*),       intent(out)   :: errmsg
          integer,                intent(out)   :: errflg
 
-         !--- local variables
+         ! Local variables
          type (random_stat) :: stat
-         integer :: ix, nb, j, i, nblks, ipseed
-         integer :: numrdm(Model%cnx*Model%cny*2)
+         integer :: ix, j, i, nblks, ipseed
+         integer :: numrdm(cnx*cny*2)
 
          ! Initialize CCPP error handling variables
          errmsg = ''
          errflg = 0
 
-         if (Model%lsswr .or. Model%lslwr) then
+         if (lsswr .or. lslwr) then
 
-           nblks = size(Model%blksz)
-
-           !--- call to GFS_radupdate_run is now in GFS_rrtmg_setup_run
-
-!$OMP parallel num_threads(nthrds) default(none)        &
-!$OMP          private (nb,ix,i,j)                      &
-!$OMP          shared (Model,Data,ipsdlim,ipsd0,ipseed) &
-!$OMP          shared (numrdm,stat,nblks)
+           !--- call to GFS_radupdate_timestep_init is now in GFS_rrtmg_setup_timestep_init
 
            !--- set up random seed index in a reproducible way for entire cubed-sphere face (lat-lon grid)
-           if ((Model%isubc_lw==2) .or. (Model%isubc_sw==2)) then
-!$OMP single
-             ipseed = mod(nint(con_100*sqrt(Model%sec)), ipsdlim) + 1 + ipsd0
+           if ((isubc_lw==2) .or. (isubc_sw==2)) then
+             ipseed = mod(nint(con_100*sqrt(sec)), ipsdlim) + 1 + ipsd0
              call random_setseed (ipseed, stat)
              call random_index (ipsdlim, numrdm, stat)
-!$OMP end single
 
-!$OMP do schedule (dynamic,1)
-             do nb=1,nblks
-               do ix=1,Model%blksz(nb)
-                 j = Data(nb)%Tbd%jmap(ix)
-                 i = Data(nb)%Tbd%imap(ix)
-                 !--- for testing purposes, replace numrdm with '100'
-                 Data(nb)%Tbd%icsdsw(ix) = numrdm(i+Model%isc-1 + (j+Model%jsc-2)*Model%cnx)
-                 Data(nb)%Tbd%icsdlw(ix) = numrdm(i+Model%isc-1 + (j+Model%jsc-2)*Model%cnx + Model%cnx*Model%cny)
-               enddo
+             do ix=1,size(jmap)
+               j = jmap(ix)
+               i = imap(ix)
+               !--- for testing purposes, replace numrdm with '100'
+               icsdsw(ix) = numrdm(i+isc-1 + (j+jsc-2)*cnx)
+               icsdlw(ix) = numrdm(i+isc-1 + (j+jsc-2)*cnx + cnx*cny)
              enddo
-!$OMP end do
+
            endif  ! isubc_lw and isubc_sw
 
-           if (Model%imp_physics == 99) then
-             if (Model%kdt == 1) then
-!$OMP do schedule (dynamic,1)
-               do nb = 1,nblks
-                 Data(nb)%Tbd%phy_f3d(:,:,1) = Data(nb)%Statein%tgrs
-                 Data(nb)%Tbd%phy_f3d(:,:,2) = max(qmin,Data(nb)%Statein%qgrs(:,:,1))
-                 Data(nb)%Tbd%phy_f3d(:,:,3) = Data(nb)%Statein%tgrs
-                 Data(nb)%Tbd%phy_f3d(:,:,4) = max(qmin,Data(nb)%Statein%qgrs(:,:,1))
-                 Data(nb)%Tbd%phy_f2d(:,1)   = Data(nb)%Statein%prsi(:,1)
-                 Data(nb)%Tbd%phy_f2d(:,2)   = Data(nb)%Statein%prsi(:,1)
-               enddo
-!$OMP end do
+           if (imp_physics == imp_physics_zhao_carr) then
+             if (kdt == 1) then
+               t_2delt  = t
+               t_1delt  = t
+               qv_2delt = qv
+               qv_1delt = qv
+               ps_2delt = ps
+               ps_1delt = ps
              endif
            endif
 
-!$OMP end parallel
-
          endif
 
-      end subroutine GFS_rad_time_vary_run
+      end subroutine GFS_rad_time_vary_timestep_init
 !> @}
- 
-      subroutine GFS_rad_time_vary_finalize()
-      end subroutine GFS_rad_time_vary_finalize
 
    end module GFS_rad_time_vary

--- a/physics/GFS_rad_time_vary.fv3.meta
+++ b/physics/GFS_rad_time_vary.fv3.meta
@@ -5,30 +5,216 @@
 
 ########################################################################
 [ccpp-arg-table]
-  name = GFS_rad_time_vary_run
+  name = GFS_rad_time_vary_timestep_init
   type = scheme
-[Model]
-  standard_name = GFS_control_type_instance
-  long_name = Fortran DDT containing FV3-GFS model control parameters
-  units = DDT
+[lslwr]
+  standard_name = flag_to_calc_lw
+  long_name = logical flags for lw radiation calls
+  units = flag
   dimensions = ()
-  type = GFS_control_type
+  type = logical
+  intent = in
+  optional = F
+[lsswr]
+  standard_name = flag_to_calc_sw
+  long_name = logical flags for sw radiation calls
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[isubc_lw]
+  standard_name = flag_for_lw_clouds_sub_grid_approximation
+  long_name = flag for lw clouds sub-grid approximation
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[isubc_sw]
+  standard_name = flag_for_sw_clouds_grid_approximation
+  long_name = flag for sw clouds sub-grid approximation
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[icsdsw]
+  standard_name = seed_random_numbers_sw
+  long_name = random seeds for sub-column cloud generators sw
+  units = none
+  dimensions = (horizontal_dimension)
+  type = integer
   intent = inout
   optional = F
-[Data]
-  standard_name = GFS_data_type_instance_all_blocks
-  long_name = Fortran DDT containing FV3-GFS data
-  units = DDT
-  dimensions = (ccpp_block_number)
-  type = GFS_data_type
+[icsdlw]
+  standard_name = seed_random_numbers_lw
+  long_name = random seeds for sub-column cloud generators lw
+  units = none
+  dimensions = (horizontal_dimension)
+  type = integer
   intent = inout
   optional = F
-[nthrds]
-  standard_name = omp_threads
-  long_name = number of OpenMP threads available for physics schemes
+[cnx]
+  standard_name = number_of_points_in_x_direction_for_this_cubed_sphere_face
+  long_name = number of points in x direction for this cubed sphere face
   units = count
   dimensions = ()
   type = integer
+  intent = in
+  optional = F
+[cny]
+  standard_name = number_of_points_in_y_direction_for_this_cubed_sphere_face
+  long_name = number of points in y direction for this cubed sphere face
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[isc]
+  standard_name = starting_x_index_for_this_MPI_rank
+  long_name = starting index in the x direction for this MPI rank
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[jsc]
+  standard_name = starting_y_index_for_this_MPI_rank
+  long_name = starting index in the y direction for this MPI rank
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[imap]
+  standard_name = map_of_block_column_number_to_global_i_index
+  long_name = map of local index ix to global index i for this block
+  units = none
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = in
+  optional = F
+[jmap]
+  standard_name = map_of_block_column_number_to_global_j_index
+  long_name = map of local index ix to global index j for this block
+  units = none
+  dimensions = (horizontal_dimension)
+  type = integer
+  intent = in
+  optional = F
+[sec]
+  standard_name = seconds_elapsed_since_model_initialization
+  long_name = seconds elapsed since model initialization
+  units = s
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[kdt]
+  standard_name = index_of_time_step
+  long_name = current forecast iteration
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[imp_physics]
+  standard_name = flag_for_microphysics_scheme
+  long_name = choice of microphysics scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[imp_physics_zhao_carr]
+  standard_name = flag_for_zhao_carr_microphysics_scheme
+  long_name = choice of Zhao-Carr microphysics scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[ps_2delt]
+  standard_name = surface_air_pressure_two_timesteps_back
+  long_name = surface air pressure two timesteps back
+  units = Pa
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[ps_1delt]
+  standard_name = surface_air_pressure_at_previous_timestep
+  long_name = surface air pressure at previous timestep
+  units = Pa
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[t_2delt]
+  standard_name = air_temperature_two_timesteps_back
+  long_name = air temperature two timesteps back
+  units = K
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[t_1delt]
+  standard_name = water_vapor_specific_humidity_two_timesteps_back
+  long_name = water vapor specific humidity two timesteps back
+  units = kg kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[qv_2delt]
+  standard_name = air_temperature_at_previous_timestep
+  long_name = air temperature at previous timestep
+  units = K
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[qv_1delt]
+  standard_name = water_vapor_specific_humidity_at_previous_timestep
+  long_name = water vapor specific humidity at previous timestep
+  units = kg kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[t]
+  standard_name = air_temperature
+  long_name = model layer mean temperature
+  units = K
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[qv]
+  standard_name = water_vapor_specific_humidity
+  long_name = water vapor specific humidity
+  units = kg kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[ps]
+  standard_name = air_pressure_at_lowest_model_interface
+  long_name = air pressure at lowest model interface
+  units = Pa
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
   intent = in
   optional = F
 [errmsg]

--- a/physics/GFS_rad_time_vary.fv3.meta
+++ b/physics/GFS_rad_time_vary.fv3.meta
@@ -164,18 +164,18 @@
   intent = inout
   optional = F
 [t_1delt]
-  standard_name = water_vapor_specific_humidity_two_timesteps_back
-  long_name = water vapor specific humidity two timesteps back
-  units = kg kg-1
+  standard_name = air_temperature_at_previous_timestep
+  long_name = air temperature at previous timestep
+  units = K
   dimensions = (horizontal_dimension,vertical_dimension)
   type = real
   kind = kind_phys
   intent = inout
   optional = F
 [qv_2delt]
-  standard_name = air_temperature_at_previous_timestep
-  long_name = air temperature at previous timestep
-  units = K
+  standard_name = water_vapor_specific_humidity_two_timesteps_back
+  long_name = water vapor specific humidity two timesteps back
+  units = kg kg-1
   dimensions = (horizontal_dimension,vertical_dimension)
   type = real
   kind = kind_phys

--- a/physics/GFS_rrtmg_setup.F90
+++ b/physics/GFS_rrtmg_setup.F90
@@ -14,7 +14,7 @@ module GFS_rrtmg_setup
 
    implicit none
 
-   public GFS_rrtmg_setup_init, GFS_rrtmg_setup_run, GFS_rrtmg_setup_finalize
+   public GFS_rrtmg_setup_init, GFS_rrtmg_setup_timestep_init, GFS_rrtmg_setup_finalize
 
    private
 
@@ -320,10 +320,10 @@ module GFS_rrtmg_setup
 
    end subroutine GFS_rrtmg_setup_init
 
-!> \section arg_table_GFS_rrtmg_setup_run Argument Table
-!! \htmlinclude GFS_rrtmg_setup_run.html
+!> \section arg_table_GFS_rrtmg_setup_timestep_init Argument Table
+!! \htmlinclude GFS_rrtmg_setup_timestep_init.html
 !!
-   subroutine GFS_rrtmg_setup_run (                &
+   subroutine GFS_rrtmg_setup_timestep_init (      &
           idate, jdate, deltsw, deltim, lsswr, me, &
           slag, sdec, cdec, solcon, errmsg, errflg)
 
@@ -345,7 +345,7 @@ module GFS_rrtmg_setup
 
       ! Check initialization state
       if (.not.is_initialized) then
-         write(errmsg, fmt='((a))') 'GFS_rrtmg_setup_run called before GFS_rrtmg_setup_init'
+         write(errmsg, fmt='((a))') 'GFS_rrtmg_setup_timestep_init called before GFS_rrtmg_setup_init'
          errflg = 1
          return
       end if
@@ -357,7 +357,7 @@ module GFS_rrtmg_setup
       call radupdate(idate,jdate,deltsw,deltim,lsswr,me, &
                      slag,sdec,cdec,solcon)
 
-   end subroutine GFS_rrtmg_setup_run
+   end subroutine GFS_rrtmg_setup_timestep_init
 
 !> \section arg_table_GFS_rrtmg_setup_finalize Argument Table
 !! \htmlinclude GFS_rrtmg_setup_finalize.html
@@ -523,12 +523,14 @@ module GFS_rrtmg_setup
 !> -# Set up control variables and external module variables in
 !!    module physparam
 #if 0
+      ! DH* WHAT IS THIS?
       ! GFS_radiation_driver.F90 may in the future initialize air/ground
       ! temperature differently; however, this is not used at the moment
       ! and as such we avoid the difficulty of dealing with exchanging
       ! itsfc between GFS_rrtmg_setup and a yet-to-be-created/-used
       ! interstitial routine (or GFS_radiation_driver.F90)
       itsfc  = iemsflg / 10             ! sfc air/ground temp control
+      ! *DH
 #endif
       loz1st = (ioznflg == 0)           ! first-time clim ozone data read flag
       month0 = 0

--- a/physics/GFS_rrtmg_setup.F90
+++ b/physics/GFS_rrtmg_setup.F90
@@ -43,13 +43,13 @@ module GFS_rrtmg_setup
 !! \section arg_table_GFS_rrtmg_setup_init Argument Table
 !! \htmlinclude GFS_rrtmg_setup_init.html
 !!
-   subroutine GFS_rrtmg_setup_init (                                    &
-          si, levr, ictm, isol, ico2, iaer, ialb, iems, ntcw,  num_p2d, &
-          num_p3d, npdf3d, ntoz, iovr, isubc_sw, isubc_lw,              &
-          icliq_sw, crick_proof, ccnorm,                                &
-          imp_physics,                                                  &
-          norad_precip, idate, iflip,                                   &
-          im, faerlw, faersw, aerodp,                                   & ! for consistency checks
+   subroutine GFS_rrtmg_setup_init (                          &
+          si, levr, ictm, isol, ico2, iaer, ialb, iems, ntcw, &
+          num_p3d, npdf3d, ntoz, iovr, isubc_sw, isubc_lw,    &
+          icliq_sw, crick_proof, ccnorm,                      &
+          imp_physics,                                        &
+          norad_precip, idate, iflip,                         &
+          im, faerlw, faersw, aerodp,                         & ! for consistency checks
           me, errmsg, errflg)
 ! =================   subprogram documentation block   ================ !
 !                                                                       !
@@ -174,7 +174,6 @@ module GFS_rrtmg_setup
       integer, intent(in) :: ialb
       integer, intent(in) :: iems
       integer, intent(in) :: ntcw
-      integer, intent(in) :: num_p2d
       integer, intent(in) :: num_p3d
       integer, intent(in) :: npdf3d
       integer, intent(in) :: ntoz

--- a/physics/GFS_rrtmg_setup.meta
+++ b/physics/GFS_rrtmg_setup.meta
@@ -80,14 +80,6 @@
   type = integer
   intent = in
   optional = F
-[num_p2d]
-  standard_name = array_dimension_of_2d_arrays_for_microphysics
-  long_name = number of 2D arrays needed for microphysics
-  units = count
-  dimensions = ()
-  type = integer
-  intent = in
-  optional = F
 [num_p3d]
   standard_name = array_dimension_of_3d_arrays_for_microphysics
   long_name = number of 3D arrays needed for microphysics

--- a/physics/GFS_rrtmg_setup.meta
+++ b/physics/GFS_rrtmg_setup.meta
@@ -255,7 +255,7 @@
 
 ########################################################################
 [ccpp-arg-table]
-  name = GFS_rrtmg_setup_run
+  name = GFS_rrtmg_setup_timestep_init
   type = scheme
 [idate]
   standard_name = date_and_time_at_model_initialization

--- a/physics/GFS_rrtmgp_setup.F90
+++ b/physics/GFS_rrtmgp_setup.F90
@@ -13,7 +13,7 @@ module GFS_rrtmgp_setup
                                          iaermdl, ialbflg, iemsflg, ivflip
   implicit none
   
-  public GFS_rrtmgp_setup_init, GFS_rrtmgp_setup_run, GFS_rrtmgp_setup_finalize
+  public GFS_rrtmgp_setup_init, GFS_rrtmgp_setup_timestep_init, GFS_rrtmgp_setup_finalize
   
   ! Version tag and last revision date
   character(40), parameter ::                                       &
@@ -27,7 +27,7 @@ module GFS_rrtmgp_setup
   logical ::  &
        is_initialized = .false.
   ! Control flag for the first time of reading climatological ozone data
-  ! (set/reset in subroutines GFS_rrtmgp_setup_init/GFS_rrtmgp_setuup_run, it is used only if 
+  ! (set/reset in subroutines GFS_rrtmgp_setup_init/GFS_rrtmgp_setup_timestep_init, it is used only if 
   ! the control parameter ioznflg=0)
   logical :: loz1st = .true.
   
@@ -151,13 +151,13 @@ contains
   end subroutine GFS_rrtmgp_setup_init
 
   ! #########################################################################################
-  ! SUBROUTINE GFS_rrtmgp_setup_run
+  ! SUBROUTINE GFS_rrtmgp_setup_timestep_init
   ! #########################################################################################
-!> \section arg_table_GFS_rrtmgp_setup_run
-!! \htmlinclude GFS_rrtmgp_setup_run.html
+!> \section arg_table_GFS_rrtmgp_setup_timestep_init
+!! \htmlinclude GFS_rrtmgp_setup_timestep_init.html
 !!
-  subroutine GFS_rrtmgp_setup_run (idate, jdate, deltsw, deltim, lsswr, me, &
-       slag, sdec, cdec, solcon, errmsg, errflg)
+  subroutine GFS_rrtmgp_setup_timestep_init (idate, jdate, deltsw, deltim, lsswr, me, &
+                                             slag, sdec, cdec, solcon, errmsg, errflg)
      
     ! Inputs
     integer,         intent(in)  :: idate(:)
@@ -188,7 +188,7 @@ contains
 
     ! Check initialization state
     if (.not.is_initialized) then
-       write(errmsg, fmt='((a))') 'GFS_rrtmgp_setup_run called before GFS_rrtmgp_setup_init'
+       write(errmsg, fmt='((a))') 'GFS_rrtmgp_setup_timestep_init called before GFS_rrtmgp_setup_init'
        errflg = 1
        return
     end if
@@ -251,7 +251,7 @@ contains
     if ( loz1st ) loz1st = .false.
 
     return
-  end subroutine GFS_rrtmgp_setup_run
+  end subroutine GFS_rrtmgp_setup_timestep_init
 
   ! #########################################################################################
   ! SUBROUTINE GFS_rrtmgp_setup_finalize
@@ -273,4 +273,5 @@ contains
     is_initialized = .false.
     
   end subroutine GFS_rrtmgp_setup_finalize
+
 end module GFS_rrtmgp_setup

--- a/physics/GFS_rrtmgp_setup.meta
+++ b/physics/GFS_rrtmgp_setup.meta
@@ -260,7 +260,7 @@
 
 ########################################################################
 [ccpp-arg-table]
-  name = GFS_rrtmgp_setup_run
+  name = GFS_rrtmgp_setup_timestep_init
   type = scheme
 [idate]
   standard_name = date_and_time_at_model_initialization

--- a/physics/GFS_suite_interstitial.F90
+++ b/physics/GFS_suite_interstitial.F90
@@ -14,42 +14,23 @@
 !> \section arg_table_GFS_suite_interstitial_rad_reset_run Argument Table
 !! \htmlinclude GFS_suite_interstitial_rad_reset_run.html
 !!
-    subroutine GFS_suite_interstitial_rad_reset_run (Interstitial, Diag, Model, errmsg, errflg)
+    subroutine GFS_suite_interstitial_rad_reset_run (Interstitial, Model, errmsg, errflg)
 
       use machine,      only: kind_phys
-      use GFS_typedefs, only: GFS_control_type, GFS_diag_type, GFS_interstitial_type
+      use GFS_typedefs, only: GFS_control_type, GFS_interstitial_type
 
       implicit none
 
       ! interface variables
       type(GFS_interstitial_type), intent(inout) :: Interstitial
-      type(GFS_diag_type),         intent(inout) :: Diag
       type(GFS_control_type),      intent(in)    :: Model
       character(len=*),            intent(out)   :: errmsg
       integer,                     intent(out)   :: errflg
-
-      ! local variables
-      real(kind_phys), parameter :: con_hr = 3600.0_kind_phys
-      real(kind_phys)            :: sec_zero
-      integer                    :: kdt_rad
 
       errmsg = ''
       errflg = 0
 
       call Interstitial%rad_reset(Model)
-
-      !--- determine if radiation diagnostics buckets need to be cleared
-      sec_zero = nint(Model%fhzero*con_hr)
-      if (sec_zero >= nint(max(Model%fhswr,Model%fhlwr))) then
-        if (mod(Model%kdt,Model%nszero) == 1) then
-          call Diag%rad_zero(Model)
-        endif
-      else
-        kdt_rad = nint(min(Model%fhswr,Model%fhlwr)/Model%dtp)
-        if (mod(Model%kdt,kdt_rad) == 1) then
-          call Diag%rad_zero(Model)
-        endif
-      endif
 
     end subroutine GFS_suite_interstitial_rad_reset_run
 
@@ -69,16 +50,15 @@
 !> \section arg_table_GFS_suite_interstitial_phys_reset_run Argument Table
 !! \htmlinclude GFS_suite_interstitial_phys_reset_run.html
 !!
-    subroutine GFS_suite_interstitial_phys_reset_run (Interstitial, Diag, Model, errmsg, errflg)
+    subroutine GFS_suite_interstitial_phys_reset_run (Interstitial, Model, errmsg, errflg)
 
       use machine,      only: kind_phys
-      use GFS_typedefs, only: GFS_control_type, GFS_diag_type, GFS_interstitial_type
+      use GFS_typedefs, only: GFS_control_type, GFS_interstitial_type
 
       implicit none
 
       ! interface variables
       type(GFS_interstitial_type), intent(inout) :: Interstitial
-      type(GFS_diag_type),         intent(inout) :: Diag
       type(GFS_control_type),      intent(in)    :: Model
       character(len=*),            intent(out)   :: errmsg
       integer,                     intent(out)   :: errflg
@@ -87,11 +67,6 @@
       errflg = 0
 
       call Interstitial%phys_reset(Model)
-
-      !--- determine if physics diagnostics buckets need to be cleared
-      if (mod(Model%kdt,Model%nszero) == 1) then
-        call Diag%phys_zero(Model)
-      endif
 
     end subroutine GFS_suite_interstitial_phys_reset_run
 

--- a/physics/GFS_suite_interstitial.F90
+++ b/physics/GFS_suite_interstitial.F90
@@ -14,22 +14,42 @@
 !> \section arg_table_GFS_suite_interstitial_rad_reset_run Argument Table
 !! \htmlinclude GFS_suite_interstitial_rad_reset_run.html
 !!
-    subroutine GFS_suite_interstitial_rad_reset_run (Interstitial, Model, errmsg, errflg)
+    subroutine GFS_suite_interstitial_rad_reset_run (Interstitial, Diag, Model, errmsg, errflg)
 
-      use GFS_typedefs, only: GFS_control_type,GFS_interstitial_type
+      use machine,      only: kind_phys
+      use GFS_typedefs, only: GFS_control_type, GFS_diag_type, GFS_interstitial_type
 
       implicit none
 
       ! interface variables
       type(GFS_interstitial_type), intent(inout) :: Interstitial
+      type(GFS_diag_type),         intent(inout) :: Diag
       type(GFS_control_type),      intent(in)    :: Model
-      character(len=*), intent(out) :: errmsg
-      integer, intent(out) :: errflg
+      character(len=*),            intent(out)   :: errmsg
+      integer,                     intent(out)   :: errflg
+
+      ! local variables
+      real(kind_phys), parameter :: con_hr = 3600.0_kind_phys
+      real(kind_phys)            :: sec_zero
+      integer                    :: kdt_rad
 
       errmsg = ''
       errflg = 0
 
       call Interstitial%rad_reset(Model)
+
+      !--- determine if radiation diagnostics buckets need to be cleared
+      sec_zero = nint(Model%fhzero*con_hr)
+      if (sec_zero >= nint(max(Model%fhswr,Model%fhlwr))) then
+        if (mod(Model%kdt,Model%nszero) == 1) then
+          call Diag%rad_zero(Model)
+        endif
+      else
+        kdt_rad = nint(min(Model%fhswr,Model%fhlwr)/Model%dtp)
+        if (mod(Model%kdt,kdt_rad) == 1) then
+          call Diag%rad_zero(Model)
+        endif
+      endif
 
     end subroutine GFS_suite_interstitial_rad_reset_run
 
@@ -49,22 +69,29 @@
 !> \section arg_table_GFS_suite_interstitial_phys_reset_run Argument Table
 !! \htmlinclude GFS_suite_interstitial_phys_reset_run.html
 !!
-    subroutine GFS_suite_interstitial_phys_reset_run (Interstitial, Model, errmsg, errflg)
+    subroutine GFS_suite_interstitial_phys_reset_run (Interstitial, Diag, Model, errmsg, errflg)
 
-      use GFS_typedefs, only: GFS_control_type, GFS_interstitial_type
+      use machine,      only: kind_phys
+      use GFS_typedefs, only: GFS_control_type, GFS_diag_type, GFS_interstitial_type
 
       implicit none
 
       ! interface variables
       type(GFS_interstitial_type), intent(inout) :: Interstitial
+      type(GFS_diag_type),         intent(inout) :: Diag
       type(GFS_control_type),      intent(in)    :: Model
-      character(len=*), intent(out) :: errmsg
-      integer, intent(out) :: errflg
+      character(len=*),            intent(out)   :: errmsg
+      integer,                     intent(out)   :: errflg
 
       errmsg = ''
       errflg = 0
 
       call Interstitial%phys_reset(Model)
+
+      !--- determine if physics diagnostics buckets need to be cleared
+      if (mod(Model%kdt,Model%nszero) == 1) then
+        call Diag%phys_zero(Model)
+      endif
 
     end subroutine GFS_suite_interstitial_phys_reset_run
 

--- a/physics/GFS_suite_interstitial.meta
+++ b/physics/GFS_suite_interstitial.meta
@@ -15,14 +15,6 @@
   type = GFS_interstitial_type
   intent = inout
   optional = F
-[Diag]
-  standard_name = GFS_diag_type_instance
-  long_name = derived type GFS_diag_type in FV3
-  units = DDT
-  dimensions = ()
-  type = GFS_diag_type
-  intent = inout
-  optional = F
 [Model]
   standard_name = GFS_control_type_instance
   long_name = Fortran DDT containing FV3-GFS model control parameters
@@ -65,14 +57,6 @@
   units = DDT
   dimensions = ()
   type = GFS_interstitial_type
-  intent = inout
-  optional = F
-[Diag]
-  standard_name = GFS_diag_type_instance
-  long_name = derived type GFS_diag_type in FV3
-  units = DDT
-  dimensions = ()
-  type = GFS_diag_type
   intent = inout
   optional = F
 [Model]

--- a/physics/GFS_suite_interstitial.meta
+++ b/physics/GFS_suite_interstitial.meta
@@ -15,6 +15,14 @@
   type = GFS_interstitial_type
   intent = inout
   optional = F
+[Diag]
+  standard_name = GFS_diag_type_instance
+  long_name = derived type GFS_diag_type in FV3
+  units = DDT
+  dimensions = ()
+  type = GFS_diag_type
+  intent = inout
+  optional = F
 [Model]
   standard_name = GFS_control_type_instance
   long_name = Fortran DDT containing FV3-GFS model control parameters
@@ -57,6 +65,14 @@
   units = DDT
   dimensions = ()
   type = GFS_interstitial_type
+  intent = inout
+  optional = F
+[Diag]
+  standard_name = GFS_diag_type_instance
+  long_name = derived type GFS_diag_type in FV3
+  units = DDT
+  dimensions = ()
+  type = GFS_diag_type
   intent = inout
   optional = F
 [Model]

--- a/physics/GFS_time_vary_pre.fv3.F90
+++ b/physics/GFS_time_vary_pre.fv3.F90
@@ -9,7 +9,7 @@
 
       private
 
-      public GFS_time_vary_pre_init, GFS_time_vary_pre_run, GFS_time_vary_pre_finalize
+      public GFS_time_vary_pre_init, GFS_time_vary_pre_timestep_init, GFS_time_vary_pre_finalize
 
       logical :: is_initialized = .false.
 
@@ -62,12 +62,12 @@
       end subroutine GFS_time_vary_pre_finalize
 
 
-!> \section arg_table_GFS_time_vary_pre_run Argument Table
-!! \htmlinclude GFS_time_vary_pre_run.html
+!> \section arg_table_GFS_time_vary_pre_timestep_init Argument Table
+!! \htmlinclude GFS_time_vary_pre_timestep_init.html
 !!
-      subroutine GFS_time_vary_pre_run (jdat, idat, dtp, lkm, lsm, lsm_noahmp, nsswr,  &
-        nslwr, nhfrad, idate, debug, me, master, nscyc, sec, phour, zhour, fhour,      &
-        kdt, julian, yearlen, ipt, lprnt, lssav, lsswr, lslwr, solhr, errmsg, errflg)
+      subroutine GFS_time_vary_pre_timestep_init (jdat, idat, dtp, lkm, lsm, lsm_noahmp, nsswr,  &
+                  nslwr, nhfrad, idate, debug, me, master, nscyc, sec, phour, zhour, fhour,      &
+                  kdt, julian, yearlen, ipt, lprnt, lssav, lsswr, lslwr, solhr, errmsg, errflg)
 
         use machine,               only: kind_phys
 
@@ -104,8 +104,7 @@
 
         ! Check initialization status
         if (.not.is_initialized) then
-           write(errmsg,'(*(a))') "Logic error: GFS_time_vary_pre_run called &
-                                  &before GFS_time_vary_pre_init"
+           write(errmsg,'(*(a))') "Logic error: GFS_time_vary_pre_timestep_init called before GFS_time_vary_pre_init"
            errflg = 1
            return
         end if
@@ -190,6 +189,6 @@
           print *,' solhr ', solhr
         endif
 
-      end subroutine GFS_time_vary_pre_run
+      end subroutine GFS_time_vary_pre_timestep_init
 
     end module GFS_time_vary_pre

--- a/physics/GFS_time_vary_pre.fv3.meta
+++ b/physics/GFS_time_vary_pre.fv3.meta
@@ -49,7 +49,7 @@
 
 ########################################################################
 [ccpp-arg-table]
-  name = GFS_time_vary_pre_run
+  name = GFS_time_vary_pre_timestep_init
   type = scheme
 [jdat]
   standard_name = forecast_date_and_time

--- a/physics/gcycle.F90
+++ b/physics/gcycle.F90
@@ -2,175 +2,159 @@
 !! This file repopulates specific time-varying surface properties for
 !! atmospheric forecast runs.
 
+module gcycle_mod
+
+  implicit none
+
+  private
+
+  public gcycle
+
+contains
+
 !>\ingroup mod_GFS_phys_time_vary
 !! This subroutine repopulates specific time-varying surface properties for
 !! atmospheric forecast runs.
-  SUBROUTINE GCYCLE (nblks, nthrds, Model, Grid, Sfcprop, Cldprop)
+  subroutine gcycle (me, nthrds, nx, ny, isc, jsc, nsst, tile_num, nlunit, &
+      input_nml_file, lsoil, kice, idate, ialb, isot, ivegsrc, use_ufo,    &
+      nst_anl, fhcyc, phour, lakefrac, min_seaice, min_lakeice, frac_grid, &
+      smc, slc, stc, tiice, tg3, tref, tsfc, tsfco, tisfc, hice, fice,     &
+      facsf, facwf, alvsf, alvwf, alnsf, alnwf, zorli, zorll, zorlo, weasd,&
+      slope, snoalb, canopy, vfrac, vtype, stype, shdmin, shdmax, snowd,   &
+      cv, cvb, cvt, oro, oro_uf, xlat_d, xlon_d, slmsk, imap, jmap)
 !
 !
-    USE MACHINE,      only: kind_phys
-    USE PHYSCONS,     only: PI => con_PI
-    USE GFS_typedefs, only: GFS_control_type, GFS_grid_type, &
-                            GFS_sfcprop_type, GFS_cldprop_type
+    use machine,      only: kind_phys
     implicit none
 
-    integer,                  intent(in)    :: nblks, nthrds
-    type(GFS_control_type),   intent(in)    :: Model
-    type(GFS_grid_type),      intent(in)    :: Grid(nblks)
-    type(GFS_sfcprop_type),   intent(inout) :: Sfcprop(nblks)
-    type(GFS_cldprop_type),   intent(inout) :: Cldprop(nblks)
+    integer,              intent(in)    :: me, nthrds, nx, ny, isc, jsc, nsst, &
+                                           tile_num, nlunit, lsoil, kice
+    integer,              intent(in)    :: idate(:), ialb, isot, ivegsrc
+    character(len=*),     intent(in)    :: input_nml_file(:)
+    logical,              intent(in)    :: use_ufo, nst_anl, frac_grid
+    real(kind=kind_phys), intent(in)    :: fhcyc, phour, lakefrac(:), &
+                                           min_seaice, min_lakeice,   &
+                                           xlat_d(:), xlon_d(:)
+    real(kind=kind_phys), intent(inout) :: smc(:,:),   &
+                                           slc(:,:),   &
+                                           stc(:,:),   &
+                                           tiice(:,:), &
+                                           tg3(:),     &
+                                           tref(:),    &
+                                           tsfc(:),    &
+                                           tsfco(:),   &
+                                           tisfc(:),   &
+                                           hice(:),    &
+                                           fice(:),    &
+                                           facsf(:),   &
+                                           facwf(:),   &
+                                           alvsf(:),   &
+                                           alvwf(:),   &
+                                           alnsf(:),   &
+                                           alnwf(:),   &
+                                           zorli(:),   &
+                                           zorll(:),   &
+                                           zorlo(:),   &
+                                           weasd(:),   &
+                                           slope(:),   &
+                                           snoalb(:),  &
+                                           canopy(:),  &
+                                           vfrac(:),   &
+                                           vtype(:),   &
+                                           stype(:),   &
+                                           shdmin(:),  &
+                                           shdmax(:),  &
+                                           snowd(:),   &
+                                           cv(:),      &
+                                           cvb(:),     &
+                                           cvt(:),     &
+                                           oro(:),     &
+                                           oro_uf(:),  &
+                                           slmsk(:)
 
+    integer,              intent(in)    :: imap(:), jmap(:)
 !
 !     Local variables
 !     ---------------
-    integer              ::                     &
-           I_INDEX(Model%nx*Model%ny),          &
-           J_INDEX(Model%nx*Model%ny)
+    real(kind=kind_phys) ::   &
+        SLMASK (nx*ny),       &
+        TSFFCS (nx*ny),       &
+        ZORFCS (nx*ny),       &
+        AISFCS (nx*ny),       &
+        ALFFC1 (nx*ny*2),     &
+        ALBFC1 (nx*ny*4),     &
+        SMCFC1 (nx*ny*lsoil), &
+        STCFC1 (nx*ny*lsoil), &
+        SLCFC1 (nx*ny*lsoil)
 
-    real(kind=kind_phys) ::                     &
-           RLA (Model%nx*Model%ny),             &
-           RLO (Model%nx*Model%ny),             &
-        SLMASK (Model%nx*Model%ny),             &
-          OROG (Model%nx*Model%ny),             &
-       OROG_UF (Model%nx*Model%ny),             &
-        SLIFCS (Model%nx*Model%ny),             &
-        TSFFCS (Model%nx*Model%ny),             &
-        SNOFCS (Model%nx*Model%ny),             &
-        ZORFCS (Model%nx*Model%ny),             &
-        TG3FCS (Model%nx*Model%ny),             &
-        CNPFCS (Model%nx*Model%ny),             &
-        AISFCS (Model%nx*Model%ny),             &
-!       F10MFCS(Model%nx*Model%ny),             &
-        VEGFCS (Model%nx*Model%ny),             &
-        VETFCS (Model%nx*Model%ny),             &
-        SOTFCS (Model%nx*Model%ny),             &
-         CVFCS (Model%nx*Model%ny),             &
-        CVBFCS (Model%nx*Model%ny),             &
-        CVTFCS (Model%nx*Model%ny),             &
-        SWDFCS (Model%nx*Model%ny),             &
-        SIHFCS (Model%nx*Model%ny),             &
-        SICFCS (Model%nx*Model%ny),             &
-        SITFCS (Model%nx*Model%ny),             &
-        VMNFCS (Model%nx*Model%ny),             &
-        VMXFCS (Model%nx*Model%ny),             &
-        SLPFCS (Model%nx*Model%ny),             &
-        ABSFCS (Model%nx*Model%ny),             &
-        ALFFC1 (Model%nx*Model%ny*2),           &
-        ALBFC1 (Model%nx*Model%ny*4),           &
-        SMCFC1 (Model%nx*Model%ny*Model%lsoil), &
-        STCFC1 (Model%nx*Model%ny*Model%lsoil), &
-        SLCFC1 (Model%nx*Model%ny*Model%lsoil)
-
-    logical          :: lake(Model%nx*Model%ny)
-
-    character(len=6) :: tile_num_ch
-    real(kind=kind_phys), parameter :: pifac=180.0/pi
-    real(kind=kind_phys)            :: sig1t, dt_warm
-    integer :: npts, len, nb, ix, jx, ls, ios, ll
-    logical :: exists
+    logical              :: lake(nx*ny)
+    character(len=6)     :: tile_num_ch
+    real(kind=kind_phys) :: sig1t, dt_warm
+    integer              :: npts, nb, ix, jx, ls, ios, ll
+    logical              :: exists
 !
 !@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 !
 !     if (Model%me .eq. 0) print *,' nlats=',nlats,' lonsinpe='
 !    *,lonsinpe(0,1)
-
-      tile_num_ch = "      "
-      if (Model%tile_num < 10) then
-        write(tile_num_ch, "(a4,i1)") "tile", Model%tile_num
-      else
-        write(tile_num_ch, "(a4,i2)") "tile", Model%tile_num
-      endif
-
-      len = 0
-      do jx = Model%jsc, (Model%jsc+Model%ny-1)
-        do ix = Model%isc, (Model%isc+Model%nx-1)
-          len = len + 1
-          i_index(len) = ix
-          j_index(len) = jx
-        enddo
-      enddo
-
-      sig1t = 0.0_kind_phys
-      npts  = Model%nx*Model%ny
 !
-      len = 0
-      do nb = 1,nblks
-        do ix = 1,size(Grid(nb)%xlat,1)
-          len = len + 1
-          RLA     (len)          = Grid(nb)%xlat      (ix) * pifac
-          RLO     (len)          = Grid(nb)%xlon      (ix) * pifac
-          OROG    (len)          = Sfcprop(nb)%oro    (ix)
-          OROG_UF (len)          = Sfcprop(nb)%oro_uf (ix)
-          SLIFCS  (len)          = Sfcprop(nb)%slmsk  (ix)
-          if ( Model%nstf_name(1) > 0 ) then
-            TSFFCS(len)          = Sfcprop(nb)%tref   (ix)
-          else
-            TSFFCS(len)          = Sfcprop(nb)%tsfc   (ix)
-          endif
-          SNOFCS  (len)          = Sfcprop(nb)%weasd  (ix)
-          ZORFCS  (len)          = Sfcprop(nb)%zorll  (ix)
-          if (SLIFCS(len) > 1.9_kind_phys .and. .not. Model%frac_grid) then
-            ZORFCS  (len)        = Sfcprop(nb)%zorli  (ix)
-          elseif (SLIFCS(len) < 0.1_kind_phys .and. .not. Model%frac_grid) then
-            ZORFCS  (len)        = Sfcprop(nb)%zorlo  (ix)
-          endif
-          TG3FCS  (len)          = Sfcprop(nb)%tg3    (ix)
-          CNPFCS  (len)          = Sfcprop(nb)%canopy (ix)
-!         F10MFCS (len)          = Sfcprop(nb)%f10m   (ix)
-          VEGFCS  (len)          = Sfcprop(nb)%vfrac  (ix)
-          VETFCS  (len)          = Sfcprop(nb)%vtype  (ix)
-          SOTFCS  (len)          = Sfcprop(nb)%stype  (ix)
-          CVFCS   (len)          = Cldprop(nb)%cv     (ix)
-          CVBFCS  (len)          = Cldprop(nb)%cvb    (ix)
-          CVTFCS  (len)          = Cldprop(nb)%cvt    (ix)
-          SWDFCS  (len)          = Sfcprop(nb)%snowd  (ix)
-          SIHFCS  (len)          = Sfcprop(nb)%hice   (ix)
-          SICFCS  (len)          = Sfcprop(nb)%fice   (ix)
-          SITFCS  (len)          = Sfcprop(nb)%tisfc  (ix)
-          VMNFCS  (len)          = Sfcprop(nb)%shdmin (ix)
-          VMXFCS  (len)          = Sfcprop(nb)%shdmax (ix)
-          SLPFCS  (len)          = Sfcprop(nb)%slope  (ix)
-          ABSFCS  (len)          = Sfcprop(nb)%snoalb (ix)
-
-          ALFFC1  (len       )   = Sfcprop(nb)%facsf  (ix)
-          ALFFC1  (len + npts)   = Sfcprop(nb)%facwf  (ix)
-
-          ALBFC1  (len         ) = Sfcprop(nb)%alvsf  (ix)
-          ALBFC1  (len + npts  ) = Sfcprop(nb)%alvwf  (ix)
-          ALBFC1  (len + npts*2) = Sfcprop(nb)%alnsf  (ix)
-          ALBFC1  (len + npts*3) = Sfcprop(nb)%alnwf  (ix)
-
-          do ls = 1,Model%lsoil
-            SMCFC1 (len + (ls-1)*npts) = Sfcprop(nb)%smc (ix,ls)
-            STCFC1 (len + (ls-1)*npts) = Sfcprop(nb)%stc (ix,ls)
-            SLCFC1 (len + (ls-1)*npts) = Sfcprop(nb)%slc (ix,ls)
-          enddo
-
-          IF (SLIFCS(len) < 0.1_kind_phys .OR. SLIFCS(len) > 1.5_kind_phys) THEN
-             SLMASK(len) = 0.0_kind_phys
-          ELSE
-             SLMASK(len) = 1.0_kind_phys
-          ENDIF
-
-          IF (SLIFCS(len) > 1.99_kind_phys) THEN
-            AISFCS(len) = 1.0_kind_phys
-          ELSE
-            AISFCS(len) = 0.0_kind_phys
-          ENDIF
-          if (Sfcprop(nb)%lakefrac(ix) > 0.0_kind_phys) then
-            lake(len) = .true.
-          else
-            lake(len) = .false.
-          endif
-
-!     if (Model%me .eq. 0)
-!    &   print *,' len=',len,' rla=',rla(len),' rlo=',rlo(len)
-        ENDDO                 !-----END BLOCK SIZE LOOP------------------------------
-      ENDDO                   !-----END BLOCK LOOP-------------------------------
-
-! check
-!     call mymaxmin(slifcs,len,len,1,'slifcs')
-!     call mymaxmin(slmask,len,len,1,'slmsk')
+      tile_num_ch = "      "
+      if (tile_num < 10) then
+        write(tile_num_ch, "(a4,i1)") "tile", tile_num
+      else
+        write(tile_num_ch, "(a4,i2)") "tile", tile_num
+      endif
+!
+      sig1t = 0.0_kind_phys
+      npts  = nx*ny
+!
+      if ( nsst > 0 ) then
+        TSFFCS = tref
+      else
+        TSFFCS = tsfc
+      end if
+!
+      do ix=1,npts
+        ZORFCS(ix) = zorll (ix)
+        if (slmsk(ix) > 1.9_kind_phys .and. .not. frac_grid) then
+          ZORFCS(ix) = zorli  (ix)
+        elseif (slmsk(ix) < 0.1_kind_phys .and. .not. frac_grid) then
+          ZORFCS(ix) = zorlo  (ix)
+        endif
+        ! DH* Why not 1.9 as for ZORFCS?
+        IF (slmsk(ix) > 1.99_kind_phys) THEN
+          AISFCS(ix) = 1.0_kind_phys
+        ELSE
+          AISFCS(ix) = 0.0_kind_phys
+        ENDIF
+        !
+        ALFFC1(ix         ) = facsf(ix)
+        ALFFC1(ix + npts  ) = facwf(ix)
+        !
+        ALBFC1(ix         ) = alvsf(ix)
+        ALBFC1(ix + npts  ) = alvwf(ix)
+        ALBFC1(ix + npts*2) = alnsf(ix)
+        ALBFC1(ix + npts*3) = alnwf(ix)
+        !
+        do ls = 1,lsoil
+          ll = ix + (ls-1)*npts
+          SMCFC1(ll) = smc(ix,ls)
+          STCFC1(ll) = stc(ix,ls)
+          SLCFC1(ll) = slc(ix,ls)
+        enddo
+        !
+        IF (slmsk(ix) < 0.1_kind_phys .OR. slmsk(ix) > 1.5_kind_phys) THEN
+           SLMASK(ix) = 0.0_kind_phys
+        ELSE
+           SLMASK(ix) = 1.0_kind_phys
+        ENDIF
+        !
+        if (lakefrac(ix) > 0.0_kind_phys) then
+          lake(ix) = .true.
+        else
+          lake(ix) = .false.
+        endif
+      end do
 !
 #ifndef INTERNAL_FILE_NML
       inquire (file=trim(Model%fn_nml),exist=exists)
@@ -182,90 +166,59 @@
         rewind (Model%nlunit)
       endif
 #endif
-      CALL SFCCYCLE (9998, npts, Model%lsoil, SIG1T, Model%fhcyc, &
-                     Model%idate(4), Model%idate(2),              &
-                     Model%idate(3), Model%idate(1),              &
-                     Model%phour, RLA, RLO, SLMASK,               &
-!                    Model%fhour, RLA, RLO, SLMASK,               &
-                     OROG, OROG_UF, Model%USE_UFO, Model%nst_anl, &
-                     SIHFCS, SICFCS, SITFCS, SWDFCS, SLCFC1,      &
-                     VMNFCS, VMXFCS, SLPFCS, ABSFCS, TSFFCS,      &
-                     SNOFCS, ZORFCS, ALBFC1, TG3FCS, CNPFCS,      &
-                     SMCFC1, STCFC1, SLIFCS, AISFCS,              &
-                     VEGFCS, VETFCS, SOTFCS, ALFFC1, CVFCS,       &
-                     CVBFCS, CVTFCS, Model%me, nthrds,            &
-                     Model%nlunit, size(Model%input_nml_file),    &
-                     Model%input_nml_file,                        &
-                     lake, Model%min_lakeice, Model%min_seaice,   &
-                     Model%ialb, Model%isot, Model%ivegsrc,       &
-                     trim(tile_num_ch), i_index, j_index)
+      CALL SFCCYCLE (9998, npts, lsoil, sig1t, fhcyc,             &
+                     idate(4), idate(2), idate(3), idate(1),      &
+                     phour, xlat_d, xlon_d, slmask,               &
+                     oro, oro_uf, use_ufo, nst_anl,               &
+                     hice, fice, tisfc, snowd, slcfc1,            &
+                     shdmin, shdmax, slope, snoalb, tsffcs,       &
+                     weasd, zorfcs, albfc1, tg3, canopy,          &
+                     smcfc1, stcfc1, slmsk, aisfcs,               &
+                     vfrac, vtype, stype, alffc1, cv,             &
+                     cvb, cvt, me, nthrds,                        &
+                     nlunit, size(input_nml_file), input_nml_file,&
+                     lake, min_lakeice, min_seaice,               &
+                     ialb, isot, ivegsrc,                         &
+                     trim(tile_num_ch), imap, jmap)
 #ifndef INTERNAL_FILE_NML
       close (Model%nlunit)
 #endif
-
-      len = 0
-      do nb = 1,nblks
-        do ix = 1,size(Grid(nb)%xlat,1)
-          len = len + 1
-          Sfcprop(nb)%slmsk  (ix) = SLIFCS  (len)
-          if ( Model%nstf_name(1) > 0 ) then
-             Sfcprop(nb)%tref(ix) = TSFFCS  (len)
-!           if ( Model%nstf_name(2) == 0 ) then
-!             dt_warm = (Sfcprop(nb)%xt(ix) + Sfcprop(nb)%xt(ix) ) &
-!                     / Sfcprop(nb)%xz(ix)
-!             Sfcprop(nb)%tsfco(ix) = Sfcprop(nb)%tref(ix)         &
-!                                   + dt_warm - Sfcprop(nb)%dt_cool(ix)
-!           endif
-          else
-             Sfcprop(nb)%tsfc(ix)  = TSFFCS  (len)
-             Sfcprop(nb)%tsfco(ix) = TSFFCS  (len)
-          endif
-          Sfcprop(nb)%weasd  (ix) = SNOFCS  (len)
-          Sfcprop(nb)%zorll  (ix) = ZORFCS  (len)
-          if (SLIFCS(len) > 1.9_kind_phys .and. .not. Model%frac_grid) then
-            Sfcprop(nb)%zorli(ix) = ZORFCS  (len)
-          elseif (SLIFCS(len) < 0.1_kind_phys .and. .not. Model%frac_grid) then
-            Sfcprop(nb)%zorlo(ix) = ZORFCS  (len)
-          endif
-          Sfcprop(nb)%tg3    (ix) = TG3FCS  (len)
-          Sfcprop(nb)%canopy (ix) = CNPFCS  (len)
-!         Sfcprop(nb)%f10m   (ix) = F10MFCS (len)
-          Sfcprop(nb)%vfrac  (ix) = VEGFCS  (len)
-          Sfcprop(nb)%vtype  (ix) = VETFCS  (len)
-          Sfcprop(nb)%stype  (ix) = SOTFCS  (len)
-          Cldprop(nb)%cv     (ix) = CVFCS   (len)
-          Cldprop(nb)%cvb    (ix) = CVBFCS  (len)
-          Cldprop(nb)%cvt    (ix) = CVTFCS  (len)
-          Sfcprop(nb)%snowd  (ix) = SWDFCS  (len)
-          Sfcprop(nb)%hice   (ix) = SIHFCS  (len)
-          Sfcprop(nb)%fice   (ix) = SICFCS  (len)
-          Sfcprop(nb)%tisfc  (ix) = SITFCS  (len)
-          Sfcprop(nb)%shdmin (ix) = VMNFCS  (len)
-          Sfcprop(nb)%shdmax (ix) = VMXFCS  (len)
-          Sfcprop(nb)%slope  (ix) = SLPFCS  (len)
-          Sfcprop(nb)%snoalb (ix) = ABSFCS  (len)
-
-          Sfcprop(nb)%facsf  (ix) = ALFFC1  (len       )
-          Sfcprop(nb)%facwf  (ix) = ALFFC1  (len + npts)
-
-          Sfcprop(nb)%alvsf  (ix) = ALBFC1  (len         )
-          Sfcprop(nb)%alvwf  (ix) = ALBFC1  (len + npts  )
-          Sfcprop(nb)%alnsf  (ix) = ALBFC1  (len + npts*2)
-          Sfcprop(nb)%alnwf  (ix) = ALBFC1  (len + npts*3)
-          do ls = 1,Model%lsoil
-            ll = len + (ls-1)*npts
-            Sfcprop(nb)%smc (ix,ls) = SMCFC1 (ll)
-            Sfcprop(nb)%stc (ix,ls) = STCFC1 (ll)
-            Sfcprop(nb)%slc (ix,ls) = SLCFC1 (ll)
-            if (ls<=Model%kice) Sfcprop(nb)%tiice (ix,ls) = STCFC1 (ll)
-          enddo
-        ENDDO                 !-----END BLOCK SIZE LOOP--------------------------
-      ENDDO                   !-----END BLOCK LOOP-------------------------------
-
-! check
-!     call mymaxmin(slifcs,len,len,1,'slifcs')
+!
+      if ( nsst > 0 ) then
+        tref = TSFFCS
+      else
+        tsfc  = TSFFCS
+        tsfco = TSFFCS
+      end if
+!
+      do ix=1,npts
+        zorll(ix) = ZORFCS(ix)
+        if (slmsk(ix) > 1.9_kind_phys .and. .not. frac_grid) then
+          zorli(ix) = ZORFCS(ix)
+        elseif (slmsk(ix) < 0.1_kind_phys .and. .not. frac_grid) then
+          zorlo(ix) = ZORFCS(ix)
+        endif
+        !
+        facsf(ix) = ALFFC1(ix         )
+        facwf(ix) = ALFFC1(ix + npts  )
+        !
+        alvsf(ix) = ALBFC1(ix         )
+        alvwf(ix) = ALBFC1(ix + npts  )
+        alnsf(ix) = ALBFC1(ix + npts*2)
+        alnwf(ix) = ALBFC1(ix + npts*3)
+        !
+        do ls = 1,lsoil
+          ll = ix + (ls-1)*npts
+          smc(ix,ls) = SMCFC1(ll)
+          stc(ix,ls) = STCFC1(ll)
+          slc(ix,ls) = SLCFC1(ll)
+          if (ls<=kice) tiice(ix,ls) = STCFC1(ll)
+        enddo
+      enddo
 !
 !     if (Model%me .eq. 0) print*,'executed gcycle during hour=',fhour
-
+!
       RETURN
       END
+
+end module gcycle_mod

--- a/physics/gcycle.F90
+++ b/physics/gcycle.F90
@@ -16,19 +16,20 @@ contains
 !! This subroutine repopulates specific time-varying surface properties for
 !! atmospheric forecast runs.
   subroutine gcycle (me, nthrds, nx, ny, isc, jsc, nsst, tile_num, nlunit, &
-      input_nml_file, lsoil, kice, idate, ialb, isot, ivegsrc, use_ufo,    &
-      nst_anl, fhcyc, phour, lakefrac, min_seaice, min_lakeice, frac_grid, &
-      smc, slc, stc, tiice, tg3, tref, tsfc, tsfco, tisfc, hice, fice,     &
-      facsf, facwf, alvsf, alvwf, alnsf, alnwf, zorli, zorll, zorlo, weasd,&
-      slope, snoalb, canopy, vfrac, vtype, stype, shdmin, shdmax, snowd,   &
-      cv, cvb, cvt, oro, oro_uf, xlat_d, xlon_d, slmsk, imap, jmap)
+      input_nml_file, lsoil, lsoil_lsm, kice, idate, ialb, isot, ivegsrc,  &
+      use_ufo, nst_anl, fhcyc, phour, lakefrac, min_seaice, min_lakeice,   &
+      frac_grid, smc, slc, stc, smois, sh2o, tslb, tiice, tg3, tref, tsfc, &
+      tsfco, tisfc, hice, fice, facsf, facwf, alvsf, alvwf, alnsf, alnwf,  &
+      zorli, zorll, zorlo, weasd, slope, snoalb, canopy, vfrac, vtype,     &
+      stype, shdmin, shdmax, snowd, cv, cvb, cvt, oro, oro_uf,             &
+      xlat_d, xlon_d, slmsk, imap, jmap)
 !
 !
     use machine,      only: kind_phys
     implicit none
 
     integer,              intent(in)    :: me, nthrds, nx, ny, isc, jsc, nsst, &
-                                           tile_num, nlunit, lsoil, kice
+                                           tile_num, nlunit, lsoil, lsoil_lsm, kice
     integer,              intent(in)    :: idate(:), ialb, isot, ivegsrc
     character(len=*),     intent(in)    :: input_nml_file(:)
     logical,              intent(in)    :: use_ufo, nst_anl, frac_grid
@@ -38,6 +39,9 @@ contains
     real(kind=kind_phys), intent(inout) :: smc(:,:),   &
                                            slc(:,:),   &
                                            stc(:,:),   &
+                                           smois(:,:), &
+                                           sh2o(:,:),  &
+                                           tslb(:,:),  &
                                            tiice(:,:), &
                                            tg3(:),     &
                                            tref(:),    &

--- a/physics/h2o_def.f
+++ b/physics/h2o_def.f
@@ -4,6 +4,11 @@
 !>\ingroup mod_GFS_phys_time_vary
 !! This module defines arrays in H2O scheme.
       module h2o_def
+
+!> \section arg_table_h2o_def
+!! \htmlinclude h2o_def.html
+!!
+
       use machine , only : kind_phys
       implicit none
 

--- a/physics/h2o_def.meta
+++ b/physics/h2o_def.meta
@@ -1,0 +1,29 @@
+[ccpp-table-properties]
+  name = h2o_def
+  type = module
+  dependencies = machine.F
+
+[ccpp-arg-table]
+  name = h2o_def
+  type = module
+
+[levh2o]
+  standard_name = vertical_dimension_of_h2o_forcing_data
+  long_name = number of vertical layers in h2o forcing data
+  units = count
+  dimensions = ()
+  type = integer
+[h2o_coeff]
+  standard_name = number_of_coefficients_in_h2o_forcing_data
+  long_name = number of coefficients in h2o forcing data
+  units = index
+  dimensions = ()
+  type = integer
+[h2o_pres]
+  standard_name = natural_log_of_h2o_forcing_data_pressure_levels
+  long_name = natural log of h2o forcing data pressure levels
+  units = log(Pa)
+  dimensions = (vertical_dimension_of_h2o_forcing_data)
+  type = real
+  kind = kind_phys
+  active = (flag_for_stratospheric_water_vapor_physics)

--- a/physics/ozne_def.f
+++ b/physics/ozne_def.f
@@ -4,6 +4,11 @@
 !>\ingroup mod_GFS_phys_time_vary
 !! This module defines arrays in Ozone scheme.
       module ozne_def
+
+!> \section arg_table_ozne_def
+!! \htmlinclude ozne_def.html
+!!
+
       use machine , only : kind_phys
       implicit none
       

--- a/physics/ozne_def.meta
+++ b/physics/ozne_def.meta
@@ -1,0 +1,29 @@
+[ccpp-table-properties]
+  name = ozne_def
+  type = module
+  dependencies = machine.F
+
+[ccpp-arg-table]
+  name = ozne_def
+  type = module
+
+[levozp]
+  standard_name = vertical_dimension_of_ozone_forcing_data
+  long_name = number of vertical layers in ozone forcing data
+  units = count
+  dimensions = ()
+  type = integer
+[oz_coeff]
+  standard_name = number_of_coefficients_in_ozone_forcing_data
+  long_name = number of coefficients in ozone forcing data
+  units = index
+  dimensions = ()
+  type = integer
+[oz_pres]
+  standard_name = natural_log_of_ozone_forcing_data_pressure_levels
+  long_name = natural log of ozone forcing data pressure levels
+  units = log(Pa)
+  dimensions = (vertical_dimension_of_ozone_forcing_data)
+  type = real
+  kind = kind_phys
+  active = (index_for_ozone>0)


### PR DESCRIPTION
This PR contains the following changes:

- move time vary physics from `run` to `timestep_init`
- remove dependency of time vary physics on GFS DDTs
- clean up o3 and h2o physics (use existing arrays instead of duplicating them and wasting memory)

Associated PRs:

https://github.com/ufs-community/ufs-weather-model/pull/337
https://github.com/NOAA-EMC/fv3atm/pull/217
https://github.com/NCAR/ccpp-physics/pull/534
https://github.com/NCAR/ccpp-framework/pull/344
https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/pull/47

For regression testing information, see https://github.com/ufs-community/ufs-weather-model/pull/337.