### PR TITLE
Remove unnecessary SIMD instruction sets from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
       string(REPLACE "-xCORE-AVX2" "-xCORE-AVX-I"
              CMAKE_Fortran_FLAGS_LOPT1
              "${CMAKE_Fortran_FLAGS_LOPT1}")
-      string(REPLACE "-axSSE4.2,AVX,CORE-AVX2,CORE-AVX512" "-axSSE4.2,AVX,CORE-AVX-I"
+      string(REPLACE "-axSSE4.2,CORE-AVX2" "-axSSE4.2,CORE-AVX-I"
              CMAKE_Fortran_FLAGS_LOPT1
              "${CMAKE_Fortran_FLAGS_LOPT1}")
       SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/physics/radiation_aerosols.f


### PR DESCRIPTION
When option `SIMDMULTIARCH` is used at compile time (currently only on Jet), four SIMD instruction sets are compiled into the executable. The ccpp-physics top-level `CMakeLists.txt` performs some modification of these optimization flags for certain files.

Also included: update of an SCM-only file that was already merged into the repository, see https://github.com/NCAR/ccpp-physics/pull/541.

Associated PRs:

https://github.com/NCAR/ccpp-physics/pull/539
https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/pull/49
https://github.com/NOAA-EMC/fv3atm/pull/220
https://github.com/ufs-community/ufs-weather-model/pull/353

For regression testing, see https://github.com/ufs-community/ufs-weather-model/pull/353.
