### PR TITLE
release/public-v5: bugfixes for GNU 10 crashes

### DIFF
--- a/physics/GFS_MP_generic.F90
+++ b/physics/GFS_MP_generic.F90
@@ -120,31 +120,30 @@
       real(kind=kind_phys), dimension(im),      intent(in   ) :: sr
       real(kind=kind_phys), dimension(im),      intent(inout) :: rain, domr_diag, domzr_diag, domip_diag, doms_diag, tprcp,  &
                                                                  srflag, cnvprcp, totprcp, totice, totsnw, totgrp, cnvprcpb, &
-                                                                 totprcpb, toticeb, totsnwb, totgrpb, rain_cpl, rainc_cpl,   &
-                                                                 snow_cpl, pwat
+                                                                 totprcpb, toticeb, totsnwb, totgrpb, pwat
+      real(kind=kind_phys), dimension(:),       intent(inout) :: rain_cpl, rainc_cpl, snow_cpl
 
       real(kind=kind_phys), dimension(:,:),     intent(inout) :: dt3dt ! only if ldiag3d
       real(kind=kind_phys), dimension(:,:),     intent(inout) :: dq3dt ! only if ldiag3d and qdiag3d
 
       ! Stochastic physics / surface perturbations
       logical, intent(in) :: do_sppt, ca_global
-      real(kind=kind_phys), dimension(im,levs), intent(inout) :: dtdtr
-      real(kind=kind_phys), dimension(im,levs), intent(in)    :: dtdtc
-      real(kind=kind_phys), dimension(im),      intent(inout) :: drain_cpl
-      real(kind=kind_phys), dimension(im),      intent(inout) :: dsnow_cpl
+      real(kind=kind_phys), dimension(:,:),     intent(inout) :: dtdtr
+      real(kind=kind_phys), dimension(:,:),     intent(in)    :: dtdtc
+      real(kind=kind_phys), dimension(:),       intent(inout) :: drain_cpl, dsnow_cpl
 
       ! Rainfall variables previous time step
       integer, intent(in) :: lsm, lsm_ruc, lsm_noahmp
-      real(kind=kind_phys), dimension(im),      intent(inout) :: raincprv
-      real(kind=kind_phys), dimension(im),      intent(inout) :: rainncprv
-      real(kind=kind_phys), dimension(im),      intent(inout) :: iceprv
-      real(kind=kind_phys), dimension(im),      intent(inout) :: snowprv
-      real(kind=kind_phys), dimension(im),      intent(inout) :: graupelprv
-      real(kind=kind_phys), dimension(im),      intent(inout) :: draincprv
-      real(kind=kind_phys), dimension(im),      intent(inout) :: drainncprv
-      real(kind=kind_phys), dimension(im),      intent(inout) :: diceprv
-      real(kind=kind_phys), dimension(im),      intent(inout) :: dsnowprv
-      real(kind=kind_phys), dimension(im),      intent(inout) :: dgraupelprv
+      real(kind=kind_phys), dimension(:),       intent(inout) :: raincprv
+      real(kind=kind_phys), dimension(:),       intent(inout) :: rainncprv
+      real(kind=kind_phys), dimension(:),       intent(inout) :: iceprv
+      real(kind=kind_phys), dimension(:),       intent(inout) :: snowprv
+      real(kind=kind_phys), dimension(:),       intent(inout) :: graupelprv
+      real(kind=kind_phys), dimension(:),       intent(inout) :: draincprv
+      real(kind=kind_phys), dimension(:),       intent(inout) :: drainncprv
+      real(kind=kind_phys), dimension(:),       intent(inout) :: diceprv
+      real(kind=kind_phys), dimension(:),       intent(inout) :: dsnowprv
+      real(kind=kind_phys), dimension(:),       intent(inout) :: dgraupelprv
 
       real(kind=kind_phys),                     intent(in)    :: dtp
 

--- a/physics/GFS_rrtmg_pre.F90
+++ b/physics/GFS_rrtmg_pre.F90
@@ -22,7 +22,6 @@
           Tbd, Cldprop, Coupling,                                    &
           Radtend,                                                   & ! input/output
           imfdeepcnv, imfdeepcnv_gf,                                 &
-          f_ice, f_rain, f_rimef, flgmin, cwm,                       & ! F-A mp scheme only
           lm, im, lmk, lmp,                                          & ! input
           kd, kt, kb, raddt, delp, dz, plvl, plyr,                   & ! output
           tlvl, tlyr, tsfg, tsfa, qlyr, olyr,                        &
@@ -94,11 +93,6 @@
       integer,              intent(in)  :: imfdeepcnv, imfdeepcnv_gf
       integer,              intent(out) :: kd, kt, kb
 
-! F-A mp scheme only
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP), intent(in) :: f_ice, &
-                                                                       f_rain, f_rimef
-      real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP), intent(out) :: cwm
-      real(kind=kind_phys), dimension(size(Grid%xlon,1)),        intent(in)  :: flgmin
       real(kind=kind_phys), intent(out) :: raddt
 
       real(kind=kind_phys), dimension(size(Grid%xlon,1),lm+LTP),   intent(out) :: delp, &

--- a/physics/GFS_rrtmg_pre.meta
+++ b/physics/GFS_rrtmg_pre.meta
@@ -70,51 +70,6 @@
   type = GFS_radtend_type
   intent = inout
   optional = F
-[f_ice]
-  standard_name = fraction_of_ice_water_cloud
-  long_name = fraction of ice water cloud
-  units = frac
-  dimensions = (horizontal_dimension,vertical_dimension)
-  type = real
-  kind = kind_phys
-  intent = in
-  optional = F
-[f_rain]
-  standard_name = fraction_of_rain_water_cloud
-  long_name = fraction of rain water cloud
-  units = frac
-  dimensions = (horizontal_dimension,vertical_dimension)
-  type = real
-  kind = kind_phys
-  intent = in
-  optional = F
-[f_rimef]
-  standard_name = rime_factor
-  long_name = rime factor
-  units = frac
-  dimensions = (horizontal_dimension,vertical_dimension)
-  type = real
-  kind = kind_phys
-  intent = in
-  optional = F
-[flgmin]
-  standard_name = minimum_large_ice_fraction
-  long_name = minimum large ice fraction in F-A mp scheme
-  units = frac
-  dimensions = (2)
-  type = real
-  kind = kind_phys
-  intent = in
-  optional = F
-[cwm]
-  standard_name = total_cloud_condensate_mixing_ratio_updated_by_physics
-  long_name = total cloud condensate mixing ratio (except water vapor) updated by physics
-  units = kg kg-1
-  dimensions = (horizontal_dimension,vertical_dimension)
-  type = real
-  kind = kind_phys
-  intent = out
-  optional = F
 [lm]
   standard_name = number_of_vertical_layers_for_radiation_calculations
   long_name = number of vertical layers for radiation calculation

--- a/physics/GFS_stochastics.F90
+++ b/physics/GFS_stochastics.F90
@@ -90,7 +90,7 @@
          real(kind_phys), dimension(:),         intent(in)    :: dsnow_cpl
          real(kind_phys), dimension(1:km),      intent(in)    :: si
          real(kind_phys), dimension(1:km),      intent(inout) :: vfact_ca
-         real(kind_phys), dimension(1:im),      intent(in)    :: ca1
+         real(kind_phys), dimension(:),         intent(in)    :: ca1
          character(len=*),                      intent(out)   :: errmsg
          integer,                               intent(out)   :: errflg
 

--- a/physics/GFS_suite_interstitial.F90
+++ b/physics/GFS_suite_interstitial.F90
@@ -175,7 +175,8 @@
 
       logical,              intent(in   ), dimension(im) :: flag_cice
       real(kind=kind_phys), intent(in   ), dimension(2) :: ctei_rm
-      real(kind=kind_phys), intent(in   ), dimension(im) :: xcosz, adjsfcdsw, adjsfcdlw, pgr, xmu, ulwsfc_cice, work1, work2
+      real(kind=kind_phys), intent(in   ), dimension(im) :: xcosz, adjsfcdsw, adjsfcdlw, pgr, xmu, work1, work2
+      real(kind=kind_phys), intent(in   ), dimension(:)  :: ulwsfc_cice
       real(kind=kind_phys), intent(in   ), dimension(im) :: cice
       real(kind=kind_phys), intent(in   ), dimension(im, levs) :: htrsw, htrlw, tgrs, prsl, qgrs_water_vapor, qgrs_cloud_water, prslk
       real(kind=kind_phys), intent(in   ), dimension(im, levs+1) :: prsi

--- a/physics/GFS_surface_generic.F90
+++ b/physics/GFS_surface_generic.F90
@@ -51,14 +51,14 @@
 
         ! Stochastic physics / surface perturbations
         logical, intent(in) :: do_sppt, ca_global
-        real(kind=kind_phys), dimension(im,levs),     intent(out) :: dtdtr
-        real(kind=kind_phys), dimension(im),          intent(out) :: drain_cpl
-        real(kind=kind_phys), dimension(im),          intent(out) :: dsnow_cpl
-        real(kind=kind_phys), dimension(im),          intent(in)  :: rain_cpl
-        real(kind=kind_phys), dimension(im),          intent(in)  :: snow_cpl
+        real(kind=kind_phys), dimension(:,:),         intent(out) :: dtdtr
+        real(kind=kind_phys), dimension(:),           intent(out) :: drain_cpl
+        real(kind=kind_phys), dimension(:),           intent(out) :: dsnow_cpl
+        real(kind=kind_phys), dimension(:),           intent(in)  :: rain_cpl
+        real(kind=kind_phys), dimension(:),           intent(in)  :: snow_cpl
         logical, intent(in) :: do_sfcperts
         integer, intent(in) :: nsfcpert
-        real(kind=kind_phys), dimension(im,nsfcpert), intent(in)  :: sfc_wts
+        real(kind=kind_phys), dimension(:,:),         intent(in)  :: sfc_wts
         real(kind=kind_phys), dimension(:),           intent(in)  :: pertz0
         real(kind=kind_phys), dimension(:),           intent(in)  :: pertzt
         real(kind=kind_phys), dimension(:),           intent(in)  :: pertshc
@@ -71,7 +71,7 @@
         real(kind=kind_phys), dimension(im),          intent(out) :: vegf1d
 
         logical, intent(in) :: cplflx
-        real(kind=kind_phys), dimension(im), intent(in) :: slimskin_cpl
+        real(kind=kind_phys), dimension(:), intent(in) :: slimskin_cpl
         logical, dimension(im), intent(inout) :: flag_cice
         integer, dimension(im), intent(out) :: islmsk_cice
         real(kind=kind_phys), dimension(im), intent(in) :: &
@@ -234,11 +234,13 @@
           adjnirbmd, adjnirdfd, adjvisbmd, adjvisdfd, adjsfculw, adjsfculw_wat, adjnirbmu, adjnirdfu, adjvisbmu, adjvisdfu,    &
           t2m, q2m, u10m, v10m, tsfc, tsfc_wat, pgr, xcosz, evbs, evcw, trans, sbsno, snowc, snohf
 
-        real(kind=kind_phys), dimension(im),  intent(inout) :: epi, gfluxi, t1, q1, u1, v1, dlwsfci_cpl, dswsfci_cpl, dlwsfc_cpl, &
-          dswsfc_cpl, dnirbmi_cpl, dnirdfi_cpl, dvisbmi_cpl, dvisdfi_cpl, dnirbm_cpl, dnirdf_cpl, dvisbm_cpl, dvisdf_cpl, &
-          nlwsfci_cpl, nlwsfc_cpl, t2mi_cpl, q2mi_cpl, u10mi_cpl, v10mi_cpl, tsfci_cpl, psurfi_cpl, nnirbmi_cpl, nnirdfi_cpl, &
-          nvisbmi_cpl, nvisdfi_cpl, nswsfci_cpl, nswsfc_cpl, nnirbm_cpl, nnirdf_cpl, nvisbm_cpl, nvisdf_cpl, gflux, evbsa, &
+        real(kind=kind_phys), dimension(im),  intent(inout) :: epi, gfluxi, t1, q1, u1, v1, gflux, evbsa, &
           evcwa, transa, sbsnoa, snowca, snohfa, ep
+
+        real(kind=kind_phys), dimension(:),   intent(inout) :: dlwsfci_cpl, dswsfci_cpl, dlwsfc_cpl, &
+                    dswsfc_cpl, dnirbmi_cpl, dnirdfi_cpl, dvisbmi_cpl, dvisdfi_cpl, dnirbm_cpl, dnirdf_cpl, dvisbm_cpl, dvisdf_cpl, &
+                    nlwsfci_cpl, nlwsfc_cpl, t2mi_cpl, q2mi_cpl, u10mi_cpl, v10mi_cpl, tsfci_cpl, psurfi_cpl, nnirbmi_cpl, nnirdfi_cpl, &
+                    nvisbmi_cpl, nvisdfi_cpl, nswsfci_cpl, nswsfc_cpl, nnirbm_cpl, nnirdf_cpl, nvisbm_cpl, nvisdf_cpl
 
         real(kind=kind_phys), dimension(im), intent(inout) :: runoff, srunoff
         real(kind=kind_phys), dimension(im), intent(in)    :: drain, runof

--- a/physics/module_MYNNPBL_wrapper.F90
+++ b/physics/module_MYNNPBL_wrapper.F90
@@ -288,10 +288,12 @@ SUBROUTINE mynnedmf_wrapper_run(        &
 !MYNN-2D
       real(kind=kind_phys), dimension(im), intent(in) ::                 &
      &        dx,zorl,slmsk,tsurf,qsfc,ps,                               &
-     &        hflx,qflx,ust,wspd,rb,recmol
+     &        hflx,qflx,ust,wspd,rb
+
+      real(kind=kind_phys), dimension(:), intent(in) ::                  &
+     &        dusfc_cice,dvsfc_cice,dtsfc_cice,dqsfc_cice,recmol
 
       real(kind=kind_phys), dimension(im), intent(in) ::                 &
-     &        dusfc_cice,dvsfc_cice,dtsfc_cice,dqsfc_cice,               &
      &        stress_ocn,hflx_ocn,qflx_ocn,                              &
      &        oceanfrac,fice
 

--- a/physics/samfdeepcnv.f
+++ b/physics/samfdeepcnv.f
@@ -96,8 +96,8 @@
       real(kind=kind_phys), dimension(:), intent(in) :: fscav
       logical, intent(in)  :: hwrf_samfdeep
       real(kind=kind_phys), intent(in) :: nthresh
-      real(kind=kind_phys), intent(in) :: ca_deep(im)
-      real(kind=kind_phys), intent(out) :: rainevap(im)
+      real(kind=kind_phys), dimension(:), intent(in)  :: ca_deep
+      real(kind=kind_phys), dimension(:), intent(out) :: rainevap
       logical, intent(in)  :: do_ca,ca_closure,ca_entr,ca_trigger
 
       integer, intent(inout)  :: kcnv(im)


### PR DESCRIPTION
This PR contains bugfixes to prevent model runs from crashing when using gfortran 10.x.y. All these changes are related to using assumed-size array declarations in several primary and interstitial schemes for arrays that are allocated only under certain conditions.

Some of these changes were contributed by @dusanjovic-noaa.

Associated PRs:

https://github.com/NCAR/ccpp-physics/pull/540
https://github.com/NOAA-EMC/fv3atm/pull/221
https://github.com/ufs-community/ufs-weather-model/pull/355

For regression testing, see https://github.com/ufs-community/ufs-weather-model/pull/355.