### PR TITLE
Add missing dependency of module_radiation_clouds on module_mp_thompson to metadata

### DIFF
--- a/physics/GFS_rrtmg_setup.meta
+++ b/physics/GFS_rrtmg_setup.meta
@@ -1,7 +1,8 @@
 [ccpp-table-properties]
   name = GFS_rrtmg_setup
   type = scheme
-  dependencies = iounitdef.f,module_bfmicrophysics.f,physparam.f,radcons.f90,radiation_aerosols.f,radiation_astronomy.f,radiation_clouds.f,radiation_gases.f,radiation_surface.f,radlw_main.F90,radlw_param.f,radsw_main.F90,radsw_param.f
+  dependencies = iounitdef.f,module_bfmicrophysics.f,physparam.f,radcons.f90,radiation_aerosols.f,radiation_astronomy.f,radiation_clouds.f,
+  dependencies = module_mp_thompson.F90,radiation_gases.f,radiation_surface.f,radlw_main.F90,radlw_param.f,radsw_main.F90,radsw_param.f,
 
 ########################################################################
 [ccpp-arg-table]

--- a/physics/GFS_rrtmgp_pre.meta
+++ b/physics/GFS_rrtmgp_pre.meta
@@ -2,7 +2,7 @@
   name = GFS_rrtmgp_pre
   type = scheme
   dependencies = funcphys.f90,iounitdef.f,machine.F,module_bfmicrophysics.f,physcons.F90,physparam.f,radcons.f90,radiation_aerosols.f
-  dependencies = radiation_astronomy.f,radiation_clouds.f,radiation_gases.f,radiation_surface.f,rrtmgp_aux.F90,rrtmg_lw_cloud_optics.F90
+  dependencies = radiation_astronomy.f,radiation_clouds.f,module_mp_thompson.F90,radiation_gases.f,radiation_surface.f,rrtmgp_aux.F90,rrtmg_lw_cloud_optics.F90
 
 ########################################################################
 [ccpp-arg-table]

--- a/physics/GFS_rrtmgp_setup.meta
+++ b/physics/GFS_rrtmgp_setup.meta
@@ -1,7 +1,8 @@
 [ccpp-table-properties]
   name = GFS_rrtmgp_setup
   type = scheme
-  dependencies = iounitdef.f,machine.F,module_bfmicrophysics.f,physparam.f,radiation_aerosols.f,radiation_astronomy.f,radiation_clouds.f,radiation_gases.f,radiation_surface.f
+  dependencies = iounitdef.f,machine.F,module_bfmicrophysics.f,physparam.f,radiation_aerosols.f,radiation_astronomy.f
+  dependencies = module_mp_thompson.F90,radiation_clouds.f,radiation_gases.f,radiation_surface.f
 
 ########################################################################
 [ccpp-arg-table]

--- a/physics/module_SGSCloud_RadPre.meta
+++ b/physics/module_SGSCloud_RadPre.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = sgscloud_radpre
   type = scheme
-  dependencies = funcphys.f90,iounitdef.f,machine.F,module_bfmicrophysics.f,physcons.F90,radcons.f90,radiation_clouds.f
+  dependencies = funcphys.f90,iounitdef.f,machine.F,module_bfmicrophysics.f,physcons.F90,radcons.f90,radiation_clouds.f,module_mp_thompson.F90
 
 ########################################################################
 [ccpp-arg-table]


### PR DESCRIPTION
As the title says.

Fixes https://github.com/NCAR/ccpp-physics/issues/545 - see the issue for more details.

Associated PRs:

https://github.com/NCAR/ccpp-physics/pull/546
https://github.com/NOAA-EMC/fv3atm/pull/225
https://github.com/ufs-community/ufs-weather-model/pull/345

For regression testing, see https://github.com/ufs-community/ufs-weather-model/pull/345.