### PR TITLE
SCM ONLY: add no_rad flag to guarantee that radiation is skipped in physics call

### DIFF
--- a/physics/GFS_time_vary_pre.scm.F90
+++ b/physics/GFS_time_vary_pre.scm.F90
@@ -66,8 +66,9 @@
 !! \htmlinclude GFS_time_vary_pre_run.html
 !!
       subroutine GFS_time_vary_pre_run (jdat, idat, dtp, lsm, lsm_noahmp, nsswr, &
-        nslwr, idate, debug, me, master, nscyc, sec, phour, zhour, fhour, kdt,   &
-        julian, yearlen, ipt, lprnt, lssav, lsswr, lslwr, solhr, errmsg, errflg)
+        nslwr, idate, debug, me, master, nscyc, no_rad, sec, phour, zhour, fhour,&
+        kdt, julian, yearlen, ipt, lprnt, lssav, lsswr, lslwr, solhr, errmsg,    &
+        errflg)
 
         use machine,               only: kind_phys
 
@@ -78,7 +79,7 @@
         integer,                          intent(in)    :: lsm, lsm_noahmp,      &
                                                            nsswr, nslwr, me,     &
                                                            master, nscyc
-        logical,                          intent(in)    :: debug
+        logical,                          intent(in)    :: debug, no_rad
         real(kind=kind_phys),             intent(in)    :: dtp
         
         integer,                          intent(out)   :: kdt, yearlen, ipt
@@ -161,14 +162,17 @@
         ipt    = 1
         lprnt  = .false.
         lssav  = .true.
-
-        !--- radiation triggers
-        lsswr  = (mod(kdt, nsswr) == 1)
-        lslwr  = (mod(kdt, nslwr) == 1)
-        !--- allow for radiation to be called on every physics time step, if needed
-        if (nsswr == 1)  lsswr = .true.
-        if (nslwr == 1)  lslwr = .true.
-
+        
+        if (.not. no_rad) then
+          !--- radiation triggers
+          lsswr  = (mod(kdt, nsswr) == 1)
+          lslwr  = (mod(kdt, nslwr) == 1)
+          
+          !--- allow for radiation to be called on every physics time step, if needed
+          if (nsswr == 1)  lsswr = .true.
+          if (nslwr == 1)  lslwr = .true.
+        end if
+        
         !--- set the solar hour based on a combination of phour and time initial hour
         solhr  = mod(phour+idate(1),con_24)
 

--- a/physics/GFS_time_vary_pre.scm.meta
+++ b/physics/GFS_time_vary_pre.scm.meta
@@ -148,6 +148,14 @@
   type = integer
   intent = in
   optional = F
+[no_rad]
+  standard_name = flag_to_deactivate_radiation
+  long_name = logical flag set to true to turn off radiation completely
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
 [sec]
   standard_name = seconds_elapsed_since_model_initialization
   long_name = seconds elapsed since model initialization


### PR DESCRIPTION
Add a no_rad flag in GFS_time_vary_pre.scm.F90 to block setting lsswr (flag_to_calc_sw) and lslwr (flag_to_calc_lw) to true. This is used in some SCM cases where radiation tendencies are included in forcing and radiation codes should not be executed.

Associated with https://github.com/NCAR/gmtb-scm/pull/222