### PR TITLE
Initialize ice flux in CMEPSA bug fix. "flag_cice" used to be a proxy for "not 1st time step cold…

### DIFF
--- a/physics/GFS_PBL_generic.F90
+++ b/physics/GFS_PBL_generic.F90
@@ -316,7 +316,7 @@
         dqdt, dusfc_cpl, dvsfc_cpl, dtsfc_cpl,                                                                                 &
         dqsfc_cpl, dusfci_cpl, dvsfci_cpl, dtsfci_cpl, dqsfci_cpl, dusfc_diag, dvsfc_diag, dtsfc_diag, dqsfc_diag,             &
         dusfci_diag, dvsfci_diag, dtsfci_diag, dqsfci_diag, dt3dt, du3dt_PBL, du3dt_OGWD, dv3dt_PBL, dv3dt_OGWD, dq3dt,        &
-        dq3dt_ozone, rd, cp, fvirt, hvap, t1, q1, prsl, hflx, ushfsfci, oceanfrac, flag_cice, dusfc_cice, dvsfc_cice,          &
+        dq3dt_ozone, rd, cp, fvirt, hvap, t1, q1, prsl, hflx, ushfsfci, oceanfrac, kdt, dusfc_cice, dvsfc_cice,                &
         dtsfc_cice, dqsfc_cice, wet, dry, icy, wind, stress_wat, hflx_wat, evap_wat, ugrs1, vgrs1, dkt_cpl, dkt, hffac, hefac, &
         ugrs, vgrs, tgrs, qgrs, save_u, save_v, save_t, save_q, errmsg, errflg)
 
@@ -333,7 +333,7 @@
       integer, intent(in) :: imp_physics_zhao_carr, imp_physics_mg, imp_physics_fer_hires
       logical, intent(in) :: ltaerosol, cplflx, cplchm, lssav, ldiag3d, qdiag3d, lsidea
       logical, intent(in) :: hybedmf, do_shoc, satmedmf, shinhong, do_ysu
-      logical, dimension(:), intent(in) :: flag_cice
+      integer, intent(in) :: kdt
 
       logical, intent(in) :: flag_for_pbl_generic_tend      
       real(kind=kind_phys), dimension(im, levs), intent(in) :: save_u, save_v, save_t
@@ -549,7 +549,7 @@
         do i=1,im
           if (oceanfrac(i) > zero) then ! Ocean only, NO LAKES
             if ( .not. wet(i)) then ! no open water
-              if (flag_cice(i)) then !use results from CICE
+              if ( kdt > 1 ) then !use results from CICE
                 dusfci_cpl(i) = dusfc_cice(i)
                 dvsfci_cpl(i) = dvsfc_cice(i)
                 dtsfci_cpl(i) = dtsfc_cice(i)

--- a/physics/GFS_PBL_generic.meta
+++ b/physics/GFS_PBL_generic.meta
@@ -1194,12 +1194,12 @@
   kind = kind_phys
   intent = in
   optional = F
-[flag_cice]
-  standard_name = flag_for_cice
-  long_name = flag for cice
-  units = flag
-  dimensions = (horizontal_loop_extent)
-  type = logical
+[kdt]
+  standard_name = index_of_time_step
+  long_name = current forecast iteration
+  units = index
+  dimensions = ()
+  type = integer
   intent = in
   optional = F
 [dusfc_cice]


### PR DESCRIPTION
A bug fix. "flag_cice" used to be a proxy for "not 1st time step cold start" in NEMS, but is no longer the case in CMEPS. It is now replaced by "kdt>1". This will change results in all coupled models.

Fixes https://github.com/NOAA-EMC/fv3atm/issues/142.

Co-authored-by: ben.green@noaa.gov

This refers to issue #472