### PR TITLE
Compositing z0 for fractional grid

### DIFF
--- a/physics/GFS_surface_composites.F90
+++ b/physics/GFS_surface_composites.F90
@@ -351,7 +351,7 @@ contains
 !!
 #endif
    subroutine GFS_surface_composites_post_run (                                                                                   &
-      im, kice, km, cplflx, cplwav2atm, frac_grid, flag_cice, islmsk, dry, wet, icy, landfrac, lakefrac, oceanfrac,               &
+      im, kice, km, cplflx, cplwav2atm, frac_grid, flag_cice, islmsk, dry, wet, icy, wind, landfrac, lakefrac, oceanfrac,         &
       zorl, zorlo, zorll, zorli, zorl_wat, zorl_lnd, zorl_ice,                                                                    &
       cd, cd_wat, cd_lnd, cd_ice, cdq, cdq_wat, cdq_lnd, cdq_ice, rb, rb_wat, rb_lnd, rb_ice, stress, stress_wat, stress_lnd,     &
       stress_ice, ffmm, ffmm_wat, ffmm_lnd, ffmm_ice, ffhh, ffhh_wat, ffhh_lnd, ffhh_ice, uustar, uustar_wat, uustar_lnd,         &
@@ -367,7 +367,7 @@ contains
       logical,                              intent(in) :: cplflx, frac_grid, cplwav2atm
       logical, dimension(im),               intent(in) :: flag_cice, dry, wet, icy
       integer, dimension(im),               intent(in) :: islmsk
-      real(kind=kind_phys), dimension(im),  intent(in) :: landfrac, lakefrac, oceanfrac,                                        &
+      real(kind=kind_phys), dimension(im),  intent(in) :: wind, landfrac, lakefrac, oceanfrac,                                  &
         zorl_wat, zorl_lnd, zorl_ice, cd_wat, cd_lnd, cd_ice, cdq_wat, cdq_lnd, cdq_ice, rb_wat, rb_lnd, rb_ice, stress_wat,    &
         stress_lnd, stress_ice, ffmm_wat, ffmm_lnd, ffmm_ice, ffhh_wat, ffhh_lnd, ffhh_ice, uustar_wat, uustar_lnd, uustar_ice, &
         fm10_wat, fm10_lnd, fm10_ice, fh2_wat, fh2_lnd, fh2_ice, tsurf_wat, tsurf_lnd, tsurf_ice, cmm_wat, cmm_lnd, cmm_ice,    &
@@ -408,20 +408,24 @@ contains
           txi   = cice(i) * wfrac        ! txi = ice fraction wrt whole cell
           txo   = max(zero, wfrac-txi)   ! txo = open water fraction
 
-          zorl(i)   = txl*zorl_lnd(i)   + txi*zorl_ice(i)   + txo*zorl_wat(i)
-          cd(i)     = txl*cd_lnd(i)     + txi*cd_ice(i)     + txo*cd_wat(i)
-          cdq(i)    = txl*cdq_lnd(i)    + txi*cdq_ice(i)    + txo*cdq_wat(i)
-          rb(i)     = txl*rb_lnd(i)     + txi*rb_ice(i)     + txo*rb_wat(i)
-          stress(i) = txl*stress_lnd(i) + txi*stress_ice(i) + txo*stress_wat(i)
-          ffmm(i)   = txl*ffmm_lnd(i)   + txi*ffmm_ice(i)   + txo*ffmm_wat(i)
-          ffhh(i)   = txl*ffhh_lnd(i)   + txi*ffhh_ice(i)   + txo*ffhh_wat(i)
-          uustar(i) = txl*uustar_lnd(i) + txi*uustar_ice(i) + txo*uustar_wat(i)
-          fm10(i)   = txl*fm10_lnd(i)   + txi*fm10_ice(i)   + txo*fm10_wat(i)
-          fh2(i)    = txl*fh2_lnd(i)    + txi*fh2_ice(i)    + txo*fh2_wat(i)
+! BWG          zorl(i)   = txl*zorl_lnd(i)   + txi*zorl_ice(i)   + txo*zorl_wat(i)
+! BWG          cd(i)     = txl*cd_lnd(i)     + txi*cd_ice(i)     + txo*cd_wat(i)
+! BWG          cdq(i)    = txl*cdq_lnd(i)    + txi*cdq_ice(i)    + txo*cdq_wat(i)
+! BWG          rb(i)     = txl*rb_lnd(i)     + txi*rb_ice(i)     + txo*rb_wat(i)
+! BWG          stress(i) = txl*stress_lnd(i) + txi*stress_ice(i) + txo*stress_wat(i)
+! BWG          ffmm(i)   = txl*ffmm_lnd(i)   + txi*ffmm_ice(i)   + txo*ffmm_wat(i)
+! BWG          ffhh(i)   = txl*ffhh_lnd(i)   + txi*ffhh_ice(i)   + txo*ffhh_wat(i)
+! BWG          uustar(i) = txl*uustar_lnd(i) + txi*uustar_ice(i) + txo*uustar_wat(i)
+! BWG          fm10(i)   = txl*fm10_lnd(i)   + txi*fm10_ice(i)   + txo*fm10_wat(i)
+! BWG          fh2(i)    = txl*fh2_lnd(i)    + txi*fh2_ice(i)    + txo*fh2_wat(i)
+
          !tsurf(i)  = txl*tsurf_lnd(i)  + txi*tice(i)       + txo*tsurf_wat(i)
          !tsurf(i)  = txl*tsurf_lnd(i)  + txi*tsurf_ice(i)  + txo*tsurf_wat(i) ! not used again! Moorthi
+
+! BWG, 2021/02/25: cmm=cd*wind, chh=cdq*wind, so use composite cd, cdq
           cmm(i)    = txl*cmm_lnd(i)    + txi*cmm_ice(i)    + txo*cmm_wat(i)
           chh(i)    = txl*chh_lnd(i)    + txi*chh_ice(i)    + txo*chh_wat(i)
+
          !gflx(i)   = txl*gflx_lnd(i)   + txi*gflx_ice(i)   + txo*gflx_wat(i)
           ep1d(i)   = txl*ep1d_lnd(i)   + txi*ep1d_ice(i)   + txo*ep1d_wat(i)
          !weasd(i)  = txl*weasd_lnd(i)  + txi*weasd_ice(i)  + txo*weasd_wat(i)
@@ -441,6 +445,8 @@ contains
             qss(i)  = txl*qss_lnd(i)    + txi*qss_ice(i)    + txo*qss_wat(i)
             gflx(i) = txl*gflx_lnd(i)   + txi*gflx_ice(i)   + txo*gflx_wat(i)
           endif
+          
+! BWG, 2021/02/25: Need to change composite skin temperature base on ULW (Fanglin)
           tsfc(i)   = txl*tsfc_lnd(i)   + txi*tice(i)       + txo*tsfc_wat(i)
 
           zorll(i) = zorl_lnd(i)

--- a/physics/GFS_surface_composites.F90
+++ b/physics/GFS_surface_composites.F90
@@ -423,8 +423,8 @@ contains
          !tsurf(i)  = txl*tsurf_lnd(i)  + txi*tsurf_ice(i)  + txo*tsurf_wat(i) ! not used again! Moorthi
 
 ! BWG, 2021/02/25: cmm=cd*wind, chh=cdq*wind, so use composite cd, cdq
-          cmm(i)    = txl*cmm_lnd(i)    + txi*cmm_ice(i)    + txo*cmm_wat(i)
-          chh(i)    = txl*chh_lnd(i)    + txi*chh_ice(i)    + txo*chh_wat(i)
+          cmm(i)    =  cd(i)*wind  !txl*cmm_lnd(i)    + txi*cmm_ice(i)    + txo*cmm_wat(i)
+          chh(i)    = cdq(i)*wind  !txl*chh_lnd(i)    + txi*chh_ice(i)    + txo*chh_wat(i)
 
          !gflx(i)   = txl*gflx_lnd(i)   + txi*gflx_ice(i)   + txo*gflx_wat(i)
           ep1d(i)   = txl*ep1d_lnd(i)   + txi*ep1d_ice(i)   + txo*ep1d_wat(i)

--- a/physics/GFS_surface_composites.F90
+++ b/physics/GFS_surface_composites.F90
@@ -423,8 +423,8 @@ contains
          !tsurf(i)  = txl*tsurf_lnd(i)  + txi*tsurf_ice(i)  + txo*tsurf_wat(i) ! not used again! Moorthi
 
 ! BWG, 2021/02/25: cmm=cd*wind, chh=cdq*wind, so use composite cd, cdq
-          cmm(i)    =  cd(i)*wind  !txl*cmm_lnd(i)    + txi*cmm_ice(i)    + txo*cmm_wat(i)
-          chh(i)    = cdq(i)*wind  !txl*chh_lnd(i)    + txi*chh_ice(i)    + txo*chh_wat(i)
+          cmm(i)    =  cd(i)*wind(i)  !txl*cmm_lnd(i)    + txi*cmm_ice(i)    + txo*cmm_wat(i)
+          chh(i)    = cdq(i)*wind(i)  !txl*chh_lnd(i)    + txi*chh_ice(i)    + txo*chh_wat(i)
 
          !gflx(i)   = txl*gflx_lnd(i)   + txi*gflx_ice(i)   + txo*gflx_wat(i)
           ep1d(i)   = txl*ep1d_lnd(i)   + txi*ep1d_ice(i)   + txo*ep1d_wat(i)

--- a/physics/GFS_surface_composites.meta
+++ b/physics/GFS_surface_composites.meta
@@ -917,6 +917,15 @@
   type = logical
   intent = in
   optional = F
+[wind]
+  standard_name = wind_speed_at_lowest_model_layer
+  long_name = wind speed at lowest model level
+  units = m s-1
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
 [landfrac]
   standard_name = land_area_fraction
   long_name = fraction of horizontal grid area occupied by land

--- a/physics/sfc_diff.f
+++ b/physics/sfc_diff.f
@@ -71,17 +71,19 @@
      &                    tskin_wat, tskin_lnd, tskin_ice,              &  !intent(in)
      &                    tsurf_wat, tsurf_lnd, tsurf_ice,              &  !intent(in)
      &                   snwdph_wat,snwdph_lnd,snwdph_ice,              &  !intent(in)
+     &                     landfrac,      cice,                         &  !intent(in) -- for use with frac_grid
+     &                       islmsk, frac_grid,                         &  !intent(in) -- for use with frac_grid
      &                     z0rl_wat,  z0rl_lnd,  z0rl_ice,              &  !intent(inout)
-     &                     z0rl_wav,                                    &  !intent(inout)
-     &                    ustar_wat, ustar_lnd, ustar_ice,              &  !intent(inout)
-     &                       cm_wat,    cm_lnd,    cm_ice,              &  !intent(inout)
-     &                       ch_wat,    ch_lnd,    ch_ice,              &  !intent(inout)
-     &                       rb_wat,    rb_lnd,    rb_ice,              &  !intent(inout)
-     &                   stress_wat,stress_lnd,stress_ice,              &  !intent(inout)
-     &                       fm_wat,    fm_lnd,    fm_ice,              &  !intent(inout)
-     &                       fh_wat,    fh_lnd,    fh_ice,              &  !intent(inout)
-     &                     fm10_wat,  fm10_lnd,  fm10_ice,              &  !intent(inout)
-     &                      fh2_wat,   fh2_lnd,   fh2_ice,              &  !intent(inout)
+     &                     z0rl_wav,  z0rl_cmp,                         &  !intent(inout)
+     &         ustar_wat, ustar_lnd, ustar_ice, ustar_cmp,              &  !intent(inout)
+     &            cm_wat,    cm_lnd,    cm_ice,    cm_cmp,              &  !intent(inout)
+     &            ch_wat,    ch_lnd,    ch_ice,    ch_cmp,              &  !intent(inout)
+     &            rb_wat,    rb_lnd,    rb_ice,    rb_cmp,              &  !intent(inout)
+     &        stress_wat,stress_lnd,stress_ice,stress_cmp,              &  !intent(inout)
+     &            fm_wat,    fm_lnd,    fm_ice,    fm_cmp,              &  !intent(inout)
+     &            fh_wat,    fh_lnd,    fh_ice,    fh_cmp,              &  !intent(inout)
+     &          fm10_wat,  fm10_lnd,  fm10_ice,  fm10_cmp,              &  !intent(inout)
+     &           fh2_wat,   fh2_lnd,   fh2_ice,   fh2_cmp,              &  !intent(inout)
      &                    errmsg, errflg)                                  !intent(out)
 !
       implicit none
@@ -107,17 +109,25 @@
      &                   snwdph_wat,snwdph_lnd,snwdph_ice
 
       real(kind=kind_phys), dimension(im), intent(in)    :: z0rl_wav
+      
+      real(kind=kind_phys), dimension(im), intent(in)    ::             &
+     &                     landfrac,     cice
+     
+      integer, dimension(im), intent(in) :: islmsk  ! For compositing
+      
+      logical, intent(in) :: frac_grid              ! For compositing
+      
       real(kind=kind_phys), dimension(im), intent(inout) ::             &
-     &                     z0rl_wat,  z0rl_lnd,  z0rl_ice,              &
-     &                    ustar_wat, ustar_lnd, ustar_ice,              &
-     &                       cm_wat,    cm_lnd,    cm_ice,              &
-     &                       ch_wat,    ch_lnd,    ch_ice,              &
-     &                       rb_wat,    rb_lnd,    rb_ice,              &
-     &                   stress_wat,stress_lnd,stress_ice,              &
-     &                       fm_wat,    fm_lnd,    fm_ice,              &
-     &                       fh_wat,    fh_lnd,    fh_ice,              &
-     &                     fm10_wat,  fm10_lnd,  fm10_ice,              &
-     &                      fh2_wat,   fh2_lnd,   fh2_ice
+     &                     z0rl_wat,  z0rl_lnd,  z0rl_ice,  z0rl_cmp,   &
+     &                    ustar_wat, ustar_lnd, ustar_ice, ustar_cmp,   &
+     &                       cm_wat,    cm_lnd,    cm_ice,    cm_cmp,   &
+     &                       ch_wat,    ch_lnd,    ch_ice,    ch_cmp,   &
+     &                       rb_wat,    rb_lnd,    rb_ice,    rb_cmp,   &
+     &                   stress_wat,stress_lnd,stress_ice,stress_cmp,   &
+     &                       fm_wat,    fm_lnd,    fm_ice,    fm_cmp,   &
+     &                       fh_wat,    fh_lnd,    fh_ice,    fh_cmp,   &
+     &                     fm10_wat,  fm10_lnd,  fm10_ice,  fm10_cmp,   &
+     &                      fh2_wat,   fh2_lnd,   fh2_ice,   fh2_cmp
       character(len=*), intent(out) :: errmsg
       integer,          intent(out) :: errflg
 !
@@ -128,7 +138,14 @@
       real(kind=kind_phys) :: rat,   thv1, restar, wind10m,
      &                        czilc, tem1, tem2, virtfac
 
-      real(kind=kind_phys) :: tvs, z0, z0max, ztmax
+      real(kind=kind_phys) :: tvs, z0, z0max
+      
+      real(kind=kind_phys), dimension(im) ::                            &
+     &                     ztmax_wat, ztmax_lnd, ztmax_ice
+
+      real(kind=kind_phys) :: txl, txi, txo, wfrac ! For fractional
+      real(kind=kind_phys) :: snwdph_cmp, ztmax_cmp! For fractional
+      real(kind=kind_phys) :: tskin_cmp, tsurf_cmp ! For fractional
 !
       real(kind=kind_phys), parameter ::
      &        one=1.0_kp, zero=0.0_kp, half=0.5_kp, qmin=1.0e-8_kp
@@ -166,6 +183,12 @@
 
       do i=1,im
         if(flag_iter(i)) then
+          
+          ! BWG: Need to initialize ztmax arrays
+          ztmax_lnd(i) = 1. ! log(1) = 0
+          ztmax_ice(i) = 1. ! log(1) = 0
+          ztmax_wat(i) = 1. ! log(1) = 0
+          
           virtfac = one + rvrdm1 * max(q1(i),qmin)
           thv1    = t1(i) * prslki(i) * virtfac
 
@@ -229,20 +252,20 @@
             czilc = 0.8_kp
 
             tem1  = 1.0_kp - sigmaf(i)
-            ztmax = z0max*exp( - tem1*tem1
+            ztmax_lnd(i) = z0max*exp( - tem1*tem1
      &              * czilc*ca*sqrt(ustar_lnd(i)*(0.01/1.5e-05)))
 
 
 ! mg, sfc-perts: add surface perturbations to ztmax/z0max ratio over land
             if (ztpert(i) /= zero) then
-              ztmax = ztmax * (10.0_kp**ztpert(i))
+              ztmax_lnd(i) = ztmax_lnd(i) * (10.0_kp**ztpert(i))
             endif
-            ztmax = max(ztmax, zmin)
+            ztmax_lnd(i) = max(ztmax_lnd(i), zmin)
 !
             call stability
 !  ---  inputs:
      &       (z1(i), snwdph_lnd(i), thv1, wind(i),
-     &        z0max, ztmax, tvs, grav,
+     &        z0max, ztmax_lnd(i), tvs, grav,
 !  ---  outputs:
      &        rb_lnd(i), fm_lnd(i), fh_lnd(i), fm10_lnd(i), fh2_lnd(i),
      &        cm_lnd(i), ch_lnd(i), stress_lnd(i), ustar_lnd(i))
@@ -270,14 +293,14 @@
             czilc = 0.8_kp
 
             tem1  = 1.0_kp - sigmaf(i)
-            ztmax = z0max*exp( - tem1*tem1
+            ztmax_ice(i) = z0max*exp( - tem1*tem1
      &              * czilc*ca*sqrt(ustar_ice(i)*(0.01/1.5e-05)))
-            ztmax = max(ztmax, 1.0e-6)
+            ztmax_ice(i) = max(ztmax_ice(i), 1.0e-6)
 !
             call stability
 !  ---  inputs:
      &     (z1(i), snwdph_ice(i), thv1, wind(i),
-     &      z0max, ztmax, tvs, grav,
+     &      z0max, ztmax_ice(i), tvs, grav,
 !  ---  outputs:
      &      rb_ice(i), fm_ice(i), fh_ice(i), fm10_ice(i), fh2_ice(i),
      &      cm_ice(i), ch_ice(i), stress_ice(i), ustar_ice(i))
@@ -307,12 +330,12 @@
 !  rat taken from zeng, zhao and dickinson 1997
 
             rat   = min(7.0_kp, 2.67_kp * sqrt(sqrt(restar)) - 2.57_kp)
-            ztmax = max(z0max * exp(-rat), zmin)
+            ztmax_wat(i) = max(z0max * exp(-rat), zmin)
 !
             if (sfc_z0_type == 6) then
-              call znot_t_v6(wind10m, ztmax)   ! 10-m wind,m/s, ztmax(m)
+              call znot_t_v6(wind10m, ztmax_wat(i))   ! 10-m wind,m/s, ztmax(m)
             else if (sfc_z0_type == 7) then
-              call znot_t_v7(wind10m, ztmax)   ! 10-m wind,m/s, ztmax(m)
+              call znot_t_v7(wind10m, ztmax_wat(i))   ! 10-m wind,m/s, ztmax(m)
             else if (sfc_z0_type > 0) then
               write(0,*)'no option for sfc_z0_type=',sfc_z0_type
               stop
@@ -321,7 +344,7 @@
             call stability
 !  ---  inputs:
      &       (z1(i), snwdph_wat(i), thv1, wind(i),
-     &        z0max, ztmax, tvs, grav,
+     &        z0max, ztmax_wat(i), tvs, grav,
 !  ---  outputs:
      &        rb_wat(i), fm_wat(i), fh_wat(i), fm10_wat(i), fh2_wat(i),
      &        cm_wat(i), ch_wat(i), stress_wat(i), ustar_wat(i))
@@ -371,6 +394,95 @@
 !
         endif                ! end of if(flagiter) loop
       enddo
+
+      ! BWG, 2021/02/23: For fractional grid, get composite values
+      if (frac_grid) then ! If fractional grid is on...
+        do i=1,im ! Loop over horizontal
+          if(flag_iter(i)) then
+            virtfac = one + rvrdm1 * max(q1(i),qmin)
+#ifdef GSD_SURFACE_FLUXES_BUGFIX
+            thv1    = t1(i) / prslk1(i) * virtfac  ! Theta-v at lowest level
+#else
+            thv1    = t1(i) * prslki(i) * virtfac  ! Theta-v at lowest level
+#endif  
+
+            ! Three-way composites (fields from sfc_diff)
+            txl   = landfrac(i)            ! land fraction
+            wfrac = one - txl              ! ocean fraction
+            txi   = cice(i) * wfrac        ! txi = ice fraction wrt whole cell
+            txo   = max(zero, wfrac-txi)   ! txo = open water fraction
+
+            ! Composite inputs to "stability" function
+            snwdph_cmp = txl*snwdph_lnd(i)  + txi*snwdph_ice(i)
+             tsurf_cmp = txl* tsurf_lnd(i)  + txi* tsurf_ice(i)         &
+     &                 + txo* tsurf_wat(i)
+             tskin_cmp = txl* tskin_lnd(i)  + txi* tskin_ice(i)         &
+     &                 + txo* tskin_wat(i)
+#ifdef GSD_SURFACE_FLUXES_BUGFIX
+            tvs  = half * (tsurf_cmp+tskin_cmp)/prsik1(i)
+     &                   * virtfac
+#else
+            tvs  = half * (tsurf_cmp+tskin_cmp) * virtfac
+#endif
+            z0rl_cmp(i) = txl*log(z0rl_lnd(i)) + txi*log(z0rl_ice(i))   &
+     &                  + txo*log(z0rl_wat(i))
+            z0rl_cmp(i) = exp(z0rl_cmp(i))
+            z0max = 0.01_kp * z0rl_cmp(i)
+
+            ztmax_cmp = txl*log(ztmax_lnd(i))+txi*log(ztmax_ice(i))     &
+     &                + txo*log(ztmax_wat(i))
+            ztmax_cmp = exp(ztmax_cmp)
+!
+            call stability
+!  ---  inputs:
+     &       (z1(i), snwdph_cmp, thv1, wind(i),
+     &        z0max, ztmax_cmp, tvs, grav,
+!  ---  outputs:
+     &        rb_cmp(i), fm_cmp(i), fh_cmp(i), fm10_cmp(i), fh2_cmp(i),
+     &        cm_cmp(i), ch_cmp(i), stress_cmp(i), ustar_cmp(i))
+
+          endif   ! end of if(flagiter) loop
+        enddo ! End of loop over horizontal
+      else  ! If frac_grid is false
+        do i=1,im ! Loop over horizontal
+          if(flag_iter(i)) then
+            if (islmsk(i) == 1) then ! Land
+                z0rl_cmp(i) =   z0rl_lnd(i)
+               ustar_cmp(i) =  ustar_lnd(i)
+                  cm_cmp(i) =     cm_lnd(i)
+                  ch_cmp(i) =     ch_lnd(i)
+                  rb_cmp(i) =     rb_lnd(i)
+              stress_cmp(i) = stress_lnd(i)
+                  fm_cmp(i) =     fm_lnd(i)
+                  fh_cmp(i) =     fh_lnd(i)
+                fm10_cmp(i) =   fm10_lnd(i)
+                 fh2_cmp(i) =    fh2_lnd(i)
+            elseif (islmsk(i) == 0) then ! Open water 
+                z0rl_cmp(i) =   z0rl_wat(i)
+               ustar_cmp(i) =  ustar_wat(i)
+                  cm_cmp(i) =     cm_wat(i)
+                  ch_cmp(i) =     ch_wat(i)
+                  rb_cmp(i) =     rb_wat(i)
+              stress_cmp(i) = stress_wat(i)
+                  fm_cmp(i) =     fm_wat(i)
+                  fh_cmp(i) =     fh_wat(i)
+                fm10_cmp(i) =   fm10_wat(i)
+                 fh2_cmp(i) =    fh2_wat(i)
+            else ! if (islmsk(i) == 2) ! Ice
+                z0rl_cmp(i) =   z0rl_ice(i)
+               ustar_cmp(i) =  ustar_ice(i)
+                  cm_cmp(i) =     cm_ice(i)
+                  ch_cmp(i) =     ch_ice(i)
+                  rb_cmp(i) =     rb_ice(i)
+              stress_cmp(i) = stress_ice(i)
+                  fm_cmp(i) =     fm_ice(i)
+                  fh_cmp(i) =     fh_ice(i)
+                fm10_cmp(i) =   fm10_ice(i)
+                 fh2_cmp(i) =    fh2_ice(i)
+            endif
+          endif  ! end of if(flagiter) loop
+        enddo ! End of loop over horizontal
+      endif ! End of getting composite values for fractional grid
 
       return
       end subroutine sfc_diff_run

--- a/physics/sfc_diff.meta
+++ b/physics/sfc_diff.meta
@@ -331,6 +331,40 @@
   kind = kind_phys
   intent = in
   optional = F
+[landfrac] 
+  standard_name = land_area_fraction
+  long_name = fraction of horizontal grid area occupied by land
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[cice]
+  standard_name = sea_ice_concentration
+  long_name = ice fraction over open water
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[islmsk]
+  standard_name = sea_land_ice_mask
+  long_name = sea/land/ice mask (=0/1/2)
+  units = flag
+  dimensions = (horizontal_loop_extent)
+  type = integer
+  intent = in
+  optional = F
+[frac_grid]
+  standard_name = flag_for_fractional_grid
+  long_name = flag for fractional grid
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
 [z0rl_wat]
   standard_name = surface_roughness_length_over_ocean_interstitial
   long_name = surface roughness length over ocean (temporary use as interstitial)
@@ -367,6 +401,15 @@
   kind = kind_phys
   intent = in
   optional = F
+[z0rl_cmp]
+  standard_name = surface_roughness_length
+  long_name = surface roughness length
+  units = cm
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
 [ustar_wat]
   standard_name = surface_friction_velocity_over_ocean
   long_name = surface friction velocity over ocean
@@ -388,6 +431,15 @@
 [ustar_ice]
   standard_name = surface_friction_velocity_over_ice
   long_name = surface friction velocity over ice
+  units = m s-1
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[ustar_cmp]
+  standard_name = surface_friction_velocity
+  long_name = boundary layer parameter
   units = m s-1
   dimensions = (horizontal_loop_extent)
   type = real
@@ -421,6 +473,15 @@
   kind = kind_phys
   intent = inout
   optional = F
+[cm_cmp]
+  standard_name = surface_drag_coefficient_for_momentum_in_air
+  long_name = surface exchange coeff for momentum
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
 [ch_wat]
   standard_name = surface_drag_coefficient_for_heat_and_moisture_in_air_over_ocean
   long_name = surface exchange coeff heat & moisture over ocean
@@ -442,6 +503,15 @@
 [ch_ice]
   standard_name = surface_drag_coefficient_for_heat_and_moisture_in_air_over_ice
   long_name = surface exchange coeff heat & moisture over ice
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[ch_cmp]
+  standard_name = surface_drag_coefficient_for_heat_and_moisture_in_air
+  long_name = surface exchange coeff heat & moisture
   units = none
   dimensions = (horizontal_loop_extent)
   type = real
@@ -475,6 +545,15 @@
   kind = kind_phys
   intent = inout
   optional = F
+[rb_cmp]
+  standard_name = bulk_richardson_number_at_lowest_model_level
+  long_name = bulk Richardson number at the surface
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
 [stress_wat]
   standard_name = surface_wind_stress_over_ocean
   long_name = surface wind stress over ocean
@@ -496,6 +575,15 @@
 [stress_ice]
   standard_name = surface_wind_stress_over_ice
   long_name = surface wind stress over ice
+  units = m2 s-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[stress_cmp]
+  standard_name = surface_wind_stress
+  long_name = surface wind stress
   units = m2 s-2
   dimensions = (horizontal_loop_extent)
   type = real
@@ -529,6 +617,15 @@
   kind = kind_phys
   intent = inout
   optional = F
+[fm_cmp]
+  standard_name = Monin_Obukhov_similarity_function_for_momentum
+  long_name = Monin-Obukhov similarity function for momentum
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
 [fh_wat]
   standard_name = Monin_Obukhov_similarity_function_for_heat_over_ocean
   long_name = Monin-Obukhov similarity function for heat over ocean
@@ -550,6 +647,15 @@
 [fh_ice]
   standard_name = Monin_Obukhov_similarity_function_for_heat_over_ice
   long_name = Monin-Obukhov similarity function for heat over ice
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[fh_cmp]
+  standard_name = Monin_Obukhov_similarity_function_for_heat
+  long_name = Monin-Obukhov similarity function for heat
   units = none
   dimensions = (horizontal_loop_extent)
   type = real
@@ -583,6 +689,15 @@
   kind = kind_phys
   intent = inout
   optional = F
+[fm10_cmp]
+  standard_name = Monin_Obukhov_similarity_function_for_momentum_at_10m
+  long_name = Monin-Obukhov similarity parameter for momentum at 10m
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
 [fh2_wat]
   standard_name = Monin_Obukhov_similarity_function_for_heat_at_2m_over_ocean
   long_name = Monin-Obukhov similarity parameter for heat at 2m over ocean
@@ -604,6 +719,15 @@
 [fh2_ice]
   standard_name = Monin_Obukhov_similarity_function_for_heat_at_2m_over_ice
   long_name = Monin-Obukhov similarity parameter for heat at 2m over ice
+  units = none
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[fh2_cmp]
+  standard_name = Monin_Obukhov_similarity_function_for_heat_at_2m
+  long_name = Monin-Obukhov similarity parameter for heat at 2m
   units = none
   dimensions = (horizontal_loop_extent)
   type = real


### PR DESCRIPTION
Refer to Issue #578 

In GFS_surface_composites.F90, the momentum roughness length zorl is currently composited (for frac_grid = .true.) by taking the arithmetic mean of zorl_lnd, zorl_wat, zorl_ice. A more physically realistic method is to composite based on the logarithms of the component zorls, which can be done in sfc_diff.f to produce self-consistent composite values of ustar, cd, cdq, rb, stress, fm, fh, fm10, and fh2.

NOTE: skin temperature has NOT been composited based on longwave radiation; it still takes weighted average of component temperatures.

@JongilHan66 @shansun6 @SMoorthi-emc @junwang-noaa @yangfanglin (weizhong.zheng@noaa.gov)