### PR TITLE
adding updated RAS

### DIFF
--- a/physics/GFS_DCNV_generic.F90
+++ b/physics/GFS_DCNV_generic.F90
@@ -169,10 +169,10 @@
               dt3dt(i,k) = dt3dt(i,k) + (gt0(i,k)-save_t(i,k)) * frain
               du3dt(i,k) = du3dt(i,k) + (gu0(i,k)-save_u(i,k)) * frain
               dv3dt(i,k) = dv3dt(i,k) + (gv0(i,k)-save_v(i,k)) * frain
-
-!             upd_mf(i,k)  = upd_mf(i,k)  + ud_mf(i,k) * (con_g*frain)
-!             dwn_mf(i,k)  = dwn_mf(i,k)  + dd_mf(i,k) * (con_g*frain)
-!             det_mf(i,k)  = det_mf(i,k)  + dt_mf(i,k) * (con_g*frain)
+              ! convective mass fluxes
+              upd_mf(i,k)  = upd_mf(i,k)  + ud_mf(i,k) * (con_g*frain)
+              dwn_mf(i,k)  = dwn_mf(i,k)  + dd_mf(i,k) * (con_g*frain)
+              det_mf(i,k)  = det_mf(i,k)  + dt_mf(i,k) * (con_g*frain)
             enddo
           enddo
           if(qdiag3d) then

--- a/physics/m_micro.F90
+++ b/physics/m_micro.F90
@@ -542,16 +542,19 @@ end subroutine m_micro_init
      &                            NCPI(I,K), qc_min)
              if (rnw(i,k) <= qc_min(1)) then
                ncpr(i,k) = zero
+               rnw(i,k)  = zero
              elseif (ncpr(i,k) <= nmin) then ! make sure NL > 0 if Q >0
                ncpr(i,k) = max(rnw(i,k) / (fourb3 * PI *RL_cub*997.0_kp), nmin)
              endif
              if (snw(i,k) <= qc_min(2)) then
                ncps(i,k) = zero
+               snw(i,k)  = zero
              elseif (ncps(i,k) <= nmin) then
                ncps(i,k) = max(snw(i,k) / (fourb3 * PI *RL_cub*500.0_kp), nmin)
              endif
              if (qgl(i,k) <= qc_min(2)) then
                ncgl(i,k) = zero
+               qgl(i,k)  = zero
              elseif (ncgl(i,k) <= nmin) then
                ncgl(i,k) = max(qgl(i,k) / (fourb3 * PI *RL_cub*500.0_kp), nmin)
              endif
@@ -1696,16 +1699,19 @@ end subroutine m_micro_init
             QI_TOT(I,K) = QILS(I,K) + QICN(I,K)
             if (rnw(i,k) <= qc_min(1)) then
               ncpr(i,k) = zero
+              rnw(i,k)  = zero
             elseif (ncpr(i,k) <= nmin) then ! make sure NL > 0 if Q >0
               ncpr(i,k) = max(rnw(i,k) / (fourb3 * PI *RL_cub*997.0_kp), nmin)
             endif
             if (snw(i,k) <= qc_min(2)) then
               ncps(i,k) = zero
+              snw(i,k)  = zero
             elseif (ncps(i,k) <= nmin) then
               ncps(i,k) = max(snw(i,k) / (fourb3 * PI *RL_cub*500.0_kp), nmin)
             endif
             if (qgl(i,k) <= qc_min(2)) then
               ncgl(i,k) = zero
+              qgl(i,k)  = zero
             elseif (ncgl(i,k) <= nmin) then
               ncgl(i,k) = max(qgl(i,k) / (fourb3 * PI *RL_cub*500.0_kp), nmin)
             endif
@@ -1736,16 +1742,19 @@ end subroutine m_micro_init
 !
             if (rnw(i,k) <= qc_min(1)) then
               ncpr(i,k) = zero
+              rnw(i,k)  = zero
             elseif (ncpr(i,k) <= nmin) then ! make sure NL > 0 if Q >0
               ncpr(i,k) = max(rnw(i,k) / (fourb3 * PI *RL_cub*997.0_kp), nmin)
             endif
             if (snw(i,k) <= qc_min(2)) then
               ncps(i,k) = zero
+              snw(i,k)  = zero
             elseif (ncps(i,k) <= nmin) then
               ncps(i,k) = max(snw(i,k) / (fourb3 * PI *RL_cub*500.0_kp), nmin)
             endif
             if (qgl(i,k) <= qc_min(2)) then
               ncgl(i,k) = zero
+              qgl(i,k)  = zero
             elseif (ncgl(i,k) <= nmin) then
               ncgl(i,k) = max(qgl(i,k) / (fourb3 * PI *RL_cub*500.0_kp), nmin)
             endif

--- a/physics/micro_mg2_0.F90
+++ b/physics/micro_mg2_0.F90
@@ -1792,7 +1792,7 @@ subroutine micro_mg_tend (                                       &
            nnucct(i,k)  = ratio * nnucct(i,k)
            npsacws(i,k) = ratio * npsacws(i,k)
            nsubc(i,k)   = ratio * nsubc(i,k)
-        end if
+        endif
 
         mnuccri(i,k) = zero
         nnuccri(i,k) = zero
@@ -1800,15 +1800,17 @@ subroutine micro_mg_tend (                                       &
         if (do_cldice) then
 
            ! freezing of rain to produce ice if mean rain size is smaller than Dcs
-           if (lamr(i,k) > qsmall .and. one/lamr(i,k) < Dcs) then
-              mnuccri(i,k) = mnuccr(i,k)
-              nnuccri(i,k) = nnuccr(i,k)
-              mnuccr(i,k)  = zero 
-              nnuccr(i,k)  = zero
-           end if
-        end if
+           if (lamr(i,k) > qsmall) then
+             if (one/lamr(i,k) < Dcs) then
+               mnuccri(i,k) = mnuccr(i,k)
+               nnuccri(i,k) = nnuccr(i,k)
+               mnuccr(i,k)  = zero 
+               nnuccr(i,k)  = zero
+             endif
+           endif
+        endif
 
-     end do
+     enddo
 
      do i=1,mgncol
 

--- a/physics/micro_mg3_0.F90
+++ b/physics/micro_mg3_0.F90
@@ -2448,7 +2448,7 @@ subroutine micro_mg_tend (                                       &
            nnucct(i,k)  = ratio * nnucct(i,k)
            npsacws(i,k) = ratio * npsacws(i,k)
            nsubc(i,k)   = ratio * nsubc(i,k)
-        end if
+        endif
 
         mnuccri(i,k) = zero
         nnuccri(i,k) = zero
@@ -2456,15 +2456,17 @@ subroutine micro_mg_tend (                                       &
         if (do_cldice) then
 
            ! freezing of rain to produce ice if mean rain size is smaller than Dcs
-           if (lamr(i,k) > qsmall .and. one/lamr(i,k) < Dcs) then
-              mnuccri(i,k) = mnuccr(i,k)
-              nnuccri(i,k) = nnuccr(i,k)
-              mnuccr(i,k)  = zero 
-              nnuccr(i,k)  = zero
-           end if
-        end if
+           if (lamr(i,k) > qsmall) then
+             if (one/lamr(i,k) < Dcs) then
+               mnuccri(i,k) = mnuccr(i,k)
+               nnuccri(i,k) = nnuccr(i,k)
+               mnuccr(i,k)  = zero 
+               nnuccr(i,k)  = zero
+             endif
+           endif
+        endif
 
-     end do
+     enddo
 
      do i=1,mgncol
 

--- a/physics/radsw_main.F90
+++ b/physics/radsw_main.F90
@@ -3011,10 +3011,10 @@
             endif
 
 !      ...  diffuse beam
-            if (abs(ze1r45) >= eps1) then
-              zden1 = zr4 / (ze1r45 * zrkg1)
+            if (ze1r45 >= f_zero) then
+              zden1   = zr4 / max(eps1, ze1r45*zrkg1)
             else
-              zden1 = f_zero
+              zden1   = zr4 / min(-eps1, ze1r45*zrkg1)
             endif
             zrefd(kp) = max(f_zero, min(f_one,                          &
      &                  zgam2*(zexp1 - zexm1)*zden1 ))
@@ -3246,10 +3246,10 @@
                 endif
 
 !      ...  diffuse beam
-                if (abs(ze1r45) >= eps1) then
-                  zden1 = zr4 / (ze1r45 * zrkg1)
+                if (ze1r45 >= f_zero) then
+                  zden1   = zr4 / max(eps1, ze1r45*zrkg1)
                 else
-                  zden1 = f_zero
+                  zden1   = zr4 / min(-eps1, ze1r45*zrkg1)
                 endif
                 zrefd(kp) = max(f_zero, min(f_one,                      &
      &                      zgam2*(zexp1 - zexm1)*zden1 ))
@@ -3808,10 +3808,10 @@
             endif
 
 !      ...  diffuse beam
-            if (abs(ze1r45) >= eps1) then
-              zden1 = zr4 / (ze1r45 * zrkg1)
+            if (ze1r45 >= f_zero) then
+              zden1   = zr4 / max(eps1, ze1r45*zrkg1)
             else
-              zden1 = f_zero
+              zden1   = zr4 / min(-eps1, ze1r45*zrkg1)
             endif
             zrefd(kp) = max(f_zero, min(f_one,                          &
      &                  zgam2*(zexp1 - zexm1)*zden1 ))
@@ -4030,10 +4030,10 @@
                 endif
 
 !      ...  diffuse beam
-                if (abs(ze1r45) >= eps1) then
-                  zden1 = zr4 / (ze1r45 * zrkg1)
+                if (ze1r45 >= f_zero) then
+                  zden1   = zr4 / max(eps1, ze1r45*zrkg1)
                 else
-                  zden1 = f_zero
+                  zden1   = zr4 / min(-eps1, ze1r45*zrkg1)
                 endif
                 zrefd(kp) = max(f_zero, min(f_one,                      &
      &                      zgam2*(zexp1 - zexm1)*zden1 ))

--- a/physics/radsw_main.F90
+++ b/physics/radsw_main.F90
@@ -2946,8 +2946,13 @@
           else                          ! for non-conservative scattering
             za1 = zgam1*zgam4 + zgam2*zgam3
             za2 = zgam1*zgam3 + zgam2*zgam4
-            zrk = sqrt ( (zgam1 - zgam2) * (zgam1 + zgam2) )
-            zrk2= 2.0 * zrk
+            zrk = (zgam1 - zgam2) * (zgam1 + zgam2)
+            if (zrk > eps1) then
+              zrk = sqrt(zrk)
+            else
+              zrk = f_zero
+            endif
+            zrk2= zrk + zrk
 
             zrp  = zrk * cosz
             zrp1 = f_one + zrp
@@ -2993,7 +2998,8 @@
             ze1r45 = zr4*zexp1 + zr5*zexm1
 
 !      ...  collimated beam
-            if (ze1r45>=-eps1 .and. ze1r45<=eps1) then
+!           if (ze1r45>=-eps1 .and. ze1r45<=eps1) then
+            if (abs(ze1r45) <= eps1) then
               zrefb(kp) = eps1
               ztrab(kp) = zexm2
             else
@@ -3005,7 +3011,11 @@
             endif
 
 !      ...  diffuse beam
-            zden1 = zr4 / (ze1r45 * zrkg1)
+            if (abs(ze1r45) >= eps1) then
+              zden1 = zr4 / (ze1r45 * zrkg1)
+            else
+              zden1 = f_zero
+            endif
             zrefd(kp) = max(f_zero, min(f_one,                          &
      &                  zgam2*(zexp1 - zexm1)*zden1 ))
             ztrad(kp) = max(f_zero, min(f_one, zrk2*zden1 ))
@@ -3171,8 +3181,13 @@
               else                          ! for non-conservative scattering
                 za1 = zgam1*zgam4 + zgam2*zgam3
                 za2 = zgam1*zgam3 + zgam2*zgam4
-                zrk = sqrt ( (zgam1 - zgam2) * (zgam1 + zgam2) )
-                zrk2= 2.0 * zrk
+                zrk = (zgam1 - zgam2) * (zgam1 + zgam2)
+                if (zrk > eps1) then
+                  zrk = sqrt(zrk)
+                else
+                  zrk = f_zero
+                endif
+                zrk2= zrk + zrk
 
                 zrp  = zrk * cosz
                 zrp1 = f_one + zrp
@@ -3218,7 +3233,8 @@
                 ze1r45 = zr4*zexp1 + zr5*zexm1
 
 !      ...  collimated beam
-                if ( ze1r45>=-eps1 .and. ze1r45<=eps1 ) then
+!               if ( ze1r45>=-eps1 .and. ze1r45<=eps1 ) then
+                if ( abs(ze1r45) <= eps1 ) then
                   zrefb(kp) = eps1
                   ztrab(kp) = zexm2
                 else
@@ -3230,7 +3246,11 @@
                 endif
 
 !      ...  diffuse beam
-                zden1 = zr4 / (ze1r45 * zrkg1)
+                if (abs(ze1r45) >= eps1) then
+                  zden1 = zr4 / (ze1r45 * zrkg1)
+                else
+                  zden1 = f_zero
+                endif
                 zrefd(kp) = max(f_zero, min(f_one,                      &
      &                      zgam2*(zexp1 - zexm1)*zden1 ))
                 ztrad(kp) = max(f_zero, min(f_one, zrk2*zden1 ))
@@ -3723,8 +3743,13 @@
           else                          ! for non-conservative scattering
             za1 = zgam1*zgam4 + zgam2*zgam3
             za2 = zgam1*zgam3 + zgam2*zgam4
-            zrk = sqrt ( (zgam1 - zgam2) * (zgam1 + zgam2) )
-            zrk2= 2.0 * zrk
+            zrk = (zgam1 - zgam2) * (zgam1 + zgam2)
+            if (zrk > eps1) then
+              zrk = sqrt(zrk)
+            else
+              zrk = f_zero
+            endif
+            zrk2= zrk + zrk
 
             zrp  = zrk * cosz
             zrp1 = f_one + zrp
@@ -3770,7 +3795,8 @@
             ze1r45 = zr4*zexp1 + zr5*zexm1
 
 !      ...  collimated beam
-            if (ze1r45>=-eps1 .and. ze1r45<=eps1) then
+!           if (ze1r45>=-eps1 .and. ze1r45<=eps1) then
+            if (abs(ze1r45) <= eps1) then
               zrefb(kp) = eps1
               ztrab(kp) = zexm2
             else
@@ -3782,7 +3808,11 @@
             endif
 
 !      ...  diffuse beam
-            zden1 = zr4 / (ze1r45 * zrkg1)
+            if (abs(ze1r45) >= eps1) then
+              zden1 = zr4 / (ze1r45 * zrkg1)
+            else
+              zden1 = f_zero
+            endif
             zrefd(kp) = max(f_zero, min(f_one,                          &
      &                  zgam2*(zexp1 - zexm1)*zden1 ))
             ztrad(kp) = max(f_zero, min(f_one, zrk2*zden1 ))
@@ -3935,8 +3965,13 @@
               else                          ! for non-conservative scattering
                 za1 = zgam1*zgam4 + zgam2*zgam3
                 za2 = zgam1*zgam3 + zgam2*zgam4
-                zrk = sqrt ( (zgam1 - zgam2) * (zgam1 + zgam2) )
-                zrk2= 2.0 * zrk
+                zrk = (zgam1 - zgam2) * (zgam1 + zgam2)
+                if (zrk > eps1) then
+                  zrk = sqrt(zrk)
+                else
+                  zrk = f_zero
+                endif
+                zrk2= zrk + zrk
 
                 zrp  = zrk * cosz
                 zrp1 = f_one + zrp
@@ -3982,7 +4017,8 @@
                 ze1r45 = zr4*zexp1 + zr5*zexm1
 
 !      ...  collimated beam
-                if ( ze1r45>=-eps1 .and. ze1r45<=eps1 ) then
+!               if ( ze1r45>=-eps1 .and. ze1r45<=eps1 ) then
+                if ( abs(ze1r45) <= eps1 ) then
                   zrefb(kp) = eps1
                   ztrab(kp) = zexm2
                 else
@@ -3994,7 +4030,11 @@
                 endif
 
 !      ...  diffuse beam
-                zden1 = zr4 / (ze1r45 * zrkg1)
+                if (abs(ze1r45) >= eps1) then
+                  zden1 = zr4 / (ze1r45 * zrkg1)
+                else
+                  zden1 = f_zero
+                endif
                 zrefd(kp) = max(f_zero, min(f_one,                      &
      &                      zgam2*(zexp1 - zexm1)*zden1 ))
                 ztrad(kp) = max(f_zero, min(f_one, zrk2*zden1 ))

--- a/physics/rascnv.meta
+++ b/physics/rascnv.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = rascnv
   type = scheme
-  dependencies = 
+  dependencies = funcphys.f90,machine.F
 
 ########################################################################
 [ccpp-arg-table]
@@ -422,7 +422,7 @@
   standard_name = convective_transportable_tracers
   long_name = array to contain cloud water and other convective trans. tracers
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension,tracer_dimension)
+  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_tracers_for_convective_transport)
   type = real
   kind = kind_phys
   intent = inout


### PR DESCRIPTION
This PR is to replace current RAS with an updated one that fixes a potential issue that can cause model crash.

Further changes:
- In MG2 and MG3 the single if loop below`if (lamr(i,k) > qsmall .and. one/lamr(i,k) < Dcs) then` is expanded to two nested ifs like
```
if (lamr(i,k) > qsmall) then
if (one/lamr(i,k) < Dcs) then
```
because on some computers the first if may lead to divide by zero leading to crash.
- In `radsw_main.F90`, the code is slightly rewritten to avoid sqrt of a negative number and potential divide by zero.
These issues were encountered during debugging. After fixing these two issues runs haven't crashed.
- reactivate 3d mass flux diagnostic tendencies in `GFS_DCNV_generic_post` (from @climbfuji).

Associated PRs:

https://github.com/NCAR/ccpp-physics/pull/585
https://github.com/NOAA-EMC/fv3atm/pull/252
https://github.com/ufs-community/ufs-weather-model/pull/448

For regression testing, see https://github.com/ufs-community/ufs-weather-model/pull/448