### PR TITLE
Add surface flux modification scheme for CCPP/SCM tutorial (For demonstration only -- DO NOT EVER MERGE)

### DIFF
--- a/physics/fix_sys_bias_sfc.F90
+++ b/physics/fix_sys_bias_sfc.F90
@@ -1,0 +1,58 @@
+!> \file fix_sys_bias_sfc.F90
+!!  Modifies surface fluxes used in GFS-based PBL schemes.
+
+!> This module contains the CCPP-compliant "fix_sys_bias_sfc" scheme.
+    module fix_sys_bias_sfc
+      
+      use machine , only : kind_phys
+      
+      contains
+
+      subroutine fix_sys_bias_sfc_init()
+      end subroutine fix_sys_bias_sfc_init
+      
+      subroutine fix_sys_bias_sfc_finalize()
+      end subroutine fix_sys_bias_sfc_finalize
+      
+!>  \brief  This subroutine contains all of the logic for the
+!! fix_sys_bias_sfc scheme used in the CCPP-SCM online tutorial.
+!!
+!> \section arg_table_fix_sys_bias_sfc_run Argument Table
+!! \htmlinclude fix_sys_bias_sfc_run.html
+!!
+      subroutine fix_sys_bias_sfc_run (im, con_cp, con_rd, con_hvap, p1, t1, hflx_r, qflx_r, errmsg, errflg)
+
+      implicit none
+
+!     arguments
+
+      integer, intent(in) :: im
+      
+      real(kind=kind_phys), intent(in) :: con_cp, con_rd, con_hvap
+      real(kind=kind_phys), intent(in) :: p1(:), t1(:)
+      real(kind=kind_phys), intent(inout) :: hflx_r(:), qflx_r(:)
+
+      character(len=*), intent(out) :: errmsg
+      integer,          intent(out) :: errflg
+
+!     locals
+
+      integer :: i
+      real(kind=kind_phys) :: rho
+      real(kind=kind_phys), parameter :: sens_mod_factor = 0 !W m-2
+      real(kind=kind_phys), parameter :: lat_mod_factor = 40 !W m-2
+
+!     Initialize CCPP error handling variables
+      errmsg = ''
+      errflg = 0
+
+      do i=1, im
+        rho = p1(i)/(con_rd*t1(i))
+        !convert mod_factor to kinematic units and add
+        hflx_r(i) = MAX(sens_mod_factor/(rho*con_cp) + hflx_r(i), 0.0)
+        qflx_r(i) = MAX(lat_mod_factor/(rho*con_hvap) + qflx_r(i), 0.0)
+      end do
+
+    end subroutine fix_sys_bias_sfc_run
+
+  end module fix_sys_bias_sfc

--- a/physics/fix_sys_bias_sfc.meta
+++ b/physics/fix_sys_bias_sfc.meta
@@ -1,0 +1,91 @@
+[ccpp-arg-table]
+  name = fix_sys_bias_sfc_run
+  type = scheme
+[im]
+  standard_name = horizontal_loop_extent
+  long_name = horizontal loop extent
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[con_cp]
+  standard_name = specific_heat_of_dry_air_at_constant_pressure
+  long_name = specific heat of dry air at constant pressure
+  units = J kg-1 K-1
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[con_rd]
+  standard_name = gas_constant_dry_air
+  long_name = ideal gas constant for dry air
+  units = J kg-1 K-1
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[con_hvap]
+  standard_name = latent_heat_of_vaporization_of_water_at_0C
+  long_name = latent heat of evaporation/sublimation
+  units = J kg-1
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[p1]
+  standard_name = air_pressure_at_lowest_model_layer
+  long_name = mean pressure at lowest model layer
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[t1]
+  standard_name = air_temperature_at_lowest_model_layer
+  long_name = mean temperature at lowest model layer
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[hflx_r]
+  standard_name = kinematic_surface_upward_sensible_heat_flux_reduced_by_surface_roughness
+  long_name = kinematic surface upward sensible heat flux reduced by surface roughness
+  units = K m s-1
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[qflx_r]
+  standard_name = kinematic_surface_upward_latent_heat_flux_reduced_by_surface_roughness
+  long_name = kinematic surface upward latent heat flux reduced by surface roughness
+  units = kg kg-1 m s-1
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+  optional = F
+[errflg]
+  standard_name = ccpp_error_flag
+  long_name = error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+  optional = F

--- a/physics/fix_sys_bias_sfc_time.F90
+++ b/physics/fix_sys_bias_sfc_time.F90
@@ -47,7 +47,9 @@
       errmsg = ''
       errflg = 0
       
-      if (solhr < 3 .or. solhr > 15) return
+      !Darwin, Australia has a local time offset of UTC + 9.5 hours;
+      !If solhr (forecast UTC time) is outside of the Darwin local 6AM - 6PM, don't apply modified surface fluxes
+      if (solhr > 8.5 .and. solhr < 20.5) return
       
       do i=1, im
         rho = p1(i)/(con_rd*t1(i))

--- a/physics/fix_sys_bias_sfc_time.F90
+++ b/physics/fix_sys_bias_sfc_time.F90
@@ -1,0 +1,61 @@
+!> \file fix_sys_bias_sfc_time.F90
+!!  Modifies surface fluxes used in GFS-based PBL schemes.
+
+!> This module contains the CCPP-compliant "fix_sys_bias_sfc_time" scheme.
+    module fix_sys_bias_sfc_time
+      
+      use machine , only : kind_phys
+      
+      contains
+
+      subroutine fix_sys_bias_sfc_time_init()
+      end subroutine fix_sys_bias_sfc_time_init
+      
+      subroutine fix_sys_bias_sfc_time_finalize()
+      end subroutine fix_sys_bias_sfc_time_finalize
+      
+!>  \brief  This subroutine contains all of the logic for the
+!! fix_sys_bias_sfc_time scheme used in the CCPP-SCM online tutorial.
+!!
+!> \section arg_table_fix_sys_bias_sfc_time_run Argument Table
+!! \htmlinclude fix_sys_bias_sfc_time_run.html
+!!
+      subroutine fix_sys_bias_sfc_time_run (im, con_cp, con_rd, con_hvap, p1, t1, solhr, hflx_r, qflx_r, errmsg, errflg)
+
+      implicit none
+
+!     arguments
+
+      integer, intent(in) :: im
+      
+      real(kind=kind_phys), intent(in) :: con_cp, con_rd, con_hvap
+      real(kind=kind_phys), intent(in) :: solhr
+      real(kind=kind_phys), intent(in) :: p1(:), t1(:)
+      real(kind=kind_phys), intent(inout) :: hflx_r(:), qflx_r(:)
+
+      character(len=*), intent(out) :: errmsg
+      integer,          intent(out) :: errflg
+
+!     locals
+
+      integer :: i
+      real(kind=kind_phys) :: rho
+      real(kind=kind_phys), parameter :: sens_mod_factor = 0 !W m-2
+      real(kind=kind_phys), parameter :: lat_mod_factor = 40 !W m-2
+
+!     Initialize CCPP error handling variables
+      errmsg = ''
+      errflg = 0
+      
+      if (solhr < 3 .or. solhr > 15) return
+      
+      do i=1, im
+        rho = p1(i)/(con_rd*t1(i))
+        !convert mod_factors to kinematic units and add to heat fluxes
+        hflx_r(i) = MAX(sens_mod_factor/(rho*con_cp) + hflx_r(i), 0.0)
+        qflx_r(i) = MAX(lat_mod_factor/(rho*con_hvap) + qflx_r(i), 0.0)
+      end do
+
+    end subroutine fix_sys_bias_sfc_time_run
+
+  end module fix_sys_bias_sfc_time

--- a/physics/fix_sys_bias_sfc_time.meta
+++ b/physics/fix_sys_bias_sfc_time.meta
@@ -1,0 +1,100 @@
+[ccpp-arg-table]
+  name = fix_sys_bias_sfc_time_run
+  type = scheme
+[im]
+  standard_name = horizontal_loop_extent
+  long_name = horizontal loop extent
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[con_cp]
+  standard_name = specific_heat_of_dry_air_at_constant_pressure
+  long_name = specific heat of dry air at constant pressure
+  units = J kg-1 K-1
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[con_rd]
+  standard_name = gas_constant_dry_air
+  long_name = ideal gas constant for dry air
+  units = J kg-1 K-1
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[con_hvap]
+  standard_name = latent_heat_of_vaporization_of_water_at_0C
+  long_name = latent heat of evaporation/sublimation
+  units = J kg-1
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[p1]
+  standard_name = air_pressure_at_lowest_model_layer
+  long_name = mean pressure at lowest model layer
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[t1]
+  standard_name = air_temperature_at_lowest_model_layer
+  long_name = mean temperature at lowest model layer
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[solhr]
+  standard_name = forecast_hour_of_the_day
+  long_name = time in hours after 00z at the current timestep
+  units = h
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[hflx_r]
+  standard_name = kinematic_surface_upward_sensible_heat_flux_reduced_by_surface_roughness
+  long_name = kinematic surface upward sensible heat flux reduced by surface roughness
+  units = K m s-1
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[qflx_r]
+  standard_name = kinematic_surface_upward_latent_heat_flux_reduced_by_surface_roughness
+  long_name = kinematic surface upward latent heat flux reduced by surface roughness
+  units = kg kg-1 m s-1
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+  optional = F
+[errflg]
+  standard_name = ccpp_error_flag
+  long_name = error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+  optional = F


### PR DESCRIPTION
Two "schemes" were added for the tutorial:
1. For the "add a scheme" section: fix_sys_bias_sfc.F90 that adds constant values to surface  sensible and latent heat fluxes (the variables used in MYNN PBL)
2. For the "add a variable" section: fix_sys_bias_sfc_time.F90 that modifies fix_sys_bias_sfc.F90 to only apply surface flux correction during a specific time of day