### PR TITLE
ugwpv1_gsldrag bug fixes, and GFS_typdefs updates associated with diag flags for ugwpv1_gsldrag.F90 and GFS_DCNV_generic.F90

### DIFF
--- a/physics/GFS_DCNV_generic.F90
+++ b/physics/GFS_DCNV_generic.F90
@@ -169,16 +169,16 @@
               dt3dt(i,k) = dt3dt(i,k) + (gt0(i,k)-save_t(i,k)) * frain
               du3dt(i,k) = du3dt(i,k) + (gu0(i,k)-save_u(i,k)) * frain
               dv3dt(i,k) = dv3dt(i,k) + (gv0(i,k)-save_v(i,k)) * frain
-              ! convective mass fluxes
-              upd_mf(i,k)  = upd_mf(i,k)  + ud_mf(i,k) * (con_g*frain)
-              dwn_mf(i,k)  = dwn_mf(i,k)  + dd_mf(i,k) * (con_g*frain)
-              det_mf(i,k)  = det_mf(i,k)  + dt_mf(i,k) * (con_g*frain)
             enddo
           enddo
           if(qdiag3d) then
              do k=1,levs
                 do i=1,im
                    dq3dt(i,k) = dq3dt(i,k) + (gq0_water_vapor(i,k)-save_qv(i,k)) * frain
+                   ! convective mass fluxes
+                   upd_mf(i,k)  = upd_mf(i,k)  + ud_mf(i,k) * (con_g*frain)
+                   dwn_mf(i,k)  = dwn_mf(i,k)  + dd_mf(i,k) * (con_g*frain)
+                   det_mf(i,k)  = det_mf(i,k)  + dt_mf(i,k) * (con_g*frain)
                 enddo
              enddo
           endif

--- a/physics/ugwpv1_gsldrag.F90
+++ b/physics/ugwpv1_gsldrag.F90
@@ -496,16 +496,21 @@ contains
 !===============================================================
 ! ORO-diag
 
-      dudt_ogw(:,:)  = 0. ; dvdt_ogw(:,:)=0. ; dudt_obl(:,:)=0. ; dvdt_obl(:,:)=0.
-      dudt_oss(:,:)  = 0. ; dvdt_oss(:,:)=0. ; dudt_ofd(:,:)=0. ; dvdt_ofd(:,:)=0.
+       if (do_ugwp_v1 .or. gwd_opt==33 .or. gwd_opt==22) then
+         dudt_ogw(:,:)= 0.; dvdt_ogw(:,:)=0.; dudt_obl(:,:)=0.; dvdt_obl(:,:)=0.
+         dudt_oss(:,:)= 0.; dvdt_oss(:,:)=0.; dudt_ofd(:,:)=0.; dvdt_ofd(:,:)=0.
+         du_ogwcol(:)=0. ; dv_ogwcol(:)=0. ; du_oblcol(:)=0. ; dv_oblcol(:)=0.
+         du_osscol(:)=0. ; dv_osscol(:)=0. ;du_ofdcol(:)=0.  ; dv_ofdcol(:)=0.
+       else
+         dudt_ogw(:,:)  = 0.
+       end if
 
-      dusfcg (:)  = 0.  ;  dvsfcg(:) =0.
-
-      du_ogwcol(:)=0. ; dv_ogwcol(:)=0. ; du_oblcol(:)=0. ; dv_oblcol(:)=0.
-      du_osscol(:)=0. ; dv_osscol(:)=0. ;du_ofdcol(:)=0.  ; dv_ofdcol(:)=0.
+       dusfcg (:)  = 0.  ;  dvsfcg(:) =0.
 
 !
-       dudt_ngw(:,:)=0. ; dvdt_ngw(:,:)=0. ; dtdt_ngw(:,:)=0. ; kdis_ngw(:,:)=0.
+       if (do_ugwp_v1) then
+         dudt_ngw(:,:)=0.; dvdt_ngw(:,:)=0.; dtdt_ngw(:,:)=0.; kdis_ngw(:,:)=0.
+       end if
 
 ! ngw+ogw - diag
 
@@ -703,16 +708,23 @@ contains
 !
 ! get total sso-OGW + NGW
 !
-     dudt_gw =  Pdudt +dudt_ngw
-     dvdt_gw =  Pdvdt +dvdt_ngw
-     dtdt_gw =  Pdtdt +dtdt_ngw
-     kdis_gw =  Pkdis +kdis_ngw
+     if (do_ugwp_v1) then
+        dudt_gw =  Pdudt + dudt_ngw
+        dvdt_gw =  Pdvdt + dvdt_ngw
+        dtdt_gw =  Pdtdt + dtdt_ngw
+        kdis_gw =  Pkdis + kdis_ngw
+     else
+        dudt_gw =  Pdudt
+        dvdt_gw =  Pdvdt
+        dtdt_gw =  Pdtdt
+        kdis_gw =  Pkdis
+     end if
 !
 ! accumulate "tendencies" as in the GFS-ipd (pbl + ugwp + zero-RF)
 !
-     dudt  = dudt  + dudt_ngw
-     dvdt  = dvdt  + dvdt_ngw
-     dtdt  = dtdt  + dtdt_ngw
+     dudt  = dudt  + dudt_gw
+     dvdt  = dvdt  + dvdt_gw
+     dtdt  = dtdt  + dtdt_gw
 
     end subroutine ugwpv1_gsldrag_run
 !! @}


### PR DESCRIPTION
1)  Fixes a bug in the final accumulation of tendencies at the end of subroutine ugwpv1_gsldrag_run in module ugwpv1_gsldrag.

2)  Fixes inconsistencies between allocation of diagnostic variables in GFS_typedefs.F90 and ugwpv1_gsldrag.F90 as determined by logical flags.

3)  Fixes inconsistencies between allocation of diagnostic variables in GFS_typedefs.F90 and GFS_DCNV_generic.F90 as determined by logical flags.