### PR TITLE
changes to GFS_phys_time_vary.scm.F90 (SCM ONLY) to match FV3-based counterpart

### DIFF
--- a/physics/GFS_phys_time_vary.scm.meta
+++ b/physics/GFS_phys_time_vary.scm.meta
@@ -1462,6 +1462,14 @@
   kind = kind_phys
   intent = inout
   optional = F
+[nthrds]
+  standard_name = omp_threads
+  long_name = number of OpenMP threads available for physics schemes
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP


### PR DESCRIPTION
- update GFS_phys_time_vary.scm.F90 to match FV3 changes

This is an addendum to the GFS_phys_time_vary.fv3.F90 changes in #623. 

Required for compilation with https://github.com/NCAR/ccpp-scm/pull/240. FV3 regression tests should not be required since this file is never used in FV3.