### PR TITLE
Ensure consistency between model namelist and CCPP suite definition file

### DIFF
--- a/physics/GFS_rrtmg_setup.F90
+++ b/physics/GFS_rrtmg_setup.F90
@@ -212,7 +212,7 @@ module GFS_rrtmg_setup
       if (is_initialized) return
       
       if (do_RRTMGP) then
-        write(errmsg,'(*(a))') "Logic error: do_RRTMGP must be set .false."
+        write(errmsg,'(*(a))') "Logic error: do_RRTMGP must be set to .false."
         errflg = 1
         return
       end if

--- a/physics/GFS_rrtmg_setup.F90
+++ b/physics/GFS_rrtmg_setup.F90
@@ -49,7 +49,7 @@ module GFS_rrtmg_setup
           icliq_sw, crick_proof, ccnorm,                      &
           imp_physics,                                        &
           norad_precip, idate, iflip,                         &
-          im, faerlw, faersw, aerodp,                         & ! for consistency checks
+          do_RRTMGP, im, faerlw, faersw, aerodp,              & ! for consistency checks
           me, errmsg, errflg)
 ! =================   subprogram documentation block   ================ !
 !                                                                       !
@@ -188,6 +188,8 @@ module GFS_rrtmg_setup
       integer, intent(in) :: idate(:)
       integer, intent(in) :: iflip
       ! For consistency checks
+      
+      logical, intent(in)         :: do_RRTMGP
       integer, intent(in)         :: im
       real(kind_phys), intent(in) :: faerlw(:,:,:,:)
       real(kind_phys), intent(in) :: faersw(:,:,:,:)
@@ -208,6 +210,12 @@ module GFS_rrtmg_setup
       errflg = 0
 
       if (is_initialized) return
+      
+      if (do_RRTMGP) then
+        write(errmsg,'(*(a))') "Logic error: do_RRTMGP should be set false"
+        errflg = 1
+        return
+      end if
 
       ! Consistency checks for dimensions of arrays, this is required
       ! to detect differences in FV3's parameters that are used to

--- a/physics/GFS_rrtmg_setup.F90
+++ b/physics/GFS_rrtmg_setup.F90
@@ -212,7 +212,7 @@ module GFS_rrtmg_setup
       if (is_initialized) return
       
       if (do_RRTMGP) then
-        write(errmsg,'(*(a))') "Logic error: do_RRTMGP should be set false"
+        write(errmsg,'(*(a))') "Logic error: do_RRTMGP must be set .false."
         errflg = 1
         return
       end if

--- a/physics/GFS_rrtmg_setup.meta
+++ b/physics/GFS_rrtmg_setup.meta
@@ -185,6 +185,14 @@
   type = integer
   intent = in
   optional = F
+[do_RRTMGP]
+  standard_name = flag_for_rrtmgp_radiation_scheme
+  long_name = flag for RRTMGP scheme
+  units = flag
+  dimensions =  ()
+  type = logical
+  intent = in
+  optional = F
 [im]
   standard_name = horizontal_dimension
   long_name = horizontal dimension

--- a/physics/GFS_rrtmgp_setup.F90
+++ b/physics/GFS_rrtmgp_setup.F90
@@ -40,13 +40,14 @@ contains
 !! \section arg_table_GFS_rrtmgp_setup_init
 !! \htmlinclude GFS_rrtmgp_setup_init.html
 !!
-  subroutine GFS_rrtmgp_setup_init(imp_physics, imp_physics_fer_hires, imp_physics_gfdl,    &
-       imp_physics_thompson, imp_physics_wsm6, imp_physics_zhao_carr,                       &
+  subroutine GFS_rrtmgp_setup_init(do_RRTMGP, imp_physics, imp_physics_fer_hires,           &
+       imp_physics_gfdl, imp_physics_thompson, imp_physics_wsm6, imp_physics_zhao_carr,     &
        imp_physics_zhao_carr_pdf, imp_physics_mg,  si, levr, ictm, isol, ico2, iaer, ialb,  &
        iems, ntcw, num_p3d,  ntoz, iovr, isubc_sw, isubc_lw, icliq_sw, crick_proof, ccnorm, &
        norad_precip, idate, iflip, me, errmsg, errflg)
 
     ! Inputs
+    logical, intent(in) :: do_RRTMGP
     integer, intent(in) :: &
          imp_physics,               & ! Flag for MP scheme
          imp_physics_fer_hires,     & ! Flag for fer-hires scheme
@@ -75,7 +76,14 @@ contains
     errflg = 0
     
     if (is_initialized) return
-    
+
+    ! Consistency checks
+    if (.not. do_RRTMGP) then
+      write(errmsg,'(*(a))') "Logic error: do_RRTMGP should be set true"
+      errflg = 1
+      return
+    end if
+
     ! Set radiation parameters
     isolar  = isol                     ! solar constant control flag
     ictmflg = ictm                     ! data ic time/date control flag

--- a/physics/GFS_rrtmgp_setup.F90
+++ b/physics/GFS_rrtmgp_setup.F90
@@ -79,7 +79,7 @@ contains
 
     ! Consistency checks
     if (.not. do_RRTMGP) then
-      write(errmsg,'(*(a))') "Logic error: do_RRTMGP must be set .true."
+      write(errmsg,'(*(a))') "Logic error: do_RRTMGP must be set to .true."
       errflg = 1
       return
     end if

--- a/physics/GFS_rrtmgp_setup.F90
+++ b/physics/GFS_rrtmgp_setup.F90
@@ -79,7 +79,7 @@ contains
 
     ! Consistency checks
     if (.not. do_RRTMGP) then
-      write(errmsg,'(*(a))') "Logic error: do_RRTMGP should be set true"
+      write(errmsg,'(*(a))') "Logic error: do_RRTMGP must be set .true."
       errflg = 1
       return
     end if

--- a/physics/GFS_rrtmgp_setup.meta
+++ b/physics/GFS_rrtmgp_setup.meta
@@ -8,6 +8,14 @@
 [ccpp-arg-table]
   name = GFS_rrtmgp_setup_init
   type = scheme
+[do_RRTMGP]
+  standard_name = flag_for_rrtmgp_radiation_scheme
+  long_name = flag for RRTMGP scheme
+  units = flag
+  dimensions =  ()
+  type = logical
+  intent = in
+  optional = F
 [imp_physics]
   standard_name = flag_for_microphysics_scheme
   long_name = choice of microphysics scheme

--- a/physics/cires_ugwp.F90
+++ b/physics/cires_ugwp.F90
@@ -40,7 +40,7 @@ contains
 !
     subroutine cires_ugwp_init (me, master, nlunit, input_nml_file, logunit, &
                 fn_nml2, lonr, latr, levs, ak, bk, dtp, cdmbgwd, cgwf,       &
-                pa_rf_in, tau_rf_in, con_p0, do_ugwp, errmsg, errflg)
+                pa_rf_in, tau_rf_in, con_p0, gwd_opt,do_ugwp, errmsg, errflg)
 
 !----  initialization of cires_ugwp
     implicit none
@@ -58,6 +58,7 @@ contains
     real(kind=kind_phys), intent (in) :: cdmbgwd(:), cgwf(:) ! "scaling" controls for "old" GFS-GW schemes
     real(kind=kind_phys), intent (in) :: pa_rf_in, tau_rf_in
     real(kind=kind_phys), intent (in) :: con_p0
+    integer,              intent(in)  :: gwd_opt
     logical,              intent (in) :: do_ugwp
 
     character(len=*), intent (in) :: fn_nml2
@@ -76,6 +77,14 @@ contains
     errflg = 0
 
     if (is_initialized) return
+    
+    ! Consistency checks
+    if (gwd_opt/=1) then
+      write(errmsg,'(*(a))') "Logic error: namelist choice of gravity wave &
+      & drag is different from cires_ugwp scheme"
+      errflg = 1
+      return
+    end if  
 
     if (do_ugwp .or. cdmbgwd(3) > 0.0) then
       call cires_ugwpv0_mod_init (me, master, nlunit, input_nml_file, logunit, &

--- a/physics/cires_ugwp.meta
+++ b/physics/cires_ugwp.meta
@@ -155,6 +155,14 @@
   kind = kind_phys
   intent = in
   optional = F
+[gwd_opt]
+  standard_name = gwd_opt
+  long_name = flag to choose gwd scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
 [do_ugwp]
   standard_name = do_ugwp
   long_name = flag to activate CIRES UGWP

--- a/physics/cu_gf_driver.F90
+++ b/physics/cu_gf_driver.F90
@@ -23,10 +23,13 @@ contains
 !! \section arg_table_cu_gf_driver_init Argument Table
 !! \htmlinclude cu_gf_driver_init.html
 !!
-      subroutine cu_gf_driver_init(mpirank, mpiroot, errmsg, errflg)
+      subroutine cu_gf_driver_init(imfshalcnv, imfshalcnv_gf, imfdeepcnv, &
+                          imfdeepcnv_gf,mpirank, mpiroot, errmsg, errflg)
 
          implicit none
-
+         
+         integer,                   intent(in) :: imfshalcnv, imfshalcnv_gf
+         integer,                   intent(in) :: imfdeepcnv, imfdeepcnv_gf       
          integer,                   intent(in)    :: mpirank
          integer,                   intent(in)    :: mpiroot
          character(len=*),          intent(  out) :: errmsg
@@ -44,6 +47,20 @@ contains
          end if
          ! *DH temporary
 
+         ! Consistency checks
+         if (imfshalcnv/=imfshalcnv_gf) then
+           write(errmsg,'(*(a))') 'Logic error: namelist choice of',       &
+        &    ' shallow convection is different from Grell-Freitas scheme'
+           errflg = 1
+           return
+         end if
+
+         if (imfdeepcnv/=imfdeepcnv_gf) then
+           write(errmsg,'(*(a))') 'Logic error: namelist choice of',       &
+        &    ' deep convection is different from Grell-Freitas scheme'
+           errflg = 1
+           return
+         end if
       end subroutine cu_gf_driver_init
 
       subroutine cu_gf_driver_finalize()

--- a/physics/cu_gf_driver.F90
+++ b/physics/cu_gf_driver.F90
@@ -48,19 +48,14 @@ contains
          ! *DH temporary
 
          ! Consistency checks
-         if (imfshalcnv/=imfshalcnv_gf) then
+         if (.not. (imfshalcnv == imfshalcnv_gf .or.                       &
+        &        imfdeepcnv == imfdeepcnv_gf)) then
            write(errmsg,'(*(a))') 'Logic error: namelist choice of',       &
-        &    ' shallow convection is different from Grell-Freitas scheme'
+        &    ' convection is different from Grell-Freitas scheme'
            errflg = 1
            return
          end if
 
-         if (imfdeepcnv/=imfdeepcnv_gf) then
-           write(errmsg,'(*(a))') 'Logic error: namelist choice of',       &
-        &    ' deep convection is different from Grell-Freitas scheme'
-           errflg = 1
-           return
-         end if
       end subroutine cu_gf_driver_init
 
       subroutine cu_gf_driver_finalize()

--- a/physics/cu_gf_driver.meta
+++ b/physics/cu_gf_driver.meta
@@ -7,6 +7,38 @@
 [ccpp-arg-table]
   name = cu_gf_driver_init
   type = scheme
+[imfshalcnv]
+  standard_name = flag_for_mass_flux_shallow_convection_scheme
+  long_name = flag for mass-flux shallow convection scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[imfshalcnv_gf]
+  standard_name = flag_for_gf_shallow_convection_scheme
+  long_name = flag for Grell-Freitas shallow convection scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[imfdeepcnv]
+  standard_name = flag_for_mass_flux_deep_convection_scheme
+  long_name = flag for mass-flux deep convection scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[imfdeepcnv_gf]
+  standard_name = flag_for_gf_deep_convection_scheme
+  long_name = flag for Grell-Freitas deep convection scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
 [mpirank]
   standard_name = mpi_rank
   long_name = current MPI-rank

--- a/physics/cu_ntiedtke.F90
+++ b/physics/cu_ntiedtke.F90
@@ -106,10 +106,13 @@ contains
 !! \section arg_table_cu_ntiedtke_init Argument Table
 !! \htmlinclude cu_ntiedtke_init.html
 !!
-      subroutine cu_ntiedtke_init(mpirank, mpiroot, errmsg, errflg)
+      subroutine cu_ntiedtke_init(imfshalcnv, imfshalcnv_ntiedtke, imfdeepcnv,  &
+                          imfdeepcnv_ntiedtke,mpirank, mpiroot, errmsg, errflg)
 
          implicit none
 
+         integer,                   intent(in) :: imfshalcnv, imfshalcnv_ntiedtke
+         integer,                   intent(in) :: imfdeepcnv, imfdeepcnv_ntiedtke           
          integer,                   intent(in)    :: mpirank
          integer,                   intent(in)    :: mpiroot
          character(len=*),          intent(  out) :: errmsg
@@ -127,6 +130,21 @@ contains
          end if
          ! *DH temporary
 
+         ! Consistency checks
+         if (imfshalcnv/=imfshalcnv_ntiedtke) then
+           write(errmsg,'(*(a))') 'Logic error: namelist choice of',       &
+        &    ' shallow convection is different from new Tiedtke scheme'
+           errflg = 1
+           return
+         end if
+
+         if (imfdeepcnv/=imfdeepcnv_ntiedtke) then
+           write(errmsg,'(*(a))') 'Logic error: namelist choice of',       &
+        &    ' deep convection is different from new Tiedtke scheme'
+           errflg = 1
+           return
+         end if
+         
       end subroutine cu_ntiedtke_init
 
       subroutine cu_ntiedtke_finalize()

--- a/physics/cu_ntiedtke.meta
+++ b/physics/cu_ntiedtke.meta
@@ -7,6 +7,38 @@
 [ccpp-arg-table]
   name = cu_ntiedtke_init
   type = scheme
+[imfshalcnv]
+  standard_name = flag_for_mass_flux_shallow_convection_scheme
+  long_name = flag for mass-flux shallow convection scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[imfshalcnv_ntiedtke]
+  standard_name = flag_for_ntiedtke_shallow_convection_scheme
+  long_name = flag for new Tiedtke shallow convection scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[imfdeepcnv]
+  standard_name = flag_for_mass_flux_deep_convection_scheme
+  long_name = flag for mass-flux deep convection scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[imfdeepcnv_ntiedtke]
+  standard_name = flag_for_ntiedtke_deep_convection_scheme
+  long_name = flag for new Tiedtke deep convection scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
 [mpirank]
   standard_name = mpi_rank
   long_name = current MPI-rank

--- a/physics/drag_suite.F90
+++ b/physics/drag_suite.F90
@@ -7,7 +7,24 @@
 
       contains
 
-      subroutine drag_suite_init()
+      subroutine drag_suite_init(gwd_opt, errmsg, errflg)
+
+      integer,          intent(in)  :: gwd_opt
+      character(len=*), intent(out) :: errmsg
+      integer,          intent(out) :: errflg
+
+
+      ! Initialize CCPP error handling variables
+      errmsg = ''
+      errflg = 0
+
+      ! Consistency checks
+      if (gwd_opt/=3 .or. gwd_opt/=33) then
+        write(errmsg,'(*(a))') "Logic error: namelist choice of gravity wave &
+          & drag is different from drag_suite scheme"
+        errflg = 1
+        return
+      end if        
       end subroutine drag_suite_init
 
 ! \defgroup GFS_ogwd GFS Orographic Gravity Wave Drag

--- a/physics/drag_suite.F90
+++ b/physics/drag_suite.F90
@@ -19,7 +19,7 @@
       errflg = 0
 
       ! Consistency checks
-      if (gwd_opt/=3 .or. gwd_opt/=33) then
+      if (gwd_opt/=3 .and. gwd_opt/=33) then
         write(errmsg,'(*(a))') "Logic error: namelist choice of gravity wave &
           & drag is different from drag_suite scheme"
         errflg = 1

--- a/physics/drag_suite.meta
+++ b/physics/drag_suite.meta
@@ -5,6 +5,36 @@
 
 ########################################################################
 [ccpp-arg-table]
+  name = unified_ugwp_init
+  type = scheme
+[gwd_opt]
+  standard_name = gwd_opt
+  long_name = flag to choose gwd scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+  optional = F
+[errflg]
+  standard_name = ccpp_error_flag
+  long_name = error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+  optional = F
+
+########################################################################
+[ccpp-arg-table]
   name = drag_suite_run
   type = scheme
 [im]

--- a/physics/gcm_shoc.F90
+++ b/physics/gcm_shoc.F90
@@ -14,7 +14,22 @@ module shoc
 
 contains
 
-subroutine shoc_init ()
+subroutine shoc_init (do_shoc, errmsg, errflg)
+  implicit none
+  logical, intent(in) :: do_shoc
+  character(len=*), intent(out) :: errmsg
+  integer,          intent(out) :: errflg
+
+! Initialize CCPP error handling variables
+  errmsg = ''
+  errflg = 0
+
+! Consistency checks
+  if (.not. do_shoc) then
+    errflg = 1
+    write(errmsg,'(*(a))') 'Logic error: do_shoc == .false.'
+    return
+  end if
 end subroutine shoc_init
 
 subroutine shoc_finalize ()

--- a/physics/gcm_shoc.meta
+++ b/physics/gcm_shoc.meta
@@ -5,6 +5,36 @@
 
 ########################################################################
 [ccpp-arg-table]
+  name = shoc_init
+  type = scheme
+[do_shoc]
+  standard_name = flag_for_shoc
+  long_name = flag for SHOC
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+  optional = F
+[errflg]
+  standard_name = ccpp_error_flag
+  long_name = error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+  optional = F
+
+########################################################################
+[ccpp-arg-table]
   name = shoc_run
   type = scheme
 [nx]

--- a/physics/gscond.f
+++ b/physics/gscond.f
@@ -37,7 +37,8 @@
          if (is_initialized) return
 
          ! Consistency checks
-         if (imp_physics/=imp_physics_zhao_carr) then
+         if (imp_physics/=imp_physics_zhao_carr .and.                   &
+     &       imp_physics/=imp_physics_zhao_carr_pdf) then
             write(errmsg,'(*(a))') "Logic error: namelist choice of     &
      &                  microphysics is different from Zhao-Carr MP"
             errflg = 1

--- a/physics/gscond.f
+++ b/physics/gscond.f
@@ -19,13 +19,16 @@
 !> \section arg_table_zhaocarr_gscond_init  Argument Table
 !!
        subroutine zhaocarr_gscond_init (imp_physics,                    &
-     &                                 imp_physics_zhao_carr,           &
+     &                                  imp_physics_zhao_carr,          &
+     &                                  imp_physics_zhao_carr_pdf,      &
      &                                  errmsg, errflg)
         implicit none
 
         ! Interface variables
          integer,              intent(in   ) :: imp_physics
-         integer,              intent(in   ) :: imp_physics_zhao_carr
+         integer,              intent(in   ) :: imp_physics_zhao_carr,  &
+     &                                      imp_physics_zhao_carr_pdf
+
          ! CCPP error handling
          character(len=*),          intent(  out) :: errmsg
          integer,                   intent(  out) :: errflg

--- a/physics/gscond.meta
+++ b/physics/gscond.meta
@@ -23,6 +23,14 @@
   type = integer
   intent = in
   optional = F
+[imp_physics_zhao_carr_pdf]
+  standard_name = flag_for_zhao_carr_pdf_microphysics_scheme
+  long_name = choice of Zhao-Carr microphysics scheme with PDF clouds
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP

--- a/physics/h2ophys.f
+++ b/physics/h2ophys.f
@@ -12,7 +12,22 @@
 
       contains
 
-      subroutine h2ophys_init()
+      subroutine h2ophys_init(h2o_phys, errmsg, errflg)
+
+      implicit none
+      logical,          intent(in)  :: h2o_phys
+      character(len=*), intent(out) :: errmsg
+      integer,          intent(out) :: errflg
+
+      ! Initialize CCPP error handling variables
+      errmsg = ''
+      errflg = 0
+
+      if (.not.h2ophys) then
+        write (errmsg,'(*(a))') 'Logic error: h2ophys == .false.'
+        errflg = 1
+        return
+      endif      
       end subroutine h2ophys_init
 
 !>\defgroup GFS_h2ophys GFS Water Vapor Photochemical Production and Loss Module

--- a/physics/h2ophys.f
+++ b/physics/h2ophys.f
@@ -23,8 +23,8 @@
       errmsg = ''
       errflg = 0
 
-      if (.not.h2ophys) then
-        write (errmsg,'(*(a))') 'Logic error: h2ophys == .false.'
+      if (.not.h2o_phys) then
+        write (errmsg,'(*(a))') 'Logic error: h2o_phys == .false.'
         errflg = 1
         return
       endif      

--- a/physics/h2ophys.meta
+++ b/physics/h2ophys.meta
@@ -5,6 +5,36 @@
 
 ########################################################################
 [ccpp-arg-table]
+  name = h2ophys_init
+  type = scheme
+[h2o_phys]
+  standard_name = flag_for_stratospheric_water_vapor_physics
+  long_name = flag for stratospheric water vapor physics
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+  optional = F
+[errflg]
+  standard_name = ccpp_error_flag
+  long_name = error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+  optional = F
+
+########################################################################
+[ccpp-arg-table]
   name = h2ophys_run
   type = scheme
 [im]

--- a/physics/module_MYJPBL_wrapper.F90
+++ b/physics/module_MYJPBL_wrapper.F90
@@ -8,7 +8,22 @@
 
       contains
 
-      subroutine myjpbl_wrapper_init ()
+      subroutine myjpbl_wrapper_init (do_myjpbl,errmsg,errflg)
+      
+      logical,              intent(in)  :: do_myjpbl
+      character(len=*),     intent(out) :: errmsg
+      integer,              intent(out) :: errflg
+
+     ! Initialize CCPP error handling variables
+      errmsg = ''
+      errflg = 0
+
+    ! Consistency checks
+      if (.not. do_myjpbl) then
+        write(errmsg,fmt='(*(a))') 'Logic error: do_myjpbl=.false.'        
+        errflg = 1
+        return
+      end if
       end subroutine myjpbl_wrapper_init
 
       subroutine myjpbl_wrapper_finalize ()

--- a/physics/module_MYJPBL_wrapper.meta
+++ b/physics/module_MYJPBL_wrapper.meta
@@ -5,6 +5,36 @@
 
 ########################################################################
 [ccpp-arg-table]
+  name = myjpbl_wrapper_init
+  type = scheme
+[do_myjpbl]
+  standard_name = do_myjpbl
+  long_name = flag to activate MYJ PBL scheme
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+  optional = F
+[errflg]
+  standard_name = ccpp_error_flag
+  long_name = error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+  optional = F
+  
+########################################################################
+[ccpp-arg-table]
   name = myjpbl_wrapper_run
   type = scheme
 [restart]

--- a/physics/module_MYJSFC_wrapper.F90
+++ b/physics/module_MYJSFC_wrapper.F90
@@ -24,6 +24,7 @@
           write(errmsg,fmt='(*(a))') 'Logic error: do_myjsfc = .false.'
           errflg = 1
           return
+        end if
       end subroutine myjsfc_wrapper_init
 
       subroutine myjsfc_wrapper_finalize ()

--- a/physics/module_MYJSFC_wrapper.F90
+++ b/physics/module_MYJSFC_wrapper.F90
@@ -8,7 +8,22 @@
 
       contains
 
-      subroutine myjsfc_wrapper_init ()
+      subroutine myjsfc_wrapper_init (do_myjsfc,    &
+      & errmsg,errflg)
+
+        logical,          intent(in)  :: do_myjsfc
+        character(len=*), intent(out) :: errmsg
+        integer,          intent(out) :: errflg
+
+      ! Initialize CCPP error handling variables
+        errmsg = ''
+        errflg = 0
+
+      ! Consistency checks
+        if (.not. do_myjsfc) then
+          write(errmsg,fmt='(*(a))') 'Logic error: do_myjsfc = .false.'
+          errflg = 1
+          return
       end subroutine myjsfc_wrapper_init
 
       subroutine myjsfc_wrapper_finalize ()

--- a/physics/module_MYJSFC_wrapper.meta
+++ b/physics/module_MYJSFC_wrapper.meta
@@ -5,6 +5,36 @@
 
 ########################################################################
 [ccpp-arg-table]
+  name = myjsfc_wrapper_init
+  type = scheme
+[do_myjsfc]
+  standard_name = do_myjsfc
+  long_name = flag to activate MYJ surface layer scheme
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+  optional = F
+[errflg]
+  standard_name = ccpp_error_flag
+  long_name = error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+  optional = F
+  
+########################################################################
+[ccpp-arg-table]
   name = myjsfc_wrapper_run
   type = scheme
 [restart]

--- a/physics/module_MYNNPBL_wrapper.F90
+++ b/physics/module_MYNNPBL_wrapper.F90
@@ -13,9 +13,10 @@
 !> \section arg_table_mynnedmf_wrapper_init Argument Table
 !! \htmlinclude mynnedmf_wrapper_init.html
 !!
-      subroutine mynnedmf_wrapper_init (lheatstrg, errmsg, errflg)
+      subroutine mynnedmf_wrapper_init (do_mynnedmf, lheatstrg, errmsg, errflg)
         implicit none
-
+        
+        logical,          intent(in)  :: do_mynnedmf
         logical,          intent(in)  :: lheatstrg
         character(len=*), intent(out) :: errmsg
         integer,          intent(out) :: errflg
@@ -23,6 +24,13 @@
         ! Initialize CCPP error handling variables
         errmsg = ''
         errflg = 0
+
+        ! Consistency checks
+        if (.not. do_mynnedmf) then
+          errmsg = 'Logic error: do_mynnedmf = .false.'
+          errflg = 1
+            return
+         end if
 
         if (lheatstrg) then
           errmsg = 'Logic error: lheatstrg not implemented for MYNN PBL'

--- a/physics/module_MYNNPBL_wrapper.meta
+++ b/physics/module_MYNNPBL_wrapper.meta
@@ -7,6 +7,14 @@
 [ccpp-arg-table]
   name = mynnedmf_wrapper_init
   type = scheme
+[do_mynnedmf]
+  standard_name = do_mynnedmf
+  long_name = flag to activate MYNN-EDMF
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
 [lheatstrg]
   standard_name = flag_for_canopy_heat_storage
   long_name = flag for canopy heat storage parameterization

--- a/physics/module_MYNNSFC_wrapper.F90
+++ b/physics/module_MYNNSFC_wrapper.F90
@@ -15,14 +15,23 @@
 !! \htmlinclude mynnsfc_wrapper_init.html
 
 !!
-      subroutine mynnsfc_wrapper_init(errmsg, errflg)
+      subroutine mynnsfc_wrapper_init(do_mynnsfclay, &
+       &                             errmsg, errflg)
 
+         logical,          intent(in)  :: do_mynnsfclay
          character(len=*), intent(out) :: errmsg
          integer, intent(out) :: errflg
 
          ! Initialize CCPP error handling variables
          errmsg = ''
          errflg = 0
+
+        ! Consistency checks
+        if (.not. do_mynnsfclay) then
+          write(errmsg,fmt='(*(a))') 'Logic error: do_mynnsfclay = .false.'
+          errflg = 1
+          return
+        end if 
 
          ! initialize tables for psih and psim (stable and unstable)
          CALL PSI_INIT(psi_opt,errmsg,errflg)

--- a/physics/module_MYNNSFC_wrapper.meta
+++ b/physics/module_MYNNSFC_wrapper.meta
@@ -7,6 +7,14 @@
 [ccpp-arg-table]
   name = mynnsfc_wrapper_init
   type = scheme
+[do_mynnsfclay]
+  standard_name = do_mynnsfclay
+  long_name = flag to activate MYNN surface layer
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP

--- a/physics/moninedmf.f
+++ b/physics/moninedmf.f
@@ -11,15 +11,25 @@
 !> \section arg_table_hedmf_init Argument Table
 !! \htmlinclude hedmf_init.html
 !!
-      subroutine hedmf_init (moninq_fac,errmsg,errflg)
+      subroutine hedmf_init (hybedmf,moninq_fac,errmsg,errflg)
          use machine, only : kind_phys
          implicit none
-         real(kind=kind_phys), intent(in ) :: moninq_fac
+
+         logical,              intent(in) :: hybedmf
+
+         real(kind=kind_phys), intent(in) :: moninq_fac
          character(len=*),     intent(out) :: errmsg
          integer,              intent(out) :: errflg
          ! Initialize CCPP error handling variables
          errmsg = ''
          errflg = 0
+
+         ! Consistency checks
+         if (.not. hybedmf) then
+            errflg = 1
+            write(errmsg,'(*(a))') 'Logic error: hybedmf = .false.'
+            return
+         end if
 
          if (moninq_fac == 0) then
              errflg = 1

--- a/physics/moninedmf.meta
+++ b/physics/moninedmf.meta
@@ -7,6 +7,14 @@
 [ccpp-arg-table]
   name = hedmf_init
   type = scheme
+[hybedmf]
+  standard_name = flag_for_hedmf
+  long_name = flag for hybrid edmf pbl scheme (moninedmf)
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
 [moninq_fac]
   standard_name = atmosphere_diffusivity_coefficient_factor
   long_name = multiplicative constant for atmospheric diffusivities

--- a/physics/moninshoc.f
+++ b/physics/moninshoc.f
@@ -6,7 +6,24 @@
 
       contains
 
-      subroutine moninshoc_init ()
+      subroutine moninshoc_init (do_shoc, errmsg, errflg)
+
+      implicit none
+      logical, intent(in) :: do_shoc
+      character(len=*), intent(out) :: errmsg
+      integer,          intent(out) :: errflg
+
+      ! Initialize CCPP error handling variables
+      errmsg = ''
+      errflg = 0
+
+      ! Consistency checks
+      if (.not. do_shoc) then
+        errflg = 1
+        write(errmsg,'(*(a))') 'Logic error: do_shoc = .false.'
+       return
+      end if
+ 
       end subroutine moninshoc_init
 
       subroutine moninshoc_finalize ()

--- a/physics/moninshoc.meta
+++ b/physics/moninshoc.meta
@@ -5,6 +5,36 @@
 
 ########################################################################
 [ccpp-arg-table]
+  name = moninshoc_init
+  type = scheme
+[do_shoc]
+  standard_name = flag_for_shoc
+  long_name = flag for SHOC
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+  optional = F
+[errflg]
+  standard_name = ccpp_error_flag
+  long_name = error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+  optional = F
+  
+########################################################################
+[ccpp-arg-table]
   name = moninshoc_run
   type = scheme
 [im]

--- a/physics/precpd.f
+++ b/physics/precpd.f
@@ -14,12 +14,14 @@
 
       subroutine zhaocarr_precpd_init (imp_physics,                     &
      &                                 imp_physics_zhao_carr,           &
+     &                                 imp_physics_zhao_carr_pdf,       &
      &                                 errmsg, errflg)
         implicit none
 
         ! Interface variables
          integer,              intent(in   ) :: imp_physics
-         integer,              intent(in   ) :: imp_physics_zhao_carr
+         integer,              intent(in   ) :: imp_physics_zhao_carr,  &
+     &                                      imp_physics_zhao_carr_pdf
          ! CCPP error handling
          character(len=*),          intent(  out) :: errmsg
          integer,                   intent(  out) :: errflg

--- a/physics/precpd.f
+++ b/physics/precpd.f
@@ -31,7 +31,8 @@
          if (is_initialized) return
 
          ! Consistency checks
-         if (imp_physics/=imp_physics_zhao_carr) then
+         if (imp_physics/=imp_physics_zhao_carr .and.                   &
+     &       imp_physics/=imp_physics_zhao_carr_pdf) then
             write(errmsg,'(*(a))') "Logic error: namelist choice of     &
      &                  microphysics is different from Zhao-Carr MP"
             errflg = 1

--- a/physics/precpd.meta
+++ b/physics/precpd.meta
@@ -23,6 +23,14 @@
   type = integer
   intent = in
   optional = F
+[imp_physics_zhao_carr_pdf]
+  standard_name = flag_for_zhao_carr_pdf_microphysics_scheme
+  long_name = choice of Zhao-Carr microphysics scheme with PDF clouds
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP

--- a/physics/samfdeepcnv.f
+++ b/physics/samfdeepcnv.f
@@ -10,7 +10,23 @@
 
       contains
 
-      subroutine samfdeepcnv_init()
+      subroutine samfdeepcnv_init(imfdeepcnv,imfdeepcnv_samf,             &
+     &                            errmsg, errflg)
+      
+      integer,                   intent(in) :: imfdeepcnv
+      integer,                   intent(in) :: imfdeepcnv_samf
+      character(len=*),          intent(out) :: errmsg
+      integer,                   intent(out) :: errflg
+
+
+      ! Consistency checks
+      if (imfdeepcnv/=imfdeepcnv_samf) then
+        write(errmsg,'(*(a))') 'Logic error: namelist choice of',       &
+     &    ' deep convection is different from SAMF scheme'
+           errflg = 1
+        return
+      end if
+
       end subroutine samfdeepcnv_init
 
       subroutine samfdeepcnv_finalize()

--- a/physics/samfdeepcnv.meta
+++ b/physics/samfdeepcnv.meta
@@ -5,6 +5,44 @@
 
 ########################################################################
 [ccpp-arg-table]
+  name = samfdeepcnv_init
+  type = scheme
+[imfdeepcnv]
+  standard_name = flag_for_mass_flux_deep_convection_scheme
+  long_name = flag for mass-flux deep convection scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[imfdeepcnv_samf]
+  standard_name = flag_for_samf_deep_convection_scheme
+  long_name = flag for SAMF deep convection scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+  optional = F
+[errflg]
+  standard_name = ccpp_error_flag
+  long_name = error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+  optional = F
+
+########################################################################
+[ccpp-arg-table]
   name = samfdeepcnv_run
   type = scheme
 [im]

--- a/physics/samfshalcnv.f
+++ b/physics/samfshalcnv.f
@@ -9,7 +9,23 @@
 
       contains
 
-      subroutine samfshalcnv_init()
+      subroutine samfshalcnv_init(imfshalcnv, imfshalcnv_samf,          &
+     &                            errmsg, errflg)
+
+      integer,                   intent(in) :: imfshalcnv
+      integer,                   intent(in) :: imfshalcnv_samf
+      
+      ! CCPP error handling
+      character(len=*),          intent(out) :: errmsg
+      integer,                   intent(out) :: errflg
+
+      ! Consistency checks
+      if (imfshalcnv/=imfshalcnv_samf) then
+        write(errmsg,'(*(a))') 'Logic error: namelist choice of',       &
+     &  ' shallow convection is different from SAMF'
+        errflg = 1
+        return
+      end if      
       end subroutine samfshalcnv_init
 
       subroutine samfshalcnv_finalize()

--- a/physics/samfshalcnv.meta
+++ b/physics/samfshalcnv.meta
@@ -5,6 +5,44 @@
 
 ########################################################################
 [ccpp-arg-table]
+  name = samfshalcnv_init
+  type = scheme
+[imfshalcnv]
+  standard_name = flag_for_mass_flux_shallow_convection_scheme
+  long_name = flag for mass-flux shallow convection scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[imfshalcnv_samf]
+  standard_name = flag_for_samf_shallow_convection_scheme
+  long_name = flag for SAMF shallow convection scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+  optional = F
+[errflg]
+  standard_name = ccpp_error_flag
+  long_name = error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+  optional = F
+
+########################################################################
+[ccpp-arg-table]
   name = samfshalcnv_run
   type = scheme
 [im]

--- a/physics/satmedmfvdif.F
+++ b/physics/satmedmfvdif.F
@@ -10,9 +10,11 @@
 !> \section arg_table_satmedmfvdif_init Argument Table
 !! \htmlinclude satmedmfvdif_init.html
 !!
-      subroutine satmedmfvdif_init (isatmedmf,isatmedmf_vdif,
+      subroutine satmedmfvdif_init (satmedmf,
+     &                              isatmedmf,isatmedmf_vdif,
      &                              errmsg,errflg)
 
+      logical, intent(in) :: satmedmf
       integer, intent(in) :: isatmedmf,isatmedmf_vdif
       character(len=*), intent(out) :: errmsg
       integer,          intent(out) :: errflg
@@ -20,6 +22,13 @@
 ! Initialize CCPP error handling variables
       errmsg = ''
       errflg = 0
+
+! Consistency checks
+      if (.not. satmedmf) then
+        write(errmsg,fmt='(*(a))') 'Logic error: satmedmf = .false.'        
+        errflg = 1
+        return
+      end if
 
       if (.not. isatmedmf==isatmedmf_vdif) then
         write(errmsg,fmt='(*(a))') 'Logic error: satmedmfvdif is ',

--- a/physics/satmedmfvdif.meta
+++ b/physics/satmedmfvdif.meta
@@ -7,6 +7,16 @@
 [ccpp-arg-table]
   name = satmedmfvdif_init
   type = scheme
+[satmedmf]
+  standard_name = flag_for_scale_aware_TKE_moist_EDMF_PBL
+  long_name = flag for scale-aware TKE moist EDMF PBL scheme
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+  intent = in
+  optional = F
 [isatmedmf]
   standard_name = choice_of_scale_aware_TKE_moist_EDMF_PBL
   long_name = choice of scale-aware TKE moist EDMF PBL scheme

--- a/physics/satmedmfvdifq.F
+++ b/physics/satmedmfvdifq.F
@@ -19,16 +19,26 @@
 !> \section arg_table_satmedmfvdifq_init Argument Table
 !! \htmlinclude satmedmfvdifq_init.html
 !!
-      subroutine satmedmfvdifq_init (isatmedmf,isatmedmf_vdifq,
+      subroutine satmedmfvdifq_init (satmedmf,
+     &                               isatmedmf,isatmedmf_vdifq,
      &                               errmsg,errflg)
 
+      logical, intent(in   ) :: satmedmf
       integer, intent(in) :: isatmedmf,isatmedmf_vdifq
+
       character(len=*), intent(out) :: errmsg
       integer,          intent(out) :: errflg
 
 ! Initialize CCPP error handling variables
       errmsg = ''
       errflg = 0
+
+! Consistency checks
+      if (.not. satmedmf) then
+        write(errmsg,fmt='(*(a))') 'Logic error: satmedmf = .false.'        
+        errflg = 1
+        return
+      end if
 
       if (.not. isatmedmf==isatmedmf_vdifq) then
         write(errmsg,fmt='(*(a))') 'Logic error: satmedmfvdif is ',

--- a/physics/satmedmfvdifq.meta
+++ b/physics/satmedmfvdifq.meta
@@ -7,6 +7,14 @@
 [ccpp-arg-table]
   name = satmedmfvdifq_init
   type = scheme
+[satmedmf]
+  standard_name = flag_for_scale_aware_TKE_moist_EDMF_PBL
+  long_name = flag for scale-aware TKE moist EDMF PBL scheme
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
 [isatmedmf]
   standard_name = choice_of_scale_aware_TKE_moist_EDMF_PBL
   long_name = choice of scale-aware TKE moist EDMF PBL scheme

--- a/physics/sfc_drv.f
+++ b/physics/sfc_drv.f
@@ -21,10 +21,12 @@
 !! \section arg_table_lsm_noah_init Argument Table
 !! \htmlinclude lsm_noah_init.html
 !!
-      subroutine lsm_noah_init(me, isot, ivegsrc, nlunit,
+      subroutine lsm_noah_init(lsm, lsm_noah, me, isot, ivegsrc, nlunit,
      &                         pores, resid, errmsg, errflg)
 
       implicit none
+      integer,              intent(in) :: lsm
+      integer,              intent(in) :: lsm_noah      
 
       integer,              intent(in)  :: me, isot, ivegsrc, nlunit
 
@@ -37,6 +39,14 @@
       errmsg = ''
       errflg = 0
       
+      ! Consistency checks
+      if (lsm/=lsm_noah) then
+        write(errmsg,'(*(a))') 'Logic error: namelist choice of ',
+     &       'LSM is different from Noah'
+        errflg = 1
+        return
+      end if
+
       if (ivegsrc > 2) then
         errmsg = 'The NOAH LSM expects that the ivegsrc physics '//
      &            'namelist parameter is 0, 1, or 2. Exiting...'

--- a/physics/sfc_drv.meta
+++ b/physics/sfc_drv.meta
@@ -7,6 +7,22 @@
 [ccpp-arg-table]
   name = lsm_noah_init
   type = scheme
+[lsm]
+  standard_name = flag_for_land_surface_scheme
+  long_name = flag for land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lsm_noah]
+  standard_name = flag_for_noah_land_surface_scheme
+  long_name = flag for NOAH land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
 [me]
   standard_name = mpi_rank
   long_name = current MPI-rank

--- a/physics/sfc_drv_ruc.F90
+++ b/physics/sfc_drv_ruc.F90
@@ -82,7 +82,7 @@ module lsm_ruc
       
       ! Consistency checks
       if (lsm/=lsm_ruc) then
-        write(errmsg,'(*(a))') 'Logic error: namelist choice of ',
+        write(errmsg,'(*(a))') 'Logic error: namelist choice of ',     &
      &       'LSM is different from RUC'
         errflg = 1
         return

--- a/physics/sfc_drv_ruc.F90
+++ b/physics/sfc_drv_ruc.F90
@@ -25,8 +25,7 @@ module lsm_ruc
 !! \section arg_table_lsm_ruc_init Argument Table
 !! \htmlinclude lsm_ruc_init.html
 !!
-      subroutine lsm_ruc_init (lsm, lsm_ruc,                             &
-                               me, master, isot, ivegsrc, nlunit,        &
+      subroutine lsm_ruc_init (me, master, isot, ivegsrc, nlunit,        &
                                flag_restart, flag_init,                  &
                                im, lsoil_ruc, lsoil, kice, nlev,         & ! in
                                lsm_ruc, lsm, slmsk, stype, vtype,        & ! in 
@@ -37,8 +36,6 @@ module lsm_ruc
 
       implicit none
 !  ---  in
-      integer,              intent(in)  :: lsm
-      integer,              intent(in)  :: lsm_ruc
       integer,              intent(in)  :: me, master, isot, ivegsrc, nlunit
       logical,              intent(in)  :: flag_restart
       logical,              intent(in)  :: flag_init

--- a/physics/sfc_drv_ruc.F90
+++ b/physics/sfc_drv_ruc.F90
@@ -25,7 +25,8 @@ module lsm_ruc
 !! \section arg_table_lsm_ruc_init Argument Table
 !! \htmlinclude lsm_ruc_init.html
 !!
-      subroutine lsm_ruc_init (me, master, isot, ivegsrc, nlunit,        &
+      subroutine lsm_ruc_init (lsm, lsm_ruc,                             &
+                               me, master, isot, ivegsrc, nlunit,        &
                                flag_restart, flag_init,                  &
                                im, lsoil_ruc, lsoil, kice, nlev,         & ! in
                                lsm_ruc, lsm, slmsk, stype, vtype,        & ! in 
@@ -36,6 +37,8 @@ module lsm_ruc
 
       implicit none
 !  ---  in
+      integer,              intent(in)  :: lsm
+      integer,              intent(in)  :: lsm_ruc
       integer,              intent(in)  :: me, master, isot, ivegsrc, nlunit
       logical,              intent(in)  :: flag_restart
       logical,              intent(in)  :: flag_init
@@ -79,6 +82,14 @@ module lsm_ruc
       ! Initialize CCPP error handling variables
       errmsg = ''
       errflg = 0 
+      
+      ! Consistency checks
+      if (lsm/=lsm_ruc) then
+        write(errmsg,'(*(a))') 'Logic error: namelist choice of ',
+     &       'LSM is different from RUC'
+        errflg = 1
+        return
+      end if
 
       ipr = 10
       debug_print = .false.

--- a/physics/sfc_drv_ruc.meta
+++ b/physics/sfc_drv_ruc.meta
@@ -7,6 +7,22 @@
 [ccpp-arg-table]
   name = lsm_ruc_init
   type = scheme
+[lsm]
+  standard_name = flag_for_land_surface_scheme
+  long_name = flag for land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lsm_ruc]
+  standard_name = flag_for_ruc_land_surface_scheme
+  long_name = flag for RUC land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
 [me]
   standard_name = mpi_rank
   long_name = current MPI-rank

--- a/physics/sfc_drv_ruc.meta
+++ b/physics/sfc_drv_ruc.meta
@@ -7,22 +7,6 @@
 [ccpp-arg-table]
   name = lsm_ruc_init
   type = scheme
-[lsm]
-  standard_name = flag_for_land_surface_scheme
-  long_name = flag for land surface model
-  units = flag
-  dimensions = ()
-  type = integer
-  intent = in
-  optional = F
-[lsm_ruc]
-  standard_name = flag_for_ruc_land_surface_scheme
-  long_name = flag for RUC land surface model
-  units = flag
-  dimensions = ()
-  type = integer
-  intent = in
-  optional = F
 [me]
   standard_name = mpi_rank
   long_name = current MPI-rank

--- a/physics/sfc_noahmp_drv.F90
+++ b/physics/sfc_noahmp_drv.F90
@@ -25,7 +25,8 @@
 !! \section arg_table_noahmpdrv_init Argument Table
 !! \htmlinclude noahmpdrv_init.html
 !!
-      subroutine noahmpdrv_init(me, isot, ivegsrc, nlunit, pores, resid, &
+      subroutine noahmpdrv_init(lsm, lsm_noahmp, me, isot, ivegsrc, &
+                                nlunit, pores, resid,               &
                                 errmsg, errflg)
 
         use machine,          only: kind_phys
@@ -33,7 +34,8 @@
         use namelist_soilveg
 
         implicit none
-
+        integer,              intent(in) :: lsm
+        integer,              intent(in) :: lsm_noahmp    
         integer,              intent(in)  :: me, isot, ivegsrc, nlunit
 
         real (kind=kind_phys), dimension(:), intent(out) :: pores, resid
@@ -44,6 +46,14 @@
         ! Initialize CCPP error handling variables
         errmsg = ''
         errflg = 0
+
+        ! Consistency checks
+        if (lsm/=lsm_noahmp) then
+          write(errmsg,'(*(a))') 'Logic error: namelist choice of ',   &
+       &       'LSM is different from Noah'
+          errflg = 1
+          return
+        end if
 
         if (ivegsrc /= 1) then
           errmsg = 'The NOAHMP LSM expects that the ivegsrc physics '// &

--- a/physics/sfc_noahmp_drv.meta
+++ b/physics/sfc_noahmp_drv.meta
@@ -7,6 +7,22 @@
 [ccpp-arg-table]
   name = noahmpdrv_init
   type = scheme
+[lsm]
+  standard_name = flag_for_land_surface_scheme
+  long_name = flag for land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[lsm_noahmp]
+  standard_name = flag_for_noahmp_land_surface_scheme
+  long_name = flag for NOAH MP land surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
 [me]
   standard_name = mpi_rank
   long_name = current MPI-rank

--- a/physics/shinhongvdif.F90
+++ b/physics/shinhongvdif.F90
@@ -11,7 +11,22 @@
       module shinhongvdif
       contains
 
-      subroutine shinhongvdif_init ()
+      subroutine shinhongvdif_init (shinhong,errmsg,errflg)
+
+      logical,              intent(in)  :: shinhong
+      character(len=*),     intent(out) :: errmsg
+      integer,              intent(out) :: errflg
+
+     ! Initialize CCPP error handling variables
+      errmsg = ''
+      errflg = 0
+
+    ! Consistency checks
+      if (.not. shinhong) then
+        write(errmsg,fmt='(*(a))') 'Logic error: shinhong = .false.'        
+        errflg = 1
+        return
+      end if
       end subroutine shinhongvdif_init
 
       subroutine shinhongvdif_finalize ()

--- a/physics/shinhongvdif.meta
+++ b/physics/shinhongvdif.meta
@@ -5,6 +5,36 @@
 
 ########################################################################
 [ccpp-arg-table]
+  name = shinhongvdif_init
+  type = scheme
+[shinhong]
+  standard_name = flag_for_scale_aware_Shinhong_PBL
+  long_name = flag for scale-aware Shinhong PBL scheme
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+  optional = F
+[errflg]
+  standard_name = ccpp_error_flag
+  long_name = error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+  optional = F
+  
+########################################################################
+[ccpp-arg-table]
   name = shinhongvdif_run
   type = scheme
 [im]

--- a/physics/unified_ugwp.F90
+++ b/physics/unified_ugwp.F90
@@ -106,7 +106,7 @@ contains
     errflg = 0
 
     ! Consistency checks
-    if (gwd_opt/=2 .or. gwd_opt/=22) then
+    if (gwd_opt/=2 .and. gwd_opt/=22) then
       write(errmsg,'(*(a))') "Logic error: namelist choice of gravity wave &
         & drag is different from unified_ugwp scheme"
       errflg = 1

--- a/physics/unified_ugwp.F90
+++ b/physics/unified_ugwp.F90
@@ -63,7 +63,7 @@ contains
                 fn_nml2, jdat, lonr, latr, levs, ak, bk, dtp, cdmbgwd, cgwf,   &
                 con_pi, con_rerth, pa_rf_in, tau_rf_in, con_p0, do_ugwp,       &
                 do_ugwp_v0, do_ugwp_v0_orog_only, do_ugwp_v0_nst_only,         &
-                do_gsl_drag_ls_bl, do_gsl_drag_ss, do_gsl_drag_tofd,           &
+                do_gsl_drag_ls_bl, do_gsl_drag_ss, do_gsl_drag_tofd, gwd_opt,  &
                 errmsg, errflg)
 
 !----  initialization of unified_ugwp
@@ -96,7 +96,8 @@ contains
     logical :: exists
     real    :: dxsg
     integer :: k
-
+    
+    integer,          intent(in)  :: gwd_opt
     character(len=*), intent(out) :: errmsg
     integer,          intent(out) :: errflg
 
@@ -104,6 +105,13 @@ contains
     errmsg = ''
     errflg = 0
 
+    ! Consistency checks
+    if (gwd_opt/=2 .or. gwd_opt/=22) then
+      write(errmsg,'(*(a))') "Logic error: namelist choice of gravity wave &
+        & drag is different from unified_ugwp scheme"
+      errflg = 1
+      return
+    end if
 
     ! Test to make sure that at most only one large-scale/blocking
     ! orographic drag scheme is chosen

--- a/physics/unified_ugwp.meta
+++ b/physics/unified_ugwp.meta
@@ -238,6 +238,14 @@
   type = logical
   intent = in
   optional = F
+[gwd_opt]
+  standard_name = gwd_opt
+  long_name = flag to choose gwd scheme
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP

--- a/physics/ysuvdif.F90
+++ b/physics/ysuvdif.F90
@@ -11,7 +11,22 @@
       module ysuvdif
       contains
 
-      subroutine ysuvdif_init ()
+      subroutine ysuvdif_init (do_ysu,errmsg,errflg)
+
+        integer, intent(in) :: do_ysu
+        character(len=*), intent(out) :: errmsg
+        integer,          intent(out) :: errflg
+
+        ! Initialize CCPP error handling variables
+        errmsg = ''
+        errflg = 0
+
+        ! Consistency checks
+        if (.not. do_ysu) then
+          write(errmsg,fmt='(*(a))') 'Logic error: do_ysu = .false.'      
+          errflg = 1
+          return
+        end if
       end subroutine ysuvdif_init
 
       subroutine ysuvdif_finalize ()

--- a/physics/ysuvdif.F90
+++ b/physics/ysuvdif.F90
@@ -13,7 +13,7 @@
 
       subroutine ysuvdif_init (do_ysu,errmsg,errflg)
 
-        integer, intent(in) :: do_ysu
+        logical,          intent(in) :: do_ysu
         character(len=*), intent(out) :: errmsg
         integer,          intent(out) :: errflg
 

--- a/physics/ysuvdif.meta
+++ b/physics/ysuvdif.meta
@@ -5,6 +5,36 @@
 
 ########################################################################
 [ccpp-arg-table]
+  name = ysuvdif_init
+  type = scheme
+[do_ysu]
+  standard_name = flag_for_ysu
+  long_name = flag for YSU PBL scheme
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[errmsg]
+  standard_name = ccpp_error_message
+  long_name = error message for error handling in CCPP
+  units = none
+  dimensions = ()
+  type = character
+  kind = len=*
+  intent = out
+  optional = F
+[errflg]
+  standard_name = ccpp_error_flag
+  long_name = error flag for error handling in CCPP
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = out
+  optional = F
+
+########################################################################
+[ccpp-arg-table]
   name = ysuvdif_run
   type = scheme
 [im]


### PR DESCRIPTION
### Description
- This PR adds compatibility/consistency checks for namelists in different CCPP schemes.

- Integer options for PBL and surface layer schemes are not implemented in this PR.

### Related PR
- NOAA-EMC/fv3atm/pull/298