### PR TITLE
Fix snet bug for Noah LSM

### DIFF
--- a/physics/GFS_radiation_surface.F90
+++ b/physics/GFS_radiation_surface.F90
@@ -88,7 +88,7 @@
                                                            alnwf, facsf, facwf,         &
                                                            semis_lnd, semis_ice, snoalb
       character(len=3)    , dimension(:),   intent(in)  :: lndp_var_list
-      real(kind=kind_phys), dimension(:),   intent(in)  :: albdvis_lnd, albdnir_lnd,    &
+      real(kind=kind_phys), dimension(:),   intent(inout)  :: albdvis_lnd, albdnir_lnd, &
                                                            albivis_lnd, albinir_lnd
       real(kind=kind_phys), dimension(:),   intent(in)  :: albdvis_ice, albdnir_ice,    &
                                                            albivis_ice, albinir_ice

--- a/physics/GFS_radiation_surface.meta
+++ b/physics/GFS_radiation_surface.meta
@@ -411,7 +411,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
   optional = F
 [albdnir_lnd]
   standard_name = surface_albedo_direct_NIR_over_land
@@ -420,7 +420,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
   optional = F
 [albivis_lnd]
   standard_name = surface_albedo_diffuse_visible_over_land
@@ -429,7 +429,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
   optional = F
 [albinir_lnd]
   standard_name = surface_albedo_diffuse_NIR_over_land
@@ -438,7 +438,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
   optional = F
 [albdvis_ice]
   standard_name = surface_albedo_direct_visible_over_ice

--- a/physics/gcycle.F90
+++ b/physics/gcycle.F90
@@ -93,6 +93,7 @@ contains
 
 
     logical              :: lake(nx*ny)
+    integer              :: i_indx(nx*ny), j_indx(nx*ny)
     character(len=6)     :: tile_num_ch
     real(kind=kind_phys) :: sig1t, dt_warm
     integer              :: npts, nb, ix, jx, ls, ios, ll
@@ -120,6 +121,9 @@ contains
       end if
 !
       do ix=1,npts
+        i_indx(ix) = imap(ix) + isc - 1
+        j_indx(ix) = jmap(ix) + jsc - 1
+
         ZORFCS(ix) = zorll (ix)
         if (slmsk(ix) > 1.9_kind_phys .and. .not. frac_grid) then
           ZORFCS(ix) = zorli  (ix)
@@ -190,7 +194,7 @@ contains
                      nlunit, size(input_nml_file), input_nml_file,   &
                      lake, min_lakeice, min_seaice,                  &
                      ialb, isot, ivegsrc,                            &
-                     trim(tile_num_ch), imap, jmap)
+                     trim(tile_num_ch), i_indx, j_indx)
 #ifndef INTERNAL_FILE_NML
       close (Model%nlunit)
 #endif

--- a/physics/module_sf_noahmplsm.f90
+++ b/physics/module_sf_noahmplsm.f90
@@ -1904,6 +1904,10 @@ endif   ! croptype == 0
 ! ground snow cover fraction [niu and yang, 2007, jgr]
 
      fsno = 0.
+     if(snowh <= 1.e-6 .or. sneqv <= 1.e-3) then
+       snowh = 0.0
+       sneqv = 0.0
+     end if
      if(snowh.gt.0.)  then
          bdsno    = sneqv / snowh
          fmelt    = (bdsno/100.)**parameters%mfsno
@@ -7070,7 +7074,7 @@ endif   ! croptype == 0
       end if
    end if
 
-   if(snowh <= 1.e-8 .or. sneqv <= 1.e-6) then
+   if(snowh <= 1.e-6 .or. sneqv <= 1.e-3) then
      snowh = 0.0
      sneqv = 0.0
    end if

--- a/physics/radiation_surface.f
+++ b/physics/radiation_surface.f
@@ -411,13 +411,15 @@
       real (kind=kind_phys), dimension(:), intent(in) ::                &
      &       slmsk, snowf, zorlf, coszf, tsknf, tairf, hprif, landfrac, &
      &       alvsf, alnsf, alvwf, alnwf, facsf, facwf, fice, tisfc,     &
-     &       lsmalbdvis, lsmalbdnir, lsmalbivis, lsmalbinir,            &
      &       icealbdvis, icealbdnir, icealbivis, icealbinir,            &
      &       sncovr, sncovr_ice, snoalb, albPpert           ! sfc-perts, mgehne
       real (kind=kind_phys),  intent(in) :: pertalb         ! sfc-perts, mgehne
       real (kind=kind_phys),  intent(in) :: min_seaice
       real (kind=kind_phys), dimension(:), intent(in) ::                &
      &       fracl, fraco, fraci
+      real (kind=kind_phys), dimension(:),intent(inout) ::              &
+     &     lsmalbdvis, lsmalbdnir, lsmalbivis, lsmalbinir 
+
       logical, dimension(:), intent(in) ::                              &
      &       icy
 
@@ -537,6 +539,10 @@
             alndnd = alnwf(i)*flnd + snoalb(i) * fsno
             alndvb = ab2bm   *flnd + snoalb(i) * fsno
             alndvd = alvwf(i)*flnd + snoalb(i) * fsno
+            lsmalbdnir(i) = min(0.99,max(0.01,alndnb))
+            lsmalbinir(i) = min(0.99,max(0.01,alndnd))
+            lsmalbdvis(i) = min(0.99,max(0.01,alndvb))
+            lsmalbivis(i) = min(0.99,max(0.01,alndvd))
           else
           !-- fill in values for land albedo
             alndnb = 0.

--- a/physics/sfc_drv.f
+++ b/physics/sfc_drv.f
@@ -94,10 +94,12 @@
 !      call sfc_drv                                                     !
 !  ---  inputs:                                                         !
 !          ( im, km, ps, t1, q1, soiltyp, vegtype, sigmaf,              !
-!            sfcemis, dlwflx, dswsfc, snet, delt, tg3, cm, ch,          !
+!            sfcemis, dlwflx, dswsfc, delt, tg3, cm, ch,                !
 !            prsl1, prslki, zf, land, wind,  slopetyp,                  !
 !            shdmin, shdmax, snoalb, sfalb, flag_iter, flag_guess,      !
 !            lheatstrg, isot, ivegsrc,                                  !
+!            albdvis_lnd, albdnir_lnd, albivis_lnd, albinir_lnd,        !
+!            adjvisbmd, adjnirbmd, adjvisdfd, adjnirdfd,                ! 
 !  ---  in/outs:                                                        !
 !            weasd, snwdph, tskin, tprcp, srflag, smc, stc, slc,        !
 !            canopy, trans, tsurf, zorl,                                !
@@ -133,7 +135,6 @@
 !     sfcemis  - real, sfc lw emissivity ( fraction )              im   !
 !     dlwflx   - real, total sky sfc downward lw flux ( w/m**2 )   im   !
 !     dswflx   - real, total sky sfc downward sw flux ( w/m**2 )   im   !
-!     snet     - real, total sky sfc netsw flx into ground(w/m**2) im   !
 !     delt     - real, time interval (second)                      1    !
 !     tg3      - real, deep soil temperature (k)                   im   !
 !     cm       - real, surface exchange coeff for momentum (m/s)   im   !
@@ -148,6 +149,14 @@
 !     shdmax   - real, max fractnl cover of green veg (not used)   im   !
 !     snoalb   - real, upper bound on max albedo over deep snow    im   !
 !     sfalb    - real, mean sfc diffused sw albedo (fractional)    im   !
+!     albdvis_lnd  - real, sfc vis direct sw albedo over land      im   !
+!     albdnir_lnd  - real, sfc nir direct sw albedo over land      im   !
+!     albivis_lnd  - real, sfc vis diffused sw albedo over land    im   !
+!     albinir_lnd  - real, sfc nir diffused sw albedo over land    im   !
+!     adjvisbmd    - real, t adj sfc uv+vis-beam sw dnward flux    im   !
+!     adjnirbmd    - real, t adj sfc nir-beam sw dnward flux       im   !
+!     adjvisdfd    - real, t adj sfc uv+vis-diff sw dnward flux    im   !
+!     adjnirdfd    - real, t adj sfc nir-diff sw dnward flux       im   !
 !     flag_iter- logical,                                          im   !
 !     flag_guess-logical,                                          im   !
 !     lheatstrg- logical, flag for canopy heat storage             1    !
@@ -203,11 +212,13 @@
       subroutine lsm_noah_run                                           &
      &     ( im, km, grav, cp, hvap, rd, eps, epsm1, rvrdm1, ps,        & !  ---  inputs:
      &       t1, q1, soiltyp, vegtype, sigmaf,                          &
-     &       sfcemis, dlwflx, dswsfc, snet, delt, tg3, cm, ch,          &
+     &       sfcemis, dlwflx, dswsfc, delt, tg3, cm, ch,                &
      &       prsl1, prslki, zf, land, wind, slopetyp,                   &
      &       shdmin, shdmax, snoalb, sfalb, flag_iter, flag_guess,      &
      &       lheatstrg, isot, ivegsrc,                                  &
      &       bexppert, xlaipert, vegfpert,pertvegf,                     &  ! sfc perts, mgehne
+     &       albdvis_lnd, albdnir_lnd, albivis_lnd, albinir_lnd,        &  
+     &       adjvisbmd, adjnirbmd, adjvisdfd, adjnirdfd,                &  
 !  ---  in/outs:
      &       weasd, snwdph, tskin, tprcp, srflag, smc, stc, slc,        &
      &       canopy, trans, tsurf, zorl,                                &
@@ -247,10 +258,12 @@
       integer, dimension(:), intent(in) :: soiltyp, vegtype, slopetyp
 
       real (kind=kind_phys), dimension(:), intent(in) :: ps,            &
-     &       t1, q1, sigmaf, sfcemis, dlwflx, dswsfc, snet, tg3, cm,    &
+     &       t1, q1, sigmaf, sfcemis, dlwflx, dswsfc, tg3, cm,          &
      &       ch, prsl1, prslki, wind, shdmin, shdmax,                   &
      &       snoalb, sfalb, zf,                                         &
-     &       bexppert, xlaipert, vegfpert
+     &       bexppert, xlaipert, vegfpert,                              &
+     &       albdvis_lnd, albdnir_lnd, albivis_lnd, albinir_lnd,        &
+     &       adjvisbmd, adjnirbmd, adjvisdfd, adjnirdfd
 
       real (kind=kind_phys),  intent(in) :: delt
 
@@ -400,7 +413,12 @@
 
           lwdn   = dlwflx(i)         !..downward lw flux at sfc in w/m2
           swdn   = dswsfc(i)         !..downward sw flux at sfc in w/m2
-          solnet = snet(i)           !..net sw rad flx (dn-up) at sfc in w/m2
+!net sw rad flx (dn-up) at sfc in w/m2
+          solnet = adjvisbmd(i)*(1-albdvis_lnd(i))                       &
+     &            +adjnirbmd(i)*(1-albdnir_lnd(i))                       &
+     &            +adjvisdfd(i)*(1-albivis_lnd(i))                       &
+     &            +adjnirdfd(i)*(1-albinir_lnd(i))  
+
           sfcems = sfcemis(i)
 
           sfcprs = prsl1(i)

--- a/physics/sfc_drv.meta
+++ b/physics/sfc_drv.meta
@@ -273,15 +273,6 @@
   kind = kind_phys
   intent = in
   optional = F
-[snet]
-  standard_name = surface_net_downwelling_shortwave_flux
-  long_name = total sky surface net shortwave flux
-  units = W m-2
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = in
-  optional = F
 [delt]
   standard_name = time_step_for_dynamics
   long_name = dynamics time step
@@ -478,6 +469,78 @@
   long_name = magnitude of perturbation of vegetation fraction
   units = frac
   dimensions = () 
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[albdvis_lnd]
+  standard_name = surface_albedo_direct_visible_over_land
+  long_name = direct surface albedo visible band over land
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[albdnir_lnd]
+  standard_name = surface_albedo_direct_NIR_over_land
+  long_name = direct surface albedo NIR band over land
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[albivis_lnd]
+  standard_name = surface_albedo_diffuse_visible_over_land
+  long_name = diffuse surface albedo visible band over land
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[albinir_lnd]
+  standard_name = surface_albedo_diffuse_NIR_over_land
+  long_name = diffuse surface albedo NIR band over land
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[adjvisbmd]
+  standard_name = surface_downwelling_direct_ultraviolet_and_visible_shortwave_flux
+  long_name = surface downwelling beam ultraviolet plus visible shortwave flux at current time
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[adjnirbmd]
+  standard_name = surface_downwelling_direct_near_infrared_shortwave_flux
+  long_name = surface downwelling beam near-infrared shortwave flux at current time
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[adjvisdfd]
+  standard_name = surface_downwelling_diffuse_ultraviolet_and_visible_shortwave_flux
+  long_name = surface downwelling diffuse ultraviolet plus visible shortwave flux at current time
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[adjnirdfd]
+  standard_name = surface_downwelling_diffuse_near_infrared_shortwave_flux
+  long_name = surface downwelling diffuse near-infrared shortwave flux at current time
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
   intent = in


### PR DESCRIPTION
This PR contains the fix to the net surface shortwave radiation (snet) to the Noah LSM when fraction grid is turned on. The current snet is computed using the composited albedo and is improperly treated as the snet over land only as a forcing to the Noah LSM. The fix will use 4 components of both surface downward shortwave and albedo to calculate the snet over land.

This PR also contains the gcycle fix from @SMoorthi-emc 

Fixes https://github.com/NCAR/ccpp-physics/issues/669