### PR TITLE
Bugfix in Thompson MP, pass correct timestep to core routine

### DIFF
--- a/physics/mp_thompson.F90
+++ b/physics/mp_thompson.F90
@@ -467,6 +467,9 @@ module mp_thompson
          !> - Also, hydrometeor variables are mass or number mixing ratio
          !> - either kg of species per kg of dry air, or per kg of (dry + vapor).
 
+#if 0
+         if (istep==1) then
+#endif
          ! DH* - do this only if istep == 1? Would be ok if it was
          ! guaranteed that nothing else in the same subcycle group
          ! was using these arrays, but it is somewhat dangerous.
@@ -488,6 +491,9 @@ module mp_thompson
            end if
          end if
          ! *DH
+#if 0
+         endif
+#endif
 
          !> - Density of air in kg m-3
          rho = con_eps*prsl/(con_rd*tgrs*(qv+con_eps))
@@ -565,7 +571,7 @@ module mp_thompson
             if (do_effective_radii) then
                call mp_gt_driver(qv=qv, qc=qc, qr=qr, qi=qi, qs=qs, qg=qg, ni=ni, nr=nr,        &
                                  nc=nc, nwfa=nwfa, nifa=nifa, nwfa2d=nwfa2d, nifa2d=nifa2d,     &
-                                 tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtp,                        &
+                                 tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtstep,                        &
                                  rainnc=rain_mp, rainncv=delta_rain_mp,                         &
                                  snownc=snow_mp, snowncv=delta_snow_mp,                         &
                                  icenc=ice_mp, icencv=delta_ice_mp,                             &
@@ -586,7 +592,7 @@ module mp_thompson
             else
                call mp_gt_driver(qv=qv, qc=qc, qr=qr, qi=qi, qs=qs, qg=qg, ni=ni, nr=nr,        &
                                  nc=nc, nwfa=nwfa, nifa=nifa, nwfa2d=nwfa2d, nifa2d=nifa2d,     &
-                                 tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtp,                        &
+                                 tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtstep,                        &
                                  rainnc=rain_mp, rainncv=delta_rain_mp,                         &
                                  snownc=snow_mp, snowncv=delta_snow_mp,                         &
                                  icenc=ice_mp, icencv=delta_ice_mp,                             &
@@ -607,7 +613,7 @@ module mp_thompson
          else
             if (do_effective_radii) then
                call mp_gt_driver(qv=qv, qc=qc, qr=qr, qi=qi, qs=qs, qg=qg, ni=ni, nr=nr,        &
-                                 tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtp,                        &
+                                 tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtstep,                        &
                                  rainnc=rain_mp, rainncv=delta_rain_mp,                         &
                                  snownc=snow_mp, snowncv=delta_snow_mp,                         &
                                  icenc=ice_mp, icencv=delta_ice_mp,                             &
@@ -627,7 +633,7 @@ module mp_thompson
                                  first_time_step=first_time_step, errmsg=errmsg, errflg=errflg)
             else
                call mp_gt_driver(qv=qv, qc=qc, qr=qr, qi=qi, qs=qs, qg=qg, ni=ni, nr=nr,        &
-                                 tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtp,                        &
+                                 tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtstep,                        &
                                  rainnc=rain_mp, rainncv=delta_rain_mp,                         &
                                  snownc=snow_mp, snowncv=delta_snow_mp,                         &
                                  icenc=ice_mp, icencv=delta_ice_mp,                             &
@@ -652,6 +658,9 @@ module mp_thompson
          ! guaranteed that nothing else in the same subcycle group
          ! was using these arrays, but it is somewhat dangerous.
 
+#if 0
+         if(istep==nsteps) then
+#endif
          !> - Convert water vapor mixing ratio back to specific humidity
          spechum = qv/(1.0_kind_phys+qv)
 
@@ -671,7 +680,9 @@ module mp_thompson
            end if
          end if
          ! *DH
-
+#if 0
+         endif
+#endif
          !> - Convert rainfall deltas from mm to m (on physics timestep); add to inout variables
          ! "rain" in Thompson MP refers to precipitation (total of liquid rainfall+snow+graupel+ice)
          prcp    = prcp    + max(0.0, delta_rain_mp/1000.0_kind_phys)

--- a/physics/mp_thompson.F90
+++ b/physics/mp_thompson.F90
@@ -467,9 +467,6 @@ module mp_thompson
          !> - Also, hydrometeor variables are mass or number mixing ratio
          !> - either kg of species per kg of dry air, or per kg of (dry + vapor).
 
-#if 0
-         if (istep==1) then
-#endif
          ! DH* - do this only if istep == 1? Would be ok if it was
          ! guaranteed that nothing else in the same subcycle group
          ! was using these arrays, but it is somewhat dangerous.
@@ -491,9 +488,6 @@ module mp_thompson
            end if
          end if
          ! *DH
-#if 0
-         endif
-#endif
 
          !> - Density of air in kg m-3
          rho = con_eps*prsl/(con_rd*tgrs*(qv+con_eps))
@@ -571,7 +565,7 @@ module mp_thompson
             if (do_effective_radii) then
                call mp_gt_driver(qv=qv, qc=qc, qr=qr, qi=qi, qs=qs, qg=qg, ni=ni, nr=nr,        &
                                  nc=nc, nwfa=nwfa, nifa=nifa, nwfa2d=nwfa2d, nifa2d=nifa2d,     &
-                                 tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtstep,                        &
+                                 tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtstep,                     &
                                  rainnc=rain_mp, rainncv=delta_rain_mp,                         &
                                  snownc=snow_mp, snowncv=delta_snow_mp,                         &
                                  icenc=ice_mp, icencv=delta_ice_mp,                             &
@@ -592,7 +586,7 @@ module mp_thompson
             else
                call mp_gt_driver(qv=qv, qc=qc, qr=qr, qi=qi, qs=qs, qg=qg, ni=ni, nr=nr,        &
                                  nc=nc, nwfa=nwfa, nifa=nifa, nwfa2d=nwfa2d, nifa2d=nifa2d,     &
-                                 tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtstep,                        &
+                                 tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtstep,                     &
                                  rainnc=rain_mp, rainncv=delta_rain_mp,                         &
                                  snownc=snow_mp, snowncv=delta_snow_mp,                         &
                                  icenc=ice_mp, icencv=delta_ice_mp,                             &
@@ -613,7 +607,7 @@ module mp_thompson
          else
             if (do_effective_radii) then
                call mp_gt_driver(qv=qv, qc=qc, qr=qr, qi=qi, qs=qs, qg=qg, ni=ni, nr=nr,        &
-                                 tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtstep,                        &
+                                 tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtstep,                     &
                                  rainnc=rain_mp, rainncv=delta_rain_mp,                         &
                                  snownc=snow_mp, snowncv=delta_snow_mp,                         &
                                  icenc=ice_mp, icencv=delta_ice_mp,                             &
@@ -633,7 +627,7 @@ module mp_thompson
                                  first_time_step=first_time_step, errmsg=errmsg, errflg=errflg)
             else
                call mp_gt_driver(qv=qv, qc=qc, qr=qr, qi=qi, qs=qs, qg=qg, ni=ni, nr=nr,        &
-                                 tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtstep,                        &
+                                 tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtstep,                     &
                                  rainnc=rain_mp, rainncv=delta_rain_mp,                         &
                                  snownc=snow_mp, snowncv=delta_snow_mp,                         &
                                  icenc=ice_mp, icencv=delta_ice_mp,                             &
@@ -658,9 +652,6 @@ module mp_thompson
          ! guaranteed that nothing else in the same subcycle group
          ! was using these arrays, but it is somewhat dangerous.
 
-#if 0
-         if(istep==nsteps) then
-#endif
          !> - Convert water vapor mixing ratio back to specific humidity
          spechum = qv/(1.0_kind_phys+qv)
 
@@ -680,9 +671,7 @@ module mp_thompson
            end if
          end if
          ! *DH
-#if 0
-         endif
-#endif
+
          !> - Convert rainfall deltas from mm to m (on physics timestep); add to inout variables
          ! "rain" in Thompson MP refers to precipitation (total of liquid rainfall+snow+graupel+ice)
          prcp    = prcp    + max(0.0, delta_rain_mp/1000.0_kind_phys)


### PR DESCRIPTION
This PR fixes a bug where the incorrect (full) time step was passed down to Thompson MP instead of the time step for the subcycles. This should fix the decline in precipitation that the early testing has shown (to be confirmed).

Fixes https://github.com/NCAR/ccpp-physics/issues/686 .

## Testing

See https://github.com/ufs-community/ufs-weather-model/pull/670

## Dependencies

https://github.com/NCAR/ccpp-physics/pull/684
https://github.com/NOAA-EMC/fv3atm/pull/334
https://github.com/ufs-community/ufs-weather-model/pull/670