### PR TITLE
Coupling Merra2 aerosol climatology  and GOCART forecasted aerosol with Thompson microphysics

### DIFF
--- a/physics/GFS_PBL_generic.F90
+++ b/physics/GFS_PBL_generic.F90
@@ -11,10 +11,10 @@
 
       contains
 
-      subroutine set_aerosol_tracer_index(imp_physics, imp_physics_wsm6,          &
-                                          imp_physics_thompson, ltaerosol,        &
-                                          imp_physics_mg, ntgl, imp_physics_gfdl, &
-                                          imp_physics_zhao_carr, kk,              &
+      subroutine set_aerosol_tracer_index(imp_physics, imp_physics_wsm6,                &
+                                          imp_physics_thompson, ltaerosol,mraeorosol,   &
+                                          imp_physics_mg, ntgl, imp_physics_gfdl,       &
+                                          imp_physics_zhao_carr, kk,                    &
                                           errmsg, errflg)
       implicit none
       !
@@ -22,7 +22,7 @@
                                        imp_physics_thompson,                   &
                                        imp_physics_mg, ntgl, imp_physics_gfdl, &
                                        imp_physics_zhao_carr
-      logical, intent(in )          :: ltaerosol
+      logical, intent(in )          :: ltaerosol, mraerosol
       integer, intent(out)          :: kk
       character(len=*), intent(out) :: errmsg
       integer, intent(out)          :: errflg
@@ -37,6 +37,8 @@
 ! Thompson
         if(ltaerosol) then
           kk = 10
+        else if(mraerosol) then
+          kk = 8
         else
           kk = 7
         endif
@@ -79,12 +81,12 @@
 !! \section arg_table_GFS_PBL_generic_pre_run Argument Table
 !! \htmlinclude GFS_PBL_generic_pre_run.html
 !!
-      subroutine GFS_PBL_generic_pre_run (im, levs, nvdiff, ntrac, rtg_ozone_index,      &
-        ntqv, ntcw, ntiw, ntrw, ntsw, ntlnc, ntinc, ntrnc, ntsnc, ntgnc,                 &
-        ntwa, ntia, ntgl, ntoz, ntke, ntkev, nqrimef, trans_aero, ntchs, ntchm,          &
-        imp_physics, imp_physics_gfdl, imp_physics_thompson, imp_physics_wsm6,           &
-        imp_physics_zhao_carr, imp_physics_mg, imp_physics_fer_hires, ltaerosol, &
-        hybedmf, do_shoc, satmedmf, qgrs, vdftra, save_u, save_v, save_t, save_q,        &
+      subroutine GFS_PBL_generic_pre_run (im, levs, nvdiff, ntrac, rtg_ozone_index,         &
+        ntqv, ntcw, ntiw, ntrw, ntsw, ntlnc, ntinc, ntrnc, ntsnc, ntgnc,                    &
+        ntwa, ntia, ntgl, ntoz, ntke, ntkev, nqrimef, trans_aero, ntchs, ntchm,             &
+        imp_physics, imp_physics_gfdl, imp_physics_thompson, imp_physics_wsm6,              &
+        imp_physics_zhao_carr, imp_physics_mg, imp_physics_fer_hires, ltaerosol, mraerosol, &
+        hybedmf, do_shoc, satmedmf, qgrs, vdftra, save_u, save_v, save_t, save_q,           &
         flag_for_pbl_generic_tend, ldiag3d, qdiag3d, lssav, ugrs, vgrs, tgrs, errmsg, errflg)
         
       use machine,                only : kind_phys
@@ -101,6 +103,7 @@
       integer, intent(in) :: imp_physics, imp_physics_gfdl, imp_physics_thompson, imp_physics_wsm6
       integer, intent(in) :: imp_physics_zhao_carr, imp_physics_mg, imp_physics_fer_hires
       logical, intent(in) :: ltaerosol, hybedmf, do_shoc, satmedmf, flag_for_pbl_generic_tend
+      logical, intent(in) :: mraerosol
 
       real(kind=kind_phys), dimension(:,:,:), intent(in) :: qgrs
       real(kind=kind_phys), dimension(:,:), intent(in) :: ugrs, vgrs, tgrs
@@ -173,6 +176,22 @@
               enddo
             enddo
             rtg_ozone_index = 10
+          elseif(ltaerosol) then
+            do k=1,levs
+              do i=1,im
+                vdftra(i,k,1)  = qgrs(i,k,ntqv)
+                vdftra(i,k,2)  = qgrs(i,k,ntcw)
+                vdftra(i,k,3)  = qgrs(i,k,ntiw)
+                vdftra(i,k,4)  = qgrs(i,k,ntrw)
+                vdftra(i,k,5)  = qgrs(i,k,ntsw)
+                vdftra(i,k,6)  = qgrs(i,k,ntgl)
+                vdftra(i,k,7)  = qgrs(i,k,ntlnc)
+                vdftra(i,k,8)  = qgrs(i,k,ntinc)
+                vdftra(i,k,9)  = qgrs(i,k,ntrnc)
+                vdftra(i,k,10) = qgrs(i,k,ntoz)
+              enddo
+            enddo
+            rtg_ozone_index = 8
           else
             do k=1,levs
               do i=1,im
@@ -253,10 +272,10 @@
         endif
 !
         if (trans_aero) then
-          call set_aerosol_tracer_index(imp_physics, imp_physics_wsm6,          &
-                                        imp_physics_thompson, ltaerosol,        &
-                                        imp_physics_mg, ntgl, imp_physics_gfdl, &
-                                        imp_physics_zhao_carr, kk,              &
+          call set_aerosol_tracer_index(imp_physics, imp_physics_wsm6,             &
+                                        imp_physics_thompson, ltaerosol,mraerosol, &
+                                        imp_physics_mg, ntgl, imp_physics_gfdl,    &
+                                        imp_physics_zhao_carr, kk,                 &
                                         errmsg, errflg)
           if (errflg /= 0) return
           !
@@ -329,7 +348,7 @@
         trans_aero, ntchs, ntchm,                                                                                              &
         imp_physics, imp_physics_gfdl, imp_physics_thompson, imp_physics_wsm6, imp_physics_zhao_carr, imp_physics_mg,          &
         imp_physics_fer_hires,                                                                                                 &
-        ltaerosol, cplflx, cplchm, lssav, flag_for_pbl_generic_tend, ldiag3d, lsidea, hybedmf, do_shoc, satmedmf,              &
+        ltaerosol, mraerosol, cplflx, cplchm, lssav, flag_for_pbl_generic_tend, ldiag3d, lsidea, hybedmf, do_shoc, satmedmf,   &
         shinhong, do_ysu, dvdftra, dusfc1, dvsfc1, dtsfc1, dqsfc1, dtf, dudt, dvdt, dtdt, htrsw, htrlw, xmu,                   &
         dqdt, dusfc_cpl, dvsfc_cpl, dtsfc_cpl, dtend, dtidx, index_of_temperature, index_of_x_wind, index_of_y_wind,           &
         index_of_process_pbl, dqsfc_cpl, dusfci_cpl, dvsfci_cpl, dtsfci_cpl, dqsfci_cpl, dusfc_diag, dvsfc_diag, dtsfc_diag,   &
@@ -349,7 +368,7 @@
       logical, intent(in) :: trans_aero
       integer, intent(in) :: imp_physics, imp_physics_gfdl, imp_physics_thompson, imp_physics_wsm6
       integer, intent(in) :: imp_physics_zhao_carr, imp_physics_mg, imp_physics_fer_hires
-      logical, intent(in) :: ltaerosol, cplflx, cplchm, lssav, ldiag3d, lsidea
+      logical, intent(in) :: ltaerosol, cplflx, cplchm, lssav, ldiag3d, lsidea, mraerosol
       logical, intent(in) :: hybedmf, do_shoc, satmedmf, shinhong, do_ysu
 
       logical, intent(in) :: flag_for_pbl_generic_tend      
@@ -416,10 +435,10 @@
 !
         if (trans_aero) then
           ! Set kk if chemistry-aerosol tracers are diffused
-          call set_aerosol_tracer_index(imp_physics, imp_physics_wsm6,          &
-                                        imp_physics_thompson, ltaerosol,        &
-                                        imp_physics_mg, ntgl, imp_physics_gfdl, &
-                                        imp_physics_zhao_carr, kk,              &
+          call set_aerosol_tracer_index(imp_physics, imp_physics_wsm6,             &
+                                        imp_physics_thompson, ltaerosol,mraerosol, &
+                                        imp_physics_mg, ntgl, imp_physics_gfdl,    &
+                                        imp_physics_zhao_carr, kk,                 &
                                         errmsg, errflg)
           if (errflg /= 0) return
           !
@@ -475,6 +494,21 @@
                 dqdt(i,k,ntoz)  = dvdftra(i,k,10)
                 dqdt(i,k,ntwa)  = dvdftra(i,k,11)
                 dqdt(i,k,ntia)  = dvdftra(i,k,12)
+              enddo
+            enddo
+          else if(mraerosol) then
+            do k=1,levs
+              do i=1,im
+                dqdt(i,k,ntqv)  = dvdftra(i,k,1)
+                dqdt(i,k,ntcw)  = dvdftra(i,k,2)
+                dqdt(i,k,ntiw)  = dvdftra(i,k,3)
+                dqdt(i,k,ntrw)  = dvdftra(i,k,4)
+                dqdt(i,k,ntsw)  = dvdftra(i,k,5)
+                dqdt(i,k,ntgl)  = dvdftra(i,k,6)
+                dqdt(i,k,ntlnc) = dvdftra(i,k,7)
+                dqdt(i,k,ntinc) = dvdftra(i,k,8)
+                dqdt(i,k,ntrnc) = dvdftra(i,k,9)
+                dqdt(i,k,ntoz)  = dvdftra(i,k,10)
               enddo
             enddo
           else

--- a/physics/GFS_PBL_generic.meta
+++ b/physics/GFS_PBL_generic.meta
@@ -271,6 +271,14 @@
   type = logical
   intent = in
   optional = F
+[mraerosol]
+  standard_name = flag_for_merra2_aerosol_aware_for_thompson
+  long_name = flag for merra2 aerosol-aware physics for thompson microphysics
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
 [hybedmf]
   standard_name = flag_for_hybrid_edmf_pbl_scheme
   long_name = flag for hybrid edmf pbl scheme (moninedmf)
@@ -687,6 +695,14 @@
 [ltaerosol]
   standard_name = flag_for_aerosol_physics
   long_name = flag for aerosol physics
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[mraerosol]
+  standard_name = flag_for_merra2_aerosol_aware_for_thompson
+  long_name = flag for merra2 aerosol-aware physics for thompson microphysics
   units = flag
   dimensions = ()
   type = logical

--- a/physics/GFS_rrtmgp_lw_post.meta
+++ b/physics/GFS_rrtmgp_lw_post.meta
@@ -172,7 +172,7 @@
   intent = in
   optional = F
 [cldtaulw]
-  standard_name = RRTMGP_cloud_optical_depth_layers_at_10mu_band
+  standard_name = cloud_optical_depth_layers_at_10mu_band
   long_name = approx 10mu band layer cloud optical depth
   units = none
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)

--- a/physics/GFS_rrtmgp_sw_post.meta
+++ b/physics/GFS_rrtmgp_sw_post.meta
@@ -234,7 +234,7 @@
   intent = in
   optional = F
 [cldtausw]
-  standard_name = RRTMGP_cloud_optical_depth_layers_at_0_55mu_band
+  standard_name = cloud_optical_depth_layers_at_0p55mu_band
   long_name = approx .55mu band layer cloud optical depth
   units = none
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)

--- a/physics/drag_suite.meta
+++ b/physics/drag_suite.meta
@@ -5,7 +5,7 @@
 
 ########################################################################
 [ccpp-arg-table]
-  name = unified_ugwp_init
+  name = drag_suite_init
   type = scheme
 [gwd_opt]
   standard_name = control_for_drag_suite_gravity_wave_drag
@@ -720,4 +720,3 @@
   type = integer
   intent = out
   optional = F
-

--- a/physics/module_mp_thompson.F90
+++ b/physics/module_mp_thompson.F90
@@ -980,6 +980,7 @@ MODULE module_mp_thompson
                               refl_10cm, diagflag, do_radar_ref,      &
                               vt_dbz_wt, first_time_step,             &
                               re_cloud, re_ice, re_snow,              &
+                              iccn, iaerclm,                          &
                               has_reqc, has_reqi, has_reqs,           &
                               rand_perturb_on,                        &
                               kme_stoch,                              &
@@ -1046,6 +1047,9 @@ MODULE module_mp_thompson
       REAL, DIMENSION(ims:ime, kms:kme, jms:jme), OPTIONAL, INTENT(INOUT):: &
                           vt_dbz_wt
       LOGICAL, INTENT(IN) :: first_time_step
+      integer, intent(in   ) :: iccn
+      logical, intent(in   ) :: iaerclm
+
       REAL, INTENT(IN):: dt_in, dt_inner
       ! To support subcycling: current step and maximum number of steps
       INTEGER, INTENT (IN) :: istep, nsteps
@@ -1107,6 +1111,7 @@ MODULE module_mp_thompson
       LOGICAL, OPTIONAL, INTENT(IN) :: diagflag
       INTEGER, OPTIONAL, INTENT(IN) :: do_radar_ref
       logical :: melti = .false.
+      logical :: merra2_aerosol_aware
       INTEGER :: ndt, it
 
       ! CCPP error handling
@@ -1151,7 +1156,7 @@ MODULE module_mp_thompson
                stop
             end if
          end if
-   
+         if(iccn == 3 .and. iaerclm) merra2_aerosol_aware=.true.
          if (is_aerosol_aware .and. (.not.present(nc)     .or. &
                                      .not.present(nwfa)   .or. &
                                      .not.present(nifa)   .or. &

--- a/physics/mp_thompson.F90
+++ b/physics/mp_thompson.F90
@@ -108,9 +108,6 @@ module mp_thompson
          errflg = 0
 
          if (is_initialized) return
-         if(iccn == 3 .and. iaerclm) then
-           call get_niwfa(aerfld, nifa, nwfa, ncol, nlev)
-         end if
          ! Consistency checks
          if (imp_physics/=imp_physics_thompson) then
             write(errmsg,'(*(a))') "Logic error: namelist choice of microphysics is different from Thompson MP"
@@ -124,6 +121,9 @@ module mp_thompson
                errflg = 1
                return
             end if
+         end if
+         if(iccn == 3 .and. iaerclm) then
+           call get_niwfa(aerfld, nifa, nwfa, ncol, nlev)
          end if
 
          ! Call Thompson init
@@ -952,6 +952,7 @@ module mp_thompson
          is_initialized = .false.
 
       end subroutine mp_thompson_finalize
+
       subroutine get_niwfa(aerfld, nifa, nwfa, ncol, nlev)
         implicit none
         integer, intent(in)::ncol, nlev

--- a/physics/mp_thompson.meta
+++ b/physics/mp_thompson.meta
@@ -270,22 +270,6 @@
   kind = kind_phys
   intent = out
   optional = T
-[iccn]
-  standard_name = control_for_ice_cloud_condensation_nuclei_forcing
-  long_name = flag for IN and CCN forcing for morrison gettelman microphysics
-  units = none
-  dimensions = ()
-  type = integer
-  intent = in
-  optional = F
-[iaerclm]
-  standard_name = flag_for_aerosol_input_MG_radiation
-  long_name = flag for using aerosols in Morrison-Gettelman MP_radiation
-  units = flag
-  dimensions = ()
-  type = logical
-  intent = in
-  optional = F
 [aerfld]
   standard_name = mass_number_concentration_of_aerosol_from_gocart_climatology
   long_name = GOCART aerosol climatology number concentration
@@ -492,6 +476,14 @@
 [is_aerosol_aware]
   standard_name = flag_for_aerosol_physics
   long_name = flag for aerosol-aware physics
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[is_aerosol_aware]
+  standard_name = flag_for_merra2_aerosol_aware_for_thompson
+  long_name = flag for merra2 aerosol-aware physics
   units = flag
   dimensions = ()
   type = logical
@@ -726,22 +718,6 @@
   kind = kind_phys
   intent = out
   optional = T
-[iccn]
-  standard_name = control_for_ice_cloud_condensation_nuclei_forcing
-  long_name = flag for IN and CCN forcing for morrison gettelman microphysics
-  units = none
-  dimensions = ()
-  type = integer
-  intent = in
-  optional = F
-[iaerclm]
-  standard_name = flag_for_aerosol_input_MG_radiation
-  long_name = flag for using aerosols in Morrison-Gettelman MP_radiation
-  units = flag
-  dimensions = ()
-  type = logical
-  intent = in
-  optional = F
 [aerfld]
   standard_name = mass_number_concentration_of_aerosol_from_gocart_climatology
   long_name = GOCART aerosol climatology number concentration

--- a/physics/mp_thompson.meta
+++ b/physics/mp_thompson.meta
@@ -271,7 +271,7 @@
   intent = out
   optional = T
 [iccn]
-  standard_name = flag_for_in_ccn_forcing_for_morrison_gettelman_microphysics
+  standard_name = control_for_ice_cloud_condensation_nuclei_forcing
   long_name = flag for IN and CCN forcing for morrison gettelman microphysics
   units = none
   dimensions = ()
@@ -287,10 +287,10 @@
   intent = in
   optional = F
 [aerfld]
-  standard_name = aerosol_number_concentration_from_gocart_aerosol_climatology
+  standard_name = mass_number_concentration_of_aerosol_from_gocart_climatology
   long_name = GOCART aerosol climatology number concentration
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_aerosol_tracers_MG)
+  dimensions = (horizontal_dimension,vertical_layer_dimension,number_of_aerosol_tracers_MG)
   type = real
   kind = kind_phys
   intent = in
@@ -727,7 +727,7 @@
   intent = out
   optional = T
 [iccn]
-  standard_name = flag_for_in_ccn_forcing_for_morrison_gettelman_microphysics
+  standard_name = control_for_ice_cloud_condensation_nuclei_forcing
   long_name = flag for IN and CCN forcing for morrison gettelman microphysics
   units = none
   dimensions = ()
@@ -743,10 +743,10 @@
   intent = in
   optional = F
 [aerfld]
-  standard_name = aerosol_number_concentration_from_gocart_aerosol_climatology
+  standard_name = mass_number_concentration_of_aerosol_from_gocart_climatology
   long_name = GOCART aerosol climatology number concentration
   units = kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_aerosol_tracers_MG)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_aerosol_tracers_MG)
   type = real
   kind = kind_phys
   intent = in

--- a/physics/mp_thompson.meta
+++ b/physics/mp_thompson.meta
@@ -270,6 +270,31 @@
   kind = kind_phys
   intent = out
   optional = T
+[iccn]
+  standard_name = flag_for_in_ccn_forcing_for_morrison_gettelman_microphysics
+  long_name = flag for IN and CCN forcing for morrison gettelman microphysics
+  units = none
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[iaerclm]
+  standard_name = flag_for_aerosol_input_MG_radiation
+  long_name = flag for using aerosols in Morrison-Gettelman MP_radiation
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[aerfld]
+  standard_name = aerosol_number_concentration_from_gocart_aerosol_climatology
+  long_name = GOCART aerosol climatology number concentration
+  units = kg-1
+  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_aerosol_tracers_MG)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
 [mpicomm]
   standard_name = mpi_communicator
   long_name = MPI communicator
@@ -701,6 +726,31 @@
   kind = kind_phys
   intent = out
   optional = T
+[iccn]
+  standard_name = flag_for_in_ccn_forcing_for_morrison_gettelman_microphysics
+  long_name = flag for IN and CCN forcing for morrison gettelman microphysics
+  units = none
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[iaerclm]
+  standard_name = flag_for_aerosol_input_MG_radiation
+  long_name = flag for using aerosols in Morrison-Gettelman MP_radiation
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[aerfld]
+  standard_name = aerosol_number_concentration_from_gocart_aerosol_climatology
+  long_name = GOCART aerosol climatology number concentration
+  units = kg-1
+  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_aerosol_tracers_MG)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
 [mpicomm]
   standard_name = mpi_communicator
   long_name = MPI communicator

--- a/physics/radlw_param.meta
+++ b/physics/radlw_param.meta
@@ -19,6 +19,16 @@
 
 ########################################################################
 [ccpp-table-properties]
+  name = proflw_type
+  type = ddt
+  dependencies = 
+
+[ccpp-arg-table]
+  name = proflw_type
+  type = ddt
+
+########################################################################
+[ccpp-table-properties]
   name = module_radlw_parameters
   type = module
   dependencies = 

--- a/physics/radsw_param.f
+++ b/physics/radsw_param.f
@@ -94,6 +94,9 @@
       end type sfcfsw_type
 !
 !> derived type for SW fluxes' column profiles (at layer interfaces)
+!! \section arg_table_profsw_type
+!! \htmlinclude profsw_type.html
+!!
       type profsw_type
         real (kind=kind_phys) :: upfxc      !< total-sky upward flux
         real (kind=kind_phys) :: dnfxc      !< total-sky downward flux

--- a/physics/radsw_param.meta
+++ b/physics/radsw_param.meta
@@ -29,6 +29,16 @@
 
 ########################################################################
 [ccpp-table-properties]
+  name = profsw_type
+  type = ddt
+  dependencies = 
+
+[ccpp-arg-table]
+  name = profsw_type
+  type = ddt
+
+########################################################################
+[ccpp-table-properties]
   name = module_radsw_parameters
   type = module
   dependencies = 

--- a/physics/rrtmgp_lw_cloud_optics.meta
+++ b/physics/rrtmgp_lw_cloud_optics.meta
@@ -292,7 +292,7 @@
   intent = in
   optional = F
 [cldtaulw]
-  standard_name = RRTMGP_cloud_optical_depth_layers_at_10mu_band
+  standard_name = cloud_optical_depth_layers_at_10mu_band
   long_name = approx 10mu band layer cloud optical depth
   units = none
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)

--- a/physics/rrtmgp_sw_cloud_optics.meta
+++ b/physics/rrtmgp_sw_cloud_optics.meta
@@ -297,7 +297,7 @@
   intent = out
   optional = F  
 [cldtausw]
-  standard_name = RRTMGP_cloud_optical_depth_layers_at_0_55mu_band
+  standard_name = cloud_optical_depth_layers_at_0p55mu_band
   long_name = approx .55mu band layer cloud optical depth
   units = none
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)


### PR DESCRIPTION
MERRA2 climatological aerosols are used to calculate number concentrations of  ice friendly and liquid friendly aerosols. So IN and CCN can be activated using aerosol. The indirect interaction of aerosol and clouds is expected to happen. 