### PR TITLE
sfcsub.F land-mask bug fix

### DIFF
--- a/physics/sfcsub.F
+++ b/physics/sfcsub.F
@@ -2019,12 +2019,14 @@
 !    *,' tsffcs=',tsffcs(iprnt),' slianl=',slianl(iprnt)
 
       do i=1,len
+       if (nint(slmskl(i)) /= 1) then
         if (sicanl(i) >= min_ice(i)) then
           slianl(i) = 2.0_kind_io8
         else
           slianl(i) = zero
           sicanl(i) = zero
         endif
+       endif
       enddo
 
       if (fh-deltsfc > -0.001 ) then


### PR DESCRIPTION
Update a sea ice loop in sfcsub.F to only operate at non-land points (slmskl /= 1).

This fix was tested using the UFS_UTILS `global_cycle` program. That program is essentially a wrapper around the sfcsub.F module. Tested successfully using a canned C768 global case.

For more details, see #719 and https://github.com/NOAA-EMC/UFS_UTILS/issues/549#issuecomment-902251172