### PR TITLE
Metadata bugfixes following CCPP standard name updates

### DIFF
--- a/physics/GFS_DCNV_generic.meta
+++ b/physics/GFS_DCNV_generic.meta
@@ -267,7 +267,7 @@
   standard_name = convective_transportable_tracers
   long_name = array to contain cloud water and other convective trans. tracers
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_tracers_for_convective_transport)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_tracers_for_convective_transport)
   type = real
   kind = kind_phys
   intent = in
@@ -477,7 +477,7 @@
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
   units = various
-  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_cumulative_change_processes)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_cumulative_change_processes)
   type = real
   kind = kind_phys
   intent = inout
@@ -534,7 +534,7 @@
   standard_name = tracer_concentration_of_new_state
   long_name = tracer concentration updated by physics
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_tracers)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_tracers)
   type = real
   kind = kind_phys
   intent = in
@@ -543,7 +543,7 @@
   standard_name = tracer_concentration_save
   long_name = tracer concentration before entering a physics scheme
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_tracers)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_tracers)
   type = real
   kind = kind_phys
   intent = in
@@ -778,7 +778,7 @@
   standard_name = convective_transportable_tracers
   long_name = array to contain cloud water and other convective trans. tracers
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_tracers_for_convective_transport)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_tracers_for_convective_transport)
   type = real
   kind = kind_phys
   intent = in

--- a/physics/GFS_MP_generic.meta
+++ b/physics/GFS_MP_generic.meta
@@ -823,7 +823,7 @@
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
   units = various
-  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_cumulative_change_processes)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_cumulative_change_processes)
   type = real
   kind = kind_phys
   intent = inout
@@ -832,7 +832,7 @@
   standard_name = cumulative_change_of_state_variables_outer_index
   long_name = index of state-variable and process in last dimension of diagnostic tendencies array AKA cumulative_change_index
   units = index
-  dimensions = (number_of_tracers_plus_one_hundred,number_of_causes)
+  dimensions = (number_of_tracers_plus_one_hundred,number_of_cumulative_change_processes)
   type = integer
   intent = in
   optional = F

--- a/physics/GFS_PBL_generic.meta
+++ b/physics/GFS_PBL_generic.meta
@@ -820,7 +820,7 @@
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
   units = various
-  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_cumulative_change_processes)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_cumulative_change_processes)
   type = real
   kind = kind_phys
   intent = inout

--- a/physics/GFS_SCNV_generic.meta
+++ b/physics/GFS_SCNV_generic.meta
@@ -259,7 +259,7 @@
   standard_name = convective_transportable_tracers
   long_name = array to contain cloud water and other convective trans. tracers
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_tracers_for_convective_transport)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_tracers_for_convective_transport)
   type = real
   kind = kind_phys
   intent = in

--- a/physics/GFS_rrtmg_pre.meta
+++ b/physics/GFS_rrtmg_pre.meta
@@ -604,7 +604,7 @@
   standard_name = surface_stochastic_weights_from_coupled_process
   long_name = weights for stochastic surface physics perturbation
   units = none
-  dimensions = (horizontal_loop_extent,number_of_surface_perturbations)
+  dimensions = (horizontal_loop_extent,number_of_perturbed_land_surface_variables)
   type = real
   kind = kind_phys
   intent = in

--- a/physics/GFS_suite_interstitial.meta
+++ b/physics/GFS_suite_interstitial.meta
@@ -1605,7 +1605,7 @@
   standard_name = liquid_cloud_number_concentration_save
   long_name = liquid cloud number concentration before entering a physics scheme
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = inout
@@ -1614,7 +1614,7 @@
   standard_name = ice_cloud_number_concentration_save
   long_name = ice cloud number concentration before entering a physics scheme
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = inout
@@ -1886,7 +1886,7 @@
   standard_name = liquid_cloud_number_concentration_save
   long_name = liquid cloud number concentration before entering a physics scheme
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = in
@@ -1895,7 +1895,7 @@
   standard_name = ice_cloud_number_concentration_save
   long_name = ice cloud number concentration before entering a physics scheme
   units = kg kg-1
-  dimensions = (horizontal_loop_extent,vertical_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = in
@@ -1993,7 +1993,7 @@
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
   units = various
-  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_cumulative_change_processes)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_cumulative_change_processes)
   type = real
   kind = kind_phys
   intent = inout

--- a/physics/drag_suite.meta
+++ b/physics/drag_suite.meta
@@ -649,7 +649,7 @@
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
   units = various
-  dimensions = (horizontal_loop_extent,vertical_dimension,number_of_cumulative_change_processes)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_cumulative_change_processes)
   type = real
   kind = kind_phys
   active = (flag_for_diagnostics_3D)


### PR DESCRIPTION
This PR corrects a few standard names used in the `dimensions` attributes. The old/invalid standard names came in with the latest gsl/develop merge. They went unnoticed, because `ccpp_prebuild.py` until now doesn't care about the dimensions, just the rank. This is going to chance soon with the new debugging feature that checks if active variables/arrays are allocated to the correct size (a separate, forthcoming PR).

Fixes https://github.com/NCAR/ccpp-physics/issues/723

Associated PRs:

https://github.com/NCAR/ccpp-physics/pull/722
https://github.com/NOAA-EMC/fv3atm/pull/379
https://github.com/ufs-community/ufs-weather-model/pull/782

For regression testing, see https://github.com/ufs-community/ufs-weather-model/pull/782