### PR TITLE
fixed issue with decomp-change RT failures with ugwpv1 and made other…

### DIFF
--- a/physics/cires_ugwpv1_oro.F90
+++ b/physics/cires_ugwpv1_oro.F90
@@ -908,8 +908,8 @@ contains
          dudt_obl(j,k) = -dbim * u1(j,k)
          dvdt_obl(j,k) = -dbim * v1(j,k)
 	    	    
-         pdvdt(j,k) = dudt_obl(j,k) +pdvdt(j,k)
-         pdudt(j,k) = dvdt_obl(j,k) +pdudt(j,k)	         	        	    
+         pdudt(j,k) = dudt_obl(j,k) +pdudt(j,k)
+         pdvdt(j,k) = dvdt_obl(j,k) +pdvdt(j,k)	         	        	    
          du_oblcol(j)    = du_oblcol(j) + dudt_obl(j,k)* del(j,k)
          dv_oblcol(j)    = dv_oblcol(j) + dvdt_obl(j,k)* del(j,k)	    
          dusfc(j)   = dusfc(j) + du_oblcol(j)

--- a/physics/ugwpv1_gsldrag.F90
+++ b/physics/ugwpv1_gsldrag.F90
@@ -581,9 +581,9 @@ contains
 !      endif
 !     endif
 
-    else
+    endif
 !
-! not gsldrag oro-scheme for example "do_ugwp_v1_orog_only"
+! not gsldrag large-scale oro-scheme for example "do_ugwp_v1_orog_only"
 !
 
     if ( do_ugwp_v1_orog_only ) then
@@ -641,7 +641,6 @@ contains
          dtend(:,:,idtend) = dtend(:,:,idtend) + Pdtdt*dtp
       endif
     endif
-   ENDIF
 !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Begin non-stationary GW schemes


### PR DESCRIPTION
drag_suite.F90:
Substantial changes to fix problem of lack of reproducibility when changing the domain decomposition layout.  Basically, the problem was that the "scale aware" feature used the grid size "dx" at one representative point, i.e., dx(1).  This would of course vary depending on the domain decomposition.  The code was changed to test the value of "dx" at every grid point.  Associated with this change, the dimensionality of the following variables was changed:
1)  ss_taper, ls_taper from a scalar to a vector of dimension im.
2) dxy4, dxy4p from dimension (4) to dimension (im,4).

Instead of multiple loops over i, there is now only one loop over i per drag component, i.e., large-scale+blocking, ssGWD and form drag.

There was also a bug found in the semi-implicit time step treatment of the v-wind component of the SSGWD.  This was fixed.


cires_ugwpv1_oro.F90:
Fixed a bug in the calculation of the pdudt and pdvdt tendencies.


ugwpv1_gsldrag.F90:
Fixed a bug in the if-then logic beginning on line 536.  Changed "else" on line 584 to "endif".  The problem was that with the "else" statement, it was impossible to combine the small-scale GSL drag schemes (SSGWD and form drag) with the ugwpv1 orog_only drag scheme.

