### PR TITLE
SCM-only updates for latest main

### DIFF
--- a/physics/scm_sfc_flux_spec.F90
+++ b/physics/scm_sfc_flux_spec.F90
@@ -53,7 +53,7 @@ module scm_sfc_flux_spec
 !!  -# Calculate the surface drag coefficient for heat and moisture.
 !!  -# Calculate the u and v wind at 10m.
   subroutine scm_sfc_flux_spec_run (u1, v1, z1, t1, q1, p1, roughness_length, spec_sh_flux, spec_lh_flux, &
-    exner_inverse, T_surf, cp, grav, hvap, rd, fvirt, vonKarman, sh_flux, lh_flux, sh_flux_chs, lh_flux_chs, u_star, sfc_stress, cm, ch, &
+    exner_inverse, T_surf, cp, grav, hvap, rd, fvirt, vonKarman, sh_flux, lh_flux, sh_flux_chs, u_star, sfc_stress, cm, ch, &
     fm, fh, rb, u10m, v10m, wind1, qss, t2m, q2m, errmsg, errflg)
 
     use machine,             only: kind_phys
@@ -63,7 +63,7 @@ module scm_sfc_flux_spec
     real(kind=kind_phys), intent(in) :: cp, grav, hvap, rd, fvirt, vonKarman
     real(kind=kind_phys), intent(out) :: sh_flux(:), lh_flux(:), u_star(:), sfc_stress(:), &
       cm(:), ch(:), fm(:), fh(:), rb(:), u10m(:), v10m(:), wind1(:), qss(:), t2m(:), q2m(:), &
-      sh_flux_chs(:), lh_flux_chs(:)
+      sh_flux_chs(:)
 
     character(len=*), intent(out) :: errmsg
     integer,          intent(out) :: errflg
@@ -83,8 +83,7 @@ module scm_sfc_flux_spec
     sh_flux(i) = spec_sh_flux(i)
     lh_flux(i) = spec_lh_flux(i)
     sh_flux_chs(i) = sh_flux(i)
-    lh_flux_chs(i) = lh_flux(i)
-
+    
     roughness_length_m = 0.01*roughness_length(i)
 
     wind1(i) = sqrt(u1(i)*u1(i) + v1(i)*v1(i))

--- a/physics/scm_sfc_flux_spec.meta
+++ b/physics/scm_sfc_flux_spec.meta
@@ -182,8 +182,8 @@
   intent = in
   optional = F
 [vonKarman]
-  standard_name = vonKarman_constant
-  long_name = vonKarman constant
+  standard_name = von_karman_constant
+  long_name = Von Karman constant
   units = none
   dimensions = ()
   type = real
@@ -209,18 +209,9 @@
   intent = out
   optional = F
 [sh_flux_chs]
-  standard_name = kinematic_surface_upward_sensible_heat_flux_reduced_by_surface_roughness
-  long_name = kinematic surface upward sensible heat flux reduced by surface roughness
+  standard_name = kinematic_surface_upward_sensible_heat_flux_reduced_by_surface_roughness_and_vegetation
+  long_name = kinematic surface upward sensible heat flux reduced by surface roughness and vegetation
   units = K m s-1
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = out
-  optional = F
-[lh_flux_chs]
-  standard_name = surface_upward_specific_humidity_flux_reduced_by_surface_roughness
-  long_name = kinematic surface upward latent heat flux reduced by surface roughness
-  units = kg kg-1 m s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys


### PR DESCRIPTION
This PR is a followup to #665 and #717.

Since this only affects the SCM, UFS regression tests should not be required. These changes have passed the SCM regression tests with bit-for-bit output.

Associated PR: https://github.com/NCAR/ccpp-scm/pull/272

Replaces #678.