### PR TITLE
restart fix for NoahMP and changes from PR#731

### DIFF
--- a/physics/GFS_surface_composites.F90
+++ b/physics/GFS_surface_composites.F90
@@ -160,7 +160,7 @@ contains
                 ! when cplflx is .true. (e.g., for the S2S application).
                 ! Whereas, for the HAFS FV3ATM-HYCOM coupling, cplice is set as
                 ! .false.. In the future HAFS FV3ATM-MOM6 coupling, the cplflx
-                ! could be .true., while cplice being .false.. 
+                ! could be .true., while cplice being .false..
                 if (cplice .and. cplflx)  then
                   islmsk_cice(i) = 4
                   flag_cice(i)   = .true.
@@ -229,7 +229,8 @@ contains
           uustar_lnd(i) = uustar(i)
            weasd_lnd(i) = weasd(i)
            tsurf_lnd(i) = tsfcl(i)
-          if (iemsflg == 2 .and. .not. flag_init) then
+          !if (iemsflg == 2 .and. .not. flag_init) then
+          if (iemsflg == 2 .and. (.not.flag_init .or. flag_restart)) then
            !-- use land emissivity from the LSM
            semis_lnd(i) = emis_lnd(i)
           else
@@ -455,7 +456,7 @@ contains
         fh2, cmm, chh, gflx, ep1d, weasd, snowd, tprcp, evap, hflx, qss, tsfc, tsfco, tsfcl, tisfc
 
       real(kind=kind_phys), dimension(:),   intent(inout) :: hice, cice
-      real(kind=kind_phys), dimension(:),   intent(inout) :: sigmaf, zvfun, hflxq, hffac                  
+      real(kind=kind_phys), dimension(:),   intent(inout) :: sigmaf, zvfun, hflxq, hffac
       real(kind=kind_phys),                 intent(in   ) :: h0facu, h0facs
       real(kind=kind_phys),                 intent(in   ) :: min_seaice
       real(kind=kind_phys),                 intent(in   ) :: rd, rvrdm1
@@ -613,7 +614,7 @@ contains
             endif
 !
             call stability(z1(i), zvfun(i), gdx, tv1, thv1, wind(i),                & ! inputs
-                           z0max, ztmax, tvs, grav, thsfc_loc,                      & ! inputs          
+                           z0max, ztmax, tvs, grav, thsfc_loc,                      & ! inputs
                            rb(i), ffmm(i), ffhh(i), fm10(i), fh2(i), cd(i), cdq(i), & ! outputs
                            stress(i), uustar(i))
           endif ! Checking to see if point is one or multiple surface types

--- a/physics/GFS_surface_composites.F90
+++ b/physics/GFS_surface_composites.F90
@@ -229,7 +229,6 @@ contains
           uustar_lnd(i) = uustar(i)
            weasd_lnd(i) = weasd(i)
            tsurf_lnd(i) = tsfcl(i)
-          !if (iemsflg == 2 .and. .not. flag_init) then
           if (iemsflg == 2 .and. (.not.flag_init .or. flag_restart)) then
            !-- use land emissivity from the LSM
            semis_lnd(i) = emis_lnd(i)

--- a/physics/scm_sfc_flux_spec.F90
+++ b/physics/scm_sfc_flux_spec.F90
@@ -53,7 +53,7 @@ module scm_sfc_flux_spec
 !!  -# Calculate the surface drag coefficient for heat and moisture.
 !!  -# Calculate the u and v wind at 10m.
   subroutine scm_sfc_flux_spec_run (u1, v1, z1, t1, q1, p1, roughness_length, spec_sh_flux, spec_lh_flux, &
-    exner_inverse, T_surf, cp, grav, hvap, rd, fvirt, vonKarman, sh_flux, lh_flux, sh_flux_chs, lh_flux_chs, u_star, sfc_stress, cm, ch, &
+    exner_inverse, T_surf, cp, grav, hvap, rd, fvirt, vonKarman, sh_flux, lh_flux, sh_flux_chs, u_star, sfc_stress, cm, ch, &
     fm, fh, rb, u10m, v10m, wind1, qss, t2m, q2m, errmsg, errflg)
 
     use machine,             only: kind_phys
@@ -63,7 +63,7 @@ module scm_sfc_flux_spec
     real(kind=kind_phys), intent(in) :: cp, grav, hvap, rd, fvirt, vonKarman
     real(kind=kind_phys), intent(out) :: sh_flux(:), lh_flux(:), u_star(:), sfc_stress(:), &
       cm(:), ch(:), fm(:), fh(:), rb(:), u10m(:), v10m(:), wind1(:), qss(:), t2m(:), q2m(:), &
-      sh_flux_chs(:), lh_flux_chs(:)
+      sh_flux_chs(:)
 
     character(len=*), intent(out) :: errmsg
     integer,          intent(out) :: errflg
@@ -83,8 +83,7 @@ module scm_sfc_flux_spec
     sh_flux(i) = spec_sh_flux(i)
     lh_flux(i) = spec_lh_flux(i)
     sh_flux_chs(i) = sh_flux(i)
-    lh_flux_chs(i) = lh_flux(i)
-
+    
     roughness_length_m = 0.01*roughness_length(i)
 
     wind1(i) = sqrt(u1(i)*u1(i) + v1(i)*v1(i))

--- a/physics/scm_sfc_flux_spec.meta
+++ b/physics/scm_sfc_flux_spec.meta
@@ -182,8 +182,8 @@
   intent = in
   optional = F
 [vonKarman]
-  standard_name = vonKarman_constant
-  long_name = vonKarman constant
+  standard_name = von_karman_constant
+  long_name = Von Karman constant
   units = none
   dimensions = ()
   type = real
@@ -209,18 +209,9 @@
   intent = out
   optional = F
 [sh_flux_chs]
-  standard_name = kinematic_surface_upward_sensible_heat_flux_reduced_by_surface_roughness
-  long_name = kinematic surface upward sensible heat flux reduced by surface roughness
+  standard_name = kinematic_surface_upward_sensible_heat_flux_reduced_by_surface_roughness_and_vegetation
+  long_name = kinematic surface upward sensible heat flux reduced by surface roughness and vegetation
   units = K m s-1
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = out
-  optional = F
-[lh_flux_chs]
-  standard_name = surface_upward_specific_humidity_flux_reduced_by_surface_roughness
-  long_name = kinematic surface upward latent heat flux reduced by surface roughness
-  units = kg kg-1 m s-1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys


### PR DESCRIPTION
1) A one line fix for NoahMP restart reproducibility for the coupled P7 configuration is added.
2) SCM-only updates from CCPP PR#731

Related PRs:

- ufs-weather-model [PR#819](https://github.com/ufs-community/ufs-weather-model/pull/819)
- fv3atm [PR#391](https://github.com/NOAA-EMC/fv3atm/pull/391)
- CCPP physics [PR#732](https://github.com/NCAR/ccpp-physics/pull/732)
- Stochastic physics [PR#46](https://github.com/noaa-psd/stochastic_physics/pull/46) 