### PR TITLE
Bugfixes for RRTMGP

### DIFF
--- a/physics/GFS_cloud_diagnostics.meta
+++ b/physics/GFS_cloud_diagnostics.meta
@@ -57,9 +57,9 @@
   intent = in
   optional = F
 [p_lay]
-  standard_name = air_pressure_at_layer_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_layer_for_RRTMGP
   long_name = air pressure at vertical layer for radiation calculation
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
@@ -75,9 +75,9 @@
   intent = in
   optional = F 
 [p_lev]
-  standard_name = air_pressure_at_interface_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_interface_for_RRTMGP
   long_name = air pressure at vertical interface for radiation calculation
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys

--- a/physics/GFS_rrtmgp_cloud_overlap_pre.meta
+++ b/physics/GFS_rrtmgp_cloud_overlap_pre.meta
@@ -66,18 +66,18 @@
   kind = kind_phys 
   optional = F     
 [p_lev]
-  standard_name = air_pressure_at_interface_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_interface_for_RRTMGP
   long_name = air pressure at vertical interface for radiation calculation
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys
   intent = in
   optional = F
 [p_lay]
-  standard_name = air_pressure_at_layer_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_layer_for_RRTMGP
   long_name = air pressure at vertical layer for radiation calculation
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys

--- a/physics/GFS_rrtmgp_gfdlmp_pre.meta
+++ b/physics/GFS_rrtmgp_gfdlmp_pre.meta
@@ -128,18 +128,18 @@
   intent = in
   optional = F
 [p_lev]
-  standard_name = air_pressure_at_interface_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_interface_for_RRTMGP
   long_name = air pressure at vertical interface for radiation calculation
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys
   intent = in
   optional = F
 [p_lay]
-  standard_name = air_pressure_at_layer_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_layer_for_RRTMGP
   long_name = air pressure at vertical layer for radiation calculation
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys

--- a/physics/GFS_rrtmgp_lw_post.meta
+++ b/physics/GFS_rrtmgp_lw_post.meta
@@ -75,9 +75,9 @@
   intent = in
   optional = F  
 [p_lev]
-  standard_name = air_pressure_at_interface_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_interface_for_RRTMGP
   long_name = air pressure level
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys

--- a/physics/GFS_rrtmgp_pre.F90
+++ b/physics/GFS_rrtmgp_pre.F90
@@ -98,9 +98,9 @@ contains
 !!
   subroutine GFS_rrtmgp_pre_run(nCol, nLev, nTracers, i_o3, lsswr, lslwr, fhswr, fhlwr,     &
        xlat, xlon,  prsl, tgrs, prslk, prsi, qgrs, tsfc, con_eps, con_epsm1, con_fvirt,     &
-       con_epsqs, minGPpres, minGPtemp, raddt, p_lay, t_lay, p_lev, t_lev, tsfg, tsfa,      & 
-       qs_lay, q_lay, tv_lay, relhum, tracer, gas_concentrations, tsfc_radtime, errmsg,     &
-       errflg)
+       con_epsqs, minGPpres, maxGPpres, minGPtemp, maxGPtemp, raddt, p_lay, t_lay, p_lev,   &
+       t_lev, tsfg, tsfa, qs_lay, q_lay, tv_lay, relhum, tracer, gas_concentrations,        &
+       tsfc_radtime, errmsg, errflg)
     
     ! Inputs   
     integer, intent(in)    :: &
@@ -113,7 +113,9 @@ contains
     	 lslwr                ! Call LW radiation
     real(kind_phys), intent(in) :: &
          minGPtemp,         & ! Minimum temperature allowed in RRTMGP.
+         maxGPtemp,         & ! Maximum ...
          minGPpres,         & ! Minimum pressure allowed in RRTMGP.
+         maxGPpres,         & ! Maximum pressure allowed in RRTMGP. 
          fhswr,             & ! Frequency of SW radiation call.
          fhlwr                ! Frequency of LW radiation call.
     real(kind_phys), intent(in) :: &
@@ -204,11 +206,20 @@ contains
     ! Temperature at layer-center
     t_lay(1:NCOL,:) = tgrs(1:NCOL,:)
 
-    ! Bound temperature at layer centers.
+    ! Bound temperature/pressure at layer centers.
     do iCol=1,NCOL
        do iLay=1,nLev
           if (t_lay(iCol,iLay) .le. minGPtemp) then
              t_lay(iCol,iLay) = minGPtemp + epsilon(minGPtemp)
+          endif
+          if (p_lay(iCol,iLay) .le. minGPpres) then
+             p_lay(iCol,iLay) = minGPpres + epsilon(minGPpres)
+          endif
+          if (t_lay(iCol,iLay) .ge. maxGPtemp) then
+             t_lay(iCol,iLay) = maxGPtemp - epsilon(maxGPtemp)
+          endif
+          if (p_lay(iCol,iLay) .ge. maxGPpres) then
+             p_lay(iCol,iLay) = maxGPpres - epsilon(maxGPpres)
           endif
        enddo
     enddo

--- a/physics/GFS_rrtmgp_pre.F90
+++ b/physics/GFS_rrtmgp_pre.F90
@@ -211,19 +211,15 @@ contains
        do iLay=1,nLev
           if (t_lay(iCol,iLay) .le. minGPtemp) then
              t_lay(iCol,iLay) = minGPtemp + epsilon(minGPtemp)
-             error_msg = "WARNING: GFS_rrtmgp_pre(), array t_lay has values outside range. Enforce lower temperature limit"
           endif
           if (p_lay(iCol,iLay) .le. minGPpres) then
              p_lay(iCol,iLay) = minGPpres + epsilon(minGPpres)
-             error_msg = "WARNING: GFS_rrtmgp_pre(), array p_lay has values outside range. Enforce lower pressure limit"
           endif
           if (t_lay(iCol,iLay) .ge. maxGPtemp) then
              t_lay(iCol,iLay) = maxGPtemp - epsilon(maxGPtemp)
-             error_msg = "WARNING: GFS_rrtmgp_pre(), array t_lay has values outside range. Enforce upper temperature limit"
           endif
           if (p_lay(iCol,iLay) .ge. maxGPpres) then
              p_lay(iCol,iLay) = maxGPpres - epsilon(maxGPpres)
-             error_msg = "WARNING: GFS_rrtmgp_pre(), array p_lay has values outside range. Enforce upper pressure limit"
           endif
        enddo
     enddo

--- a/physics/GFS_rrtmgp_pre.F90
+++ b/physics/GFS_rrtmgp_pre.F90
@@ -211,15 +211,19 @@ contains
        do iLay=1,nLev
           if (t_lay(iCol,iLay) .le. minGPtemp) then
              t_lay(iCol,iLay) = minGPtemp + epsilon(minGPtemp)
+             error_msg = "WARNING: GFS_rrtmgp_pre(), array t_lay has values outside range. Enforce lower temperature limit"
           endif
           if (p_lay(iCol,iLay) .le. minGPpres) then
              p_lay(iCol,iLay) = minGPpres + epsilon(minGPpres)
+             error_msg = "WARNING: GFS_rrtmgp_pre(), array p_lay has values outside range. Enforce lower pressure limit"
           endif
           if (t_lay(iCol,iLay) .ge. maxGPtemp) then
              t_lay(iCol,iLay) = maxGPtemp - epsilon(maxGPtemp)
+             error_msg = "WARNING: GFS_rrtmgp_pre(), array t_lay has values outside range. Enforce upper temperature limit"
           endif
           if (p_lay(iCol,iLay) .ge. maxGPpres) then
              p_lay(iCol,iLay) = maxGPpres - epsilon(maxGPpres)
+             error_msg = "WARNING: GFS_rrtmgp_pre(), array p_lay has values outside range. Enforce upper pressure limit"
           endif
        enddo
     enddo

--- a/physics/GFS_rrtmgp_pre.F90
+++ b/physics/GFS_rrtmgp_pre.F90
@@ -99,7 +99,7 @@ contains
   subroutine GFS_rrtmgp_pre_run(nCol, nLev, nTracers, i_o3, lsswr, lslwr, fhswr, fhlwr,     &
        xlat, xlon,  prsl, tgrs, prslk, prsi, qgrs, tsfc, con_eps, con_epsm1, con_fvirt,     &
        con_epsqs, minGPpres, minGPtemp, raddt, p_lay, t_lay, p_lev, t_lev, tsfg, tsfa,      & 
-       qs_lay, q_lay, tv_lay, relhum, tracer, gas_concentrations, t_lev_radtime, errmsg,    &
+       qs_lay, q_lay, tv_lay, relhum, tracer, gas_concentrations, tsfc_radtime, errmsg,     &
        errflg)
     
     ! Inputs   
@@ -143,7 +143,8 @@ contains
          raddt                ! Radiation time-step
     real(kind_phys), dimension(ncol), intent(inout) :: &
          tsfg,              & ! Ground temperature
-         tsfa                 ! Skin temperature    
+         tsfa,              & ! Skin temperature    
+         tsfc_radtime         ! Surface temperature at radiation timestep
     real(kind_phys), dimension(nCol,nLev), intent(inout) :: &
          p_lay,             & ! Pressure at model-layer
          t_lay,             & ! Temperature at model layer
@@ -153,8 +154,7 @@ contains
          qs_lay               ! Saturation vapor pressure at model-layers
     real(kind_phys), dimension(nCol,nLev+1), intent(inout) :: &
          p_lev,             & ! Pressure at model-interface
-         t_lev,             & ! Temperature at model-interface
-         t_lev_radtime        ! Temperature at model-interface (Save for use in between radiation calls)
+         t_lev                ! Temperature at model-interface
     real(kind_phys), dimension(nCol, nLev, nTracers),intent(inout) :: &
          tracer               ! Array containing trace gases
     type(ty_gas_concs),intent(inout) :: &
@@ -215,7 +215,10 @@ contains
 
     ! Temperature at layer-interfaces          
     call cmp_tlev(nCol,nLev,minGPpres,p_lay,t_lay,p_lev,tsfc,t_lev)
-    t_lev_radtime = t_lev
+
+    ! Save surface temperature at radiation time-step, used for LW flux adjustment betwen
+    ! radiation calls.
+    tsfc_radtime = tsfc
 
     ! Compute a bunch of thermodynamic fields needed by the cloud microphysics schemes. 
     ! Relative humidity, saturation mixing-ratio, vapor mixing-ratio, virtual temperature, 

--- a/physics/GFS_rrtmgp_pre.F90
+++ b/physics/GFS_rrtmgp_pre.F90
@@ -99,7 +99,8 @@ contains
   subroutine GFS_rrtmgp_pre_run(nCol, nLev, nTracers, i_o3, lsswr, lslwr, fhswr, fhlwr,     &
        xlat, xlon,  prsl, tgrs, prslk, prsi, qgrs, tsfc, con_eps, con_epsm1, con_fvirt,     &
        con_epsqs, minGPpres, minGPtemp, raddt, p_lay, t_lay, p_lev, t_lev, tsfg, tsfa,      & 
-       qs_lay, q_lay, tv_lay, relhum, tracer, gas_concentrations, errmsg, errflg)
+       qs_lay, q_lay, tv_lay, relhum, tracer, gas_concentrations, t_lev_radtime, errmsg,    &
+       errflg)
     
     ! Inputs   
     integer, intent(in)    :: &
@@ -152,7 +153,8 @@ contains
          qs_lay               ! Saturation vapor pressure at model-layers
     real(kind_phys), dimension(nCol,nLev+1), intent(inout) :: &
          p_lev,             & ! Pressure at model-interface
-         t_lev                ! Temperature at model-interface
+         t_lev,             & ! Temperature at model-interface
+         t_lev_radtime        ! Temperature at model-interface (Save for use in between radiation calls)
     real(kind_phys), dimension(nCol, nLev, nTracers),intent(inout) :: &
          tracer               ! Array containing trace gases
     type(ty_gas_concs),intent(inout) :: &
@@ -213,6 +215,7 @@ contains
 
     ! Temperature at layer-interfaces          
     call cmp_tlev(nCol,nLev,minGPpres,p_lay,t_lay,p_lev,tsfc,t_lev)
+    t_lev_radtime = t_lev
 
     ! Compute a bunch of thermodynamic fields needed by the cloud microphysics schemes. 
     ! Relative humidity, saturation mixing-ratio, vapor mixing-ratio, virtual temperature, 

--- a/physics/GFS_rrtmgp_pre.meta
+++ b/physics/GFS_rrtmgp_pre.meta
@@ -284,14 +284,14 @@
   kind = kind_phys
   intent = inout
   optional = F
-[t_lev_radtime]
-  standard_name = air_temperature_at_interface_on_radiation_timestep
-  long_name = air temperature layer
+[tsfc_radtime]
+  standard_name = surface_skin_temperature_on_radiation_timestep
+  long_name = surface skin temperature on radiation timestep
   units = K
-  dimensions = (horizontal_loop_extent,vertical_interface_dimension)
+  dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = inout
+  intent = in
   optional = F
 [tsfg]
   standard_name = surface_ground_temperature_for_radiation

--- a/physics/GFS_rrtmgp_pre.meta
+++ b/physics/GFS_rrtmgp_pre.meta
@@ -230,9 +230,27 @@
   kind = kind_phys
   intent = in
   optional = F
+[maxGPpres]
+  standard_name = maximum_pressure_in_RRTMGP
+  long_name = maximum pressure allowed in RRTMGP
+  units = Pa
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
 [minGPtemp]
   standard_name = minimum_temperature_in_RRTMGP
   long_name = minimum temperature allowed in RRTMGP
+  units = K
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[maxGPtemp]
+  standard_name = maximum_temperature_in_RRTMGP
+  long_name = maximum temperature allowed in RRTMGP
   units = K
   dimensions = ()
   type = real
@@ -249,18 +267,18 @@
   intent = inout
   optional = F
 [p_lay]
-  standard_name = air_pressure_at_layer_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_layer_for_RRTMGP
   long_name = air pressure at vertical layer for radiation calculation
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = inout
   optional = F
 [p_lev]
-  standard_name = air_pressure_at_interface_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_interface_for_RRTMGP
   long_name = air pressure at vertical interface for radiation calculation
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys

--- a/physics/GFS_rrtmgp_pre.meta
+++ b/physics/GFS_rrtmgp_pre.meta
@@ -284,6 +284,15 @@
   kind = kind_phys
   intent = inout
   optional = F
+[t_lev_radtime]
+  standard_name = air_temperature_at_interface_on_radiation_timestep
+  long_name = air temperature layer
+  units = K
+  dimensions = (horizontal_loop_extent,vertical_interface_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+  optional = F
 [tsfg]
   standard_name = surface_ground_temperature_for_radiation
   long_name = surface ground temperature for radiation

--- a/physics/GFS_rrtmgp_sw_post.meta
+++ b/physics/GFS_rrtmgp_sw_post.meta
@@ -101,9 +101,9 @@
   intent = in
   optional = F
 [p_lev]
-  standard_name = air_pressure_at_interface_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_interface_for_RRTMGP
   long_name = air pressure level
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys

--- a/physics/GFS_rrtmgp_thompsonmp_pre.meta
+++ b/physics/GFS_rrtmgp_thompsonmp_pre.meta
@@ -136,18 +136,18 @@
   intent = in
   optional = F   
 [p_lev]
-  standard_name = air_pressure_at_interface_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_interface_for_RRTMGP
   long_name = air pressure at vertical interface for radiation calculation
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys
   intent = in
   optional = F
 [p_lay]
-  standard_name = air_pressure_at_layer_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_layer_for_RRTMGP
   long_name = air pressure at vertical layer for radiation calculation
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys

--- a/physics/GFS_rrtmgp_zhaocarr_pre.meta
+++ b/physics/GFS_rrtmgp_zhaocarr_pre.meta
@@ -105,18 +105,18 @@
   intent = in
   optional = F    
 [p_lev]
-  standard_name = air_pressure_at_interface_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_interface_for_RRTMGP
   long_name = air pressure at vertical interface for radiation calculation
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys
   intent = in
   optional = F
 [p_lay]
-  standard_name = air_pressure_at_layer_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_layer_for_RRTMGP
   long_name = air pressure at vertical layer for radiation calculation
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys

--- a/physics/GFS_suite_interstitial.F90
+++ b/physics/GFS_suite_interstitial.F90
@@ -234,9 +234,8 @@
         enddo
 
 !  --- ...  sfc lw fluxes used by atmospheric model are saved for output
-        if (.not. use_LW_jacobian) then
-          if (frac_grid) then
-            do i=1,im
+        if (frac_grid) then
+           do i=1,im
               tem = (one - frland(i)) * cice(i) ! tem = ice fraction wrt whole cell
               if (flag_cice(i)) then
                  adjsfculw(i) = adjsfculw_lnd(i) * frland(i)               &
@@ -247,9 +246,9 @@
                               + adjsfculw_ice(i) * tem                     &
                               + adjsfculw_wat(i) * (one - frland(i) - tem)
               endif
-            enddo
-          else
-            do i=1,im
+           enddo
+        else
+           do i=1,im
               if (dry(i)) then                     ! all land
                  adjsfculw(i) = adjsfculw_lnd(i)
               elseif (icy(i)) then                 ! ice (and water)
@@ -270,8 +269,7 @@
               else                                 ! all water
                  adjsfculw(i) = adjsfculw_wat(i)
               endif
-            enddo
-          endif
+           enddo
         endif
 
         do i=1,im

--- a/physics/dcyc2.f
+++ b/physics/dcyc2.f
@@ -180,7 +180,7 @@
      &       sfcnirbmd,sfcnirdfd,sfcvisbmd,sfcvisdfd,                   &
      &       im, levs, deltim, fhswr,                                   &
      &       dry, icy, wet, damp_LW_fluxadj, lfnc_k, lfnc_p0,           &
-     &       minGPpres, use_LW_jacobian, sfculw, fluxlwUP_jac,          &
+     &       use_LW_jacobian, sfculw, fluxlwUP_jac,                     &
      &       t_lay, p_lay, p_lev, flux2D_lwUP, flux2D_lwDOWN,           &
      &       pert_radtend, do_sppt,ca_global, tsfc_radtime,             &
 !    &       dry, icy, wet, lprnt, ipr,                                 &
@@ -216,7 +216,7 @@
      &     pert_radtend
       logical, intent(in) :: do_sppt,ca_global
       real(kind=kind_phys),   intent(in) :: solhr, slag, cdec, sdec,    &
-     &     deltim, fhswr, minGPpres, lfnc_k, lfnc_p0
+     &     deltim, fhswr, lfnc_k, lfnc_p0
 
       real(kind=kind_phys), dimension(:), intent(in) ::                 &
      &      sinlat, coslat, xlon, coszen, tf, tsflw, sfcdlw,            &

--- a/physics/dcyc2.f
+++ b/physics/dcyc2.f
@@ -329,32 +329,27 @@
 
       do i = 1, im
 !> - LW time-step adjustment:
-         if (use_LW_Jacobian) then
-            ! F_adj = F_o + (dF/dT) * dT
-            dT           = tf(i) - tsflw(i)
-            adjsfculw(i) = sfculw(i) + fluxlwUP_jac(i,iSFC) * dT
-         else
-           tem1 = tf(i) / tsflw(i)
-           tem2 = tem1 * tem1
-           adjsfcdlw(i) = sfcdlw(i) * tem2 * tem2
+         tem1 = tf(i) / tsflw(i)
+         tem2 = tem1 * tem1
+         adjsfcdlw(i) = sfcdlw(i) * tem2 * tem2
 !!  - adjust \a sfc downward LW flux to account for t changes in the lowest model layer.
 !! compute 4th power of the ratio of \c tf in the lowest model layer over the mean value \c tsflw.
-           if (dry(i)) then
-             tem2 = tsfc_lnd(i) * tsfc_lnd(i)
-             adjsfculw_lnd(i) =  sfcemis_lnd(i) * con_sbc * tem2 * tem2
+         if (dry(i)) then
+            tem2 = tsfc_lnd(i) * tsfc_lnd(i)
+            adjsfculw_lnd(i) =  sfcemis_lnd(i) * con_sbc * tem2 * tem2
      &                        + (one - sfcemis_lnd(i)) * adjsfcdlw(i)
-           endif
-           if (icy(i)) then
-             tem2 = tsfc_ice(i) * tsfc_ice(i)
-             adjsfculw_ice(i) =  sfcemis_ice(i) * con_sbc * tem2 * tem2
+         endif
+         if (icy(i)) then
+            tem2 = tsfc_ice(i) * tsfc_ice(i)
+            adjsfculw_ice(i) =  sfcemis_ice(i) * con_sbc * tem2 * tem2
      &                        + (one - sfcemis_ice(i)) * adjsfcdlw(i)
-           endif
-           if (wet(i)) then
-             tem2 = tsfc_wat(i) * tsfc_wat(i)
-             adjsfculw_wat(i) =  sfcemis_wat(i) * con_sbc * tem2 * tem2
+         endif
+         if (wet(i)) then
+            tem2 = tsfc_wat(i) * tsfc_wat(i)
+            adjsfculw_wat(i) =  sfcemis_wat(i) * con_sbc * tem2 * tem2
      &                        + (one - sfcemis_wat(i)) * adjsfcdlw(i)
-          endif
-        endif  
+         endif
+
 !     if (lprnt .and. i == ipr) write(0,*)' in dcyc3: dry==',dry(i)
 !    &,' wet=',wet(i),' icy=',icy(i),' tsfc3=',tsfc3(i,:)
 !    &,' sfcemis=',sfcemis(i,:),' adjsfculw=',adjsfculw(i,:)

--- a/physics/dcyc2.f
+++ b/physics/dcyc2.f
@@ -181,8 +181,8 @@
      &       im, levs, deltim, fhswr,                                   &
      &       dry, icy, wet, damp_LW_fluxadj, lfnc_k, lfnc_p0,           &
      &       minGPpres, use_LW_jacobian, sfculw, fluxlwUP_jac,          &
-     &       t_lay, t_lev, p_lay, p_lev, flux2D_lwUP, flux2D_lwDOWN,    &
-     &       pert_radtend, do_sppt,ca_global,                           &
+     &       t_lay, p_lay, p_lev, flux2D_lwUP, flux2D_lwDOWN,           &
+     &       pert_radtend, do_sppt,ca_global, tsfc_radtime,             &
 !    &       dry, icy, wet, lprnt, ipr,                                 &
 !  ---  input/output:
      &       dtdt,dtdtnp,htrlw,                                         &
@@ -195,7 +195,6 @@
      &     )
 !
       use machine,         only : kind_phys
-      use radiation_tools, only : cmp_tlev
 
       implicit none
 !
@@ -221,7 +220,7 @@
 
       real(kind=kind_phys), dimension(:), intent(in) ::                 &
      &      sinlat, coslat, xlon, coszen, tf, tsflw, sfcdlw,            &
-     &      sfcdsw, sfcnsw, sfculw, tsfc
+     &      sfcdsw, sfcnsw, sfculw, tsfc, tsfc_radtime
 
       real(kind=kind_phys), dimension(:), intent(in) ::                 &
      &                         tsfc_lnd, tsfc_ice, tsfc_wat,            &
@@ -235,7 +234,7 @@
      &                                     swhc, hlwc, p_lay, t_lay
 
       real(kind=kind_phys), dimension(:,:), intent(in) :: p_lev,        &
-     &     flux2D_lwUP, flux2D_lwDOWN, fluxlwUP_jac, t_lev
+     &     flux2D_lwUP, flux2D_lwDOWN, fluxlwUP_jac
 
       real(kind_phys),           intent(in   ) :: con_g, con_cp,        &
      &     con_pi, con_sbc
@@ -264,7 +263,7 @@
       real(kind=kind_phys) :: cns,  coszn, tem1, tem2, anginc,          &
      &                        rstl, solang, dT
       real(kind=kind_phys), dimension(im,levs+1) :: flxlwup_adj,        &
-     &     flxlwdn_adj, t_lev2
+     &     flxlwdn_adj
       real(kind=kind_phys) :: fluxlwnet_adj,fluxlwnet,dT_sfc,           &
      &fluxlwDOWN_jac,lfnc,c1
       ! Length scale for flux-adjustment scaling
@@ -379,15 +378,10 @@
         adjvisdfd(i) = sfcvisdfd(i) * xmu(i)
       enddo
 
-!>  - adjust SW heating rates with zenith angle change and
-!     add with LW heating to temperature tendency.
+      ! Adjust the LW and SW heating-rates.
+      ! For LW, optionally scale using the Jacobian of the upward LW flux. *RRTMGP ONLY*
+      ! For SW, adjust heating rates with zenith angle change.
       if (use_LW_jacobian) then
-         !
-         ! Compute temperatute at level interfaces.
-         !
-         call cmp_tlev(im, levs, minGPpres, p_lay, t_lay, p_lev, tsfc,  &
-     &        t_lev2)
-
          ! Compute adjusted net LW flux foillowing Hogan and Bozzo 2015 (10.1002/2015MS000455)
          ! Here we assume that the profile of the downwelling LW Jaconiam has the same shape
          ! as the upwelling, but scaled and offset.
@@ -403,7 +397,8 @@
          ! p0 = Transition pressure (Pa)       - Controlled by namelsit
          do i = 1, im
             c1 = fluxlwUP_jac(i,iTOA) / fluxlwUP_jac(i,iSFC)
-            dT_sfc = t_lev2(i,iSFC) - t_lev(i,iSFC)
+            !dT_sfc = t_lev2(i,iSFC) - t_lev(i,iSFC)
+            dT_sfc = tsfc(i) - tsfc_radtime(i)
             do k = 1, levs
                ! LW net flux
                fluxlwnet = (flux2D_lwUP(i,  k+1) - flux2D_lwUP(i,  k) - &

--- a/physics/dcyc2.meta
+++ b/physics/dcyc2.meta
@@ -398,15 +398,6 @@
   type = logical
   intent = in
   optional = F
-[minGPpres]
-  standard_name = minimum_pressure_in_RRTMGP
-  long_name = minimum pressure allowed in RRTMGP
-  units = Pa
-  dimensions = ()
-  type = real
-  kind = kind_phys
-  intent = in
-  optional = F
 [use_LW_jacobian]
   standard_name = flag_to_calc_RRTMGP_LW_jacobian
   long_name = logical flag to control RRTMGP LW calculation

--- a/physics/dcyc2.meta
+++ b/physics/dcyc2.meta
@@ -460,7 +460,7 @@
   intent = in
   optional = F
 [t_lev]
-  standard_name = air_temperature_at_interface_for_RRTMGP
+  standard_name = air_temperature_at_interface_on_radiation_timestep
   long_name = air temperature  at vertical interface for radiation calculation
   units = K
   dimensions = (horizontal_loop_extent,vertical_interface_dimension)

--- a/physics/dcyc2.meta
+++ b/physics/dcyc2.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = dcyc2t3
   type = scheme
-  dependencies = machine.F,physcons.F90,radiation_tools.F90
+  dependencies = machine.F,physcons.F90
 
 ########################################################################
 [ccpp-arg-table]
@@ -163,6 +163,15 @@
 [tsfc]
   standard_name = surface_skin_temperature
   long_name = surface skin temperature
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
+[tsfc_radtime]
+  standard_name = surface_skin_temperature_on_radiation_timestep
+  long_name = surface skin temperature on radiation timestep
   units = K
   dimensions = (horizontal_loop_extent)
   type = real
@@ -455,15 +464,6 @@
   long_name = model layer mean temperature updated by physics
   units = K
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
-  type = real
-  kind = kind_phys
-  intent = in
-  optional = F
-[t_lev]
-  standard_name = air_temperature_at_interface_on_radiation_timestep
-  long_name = air temperature  at vertical interface for radiation calculation
-  units = K
-  dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys
   intent = in

--- a/physics/rrtmgp_lw_aerosol_optics.meta
+++ b/physics/rrtmgp_lw_aerosol_optics.meta
@@ -48,18 +48,18 @@
   intent = in
   optional = F
 [p_lev]
-  standard_name = air_pressure_at_interface_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_interface_for_RRTMGP
   long_name = air pressure at vertical interface for radiation calculation
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys
   intent = in
   optional = F
 [p_lay]
-  standard_name = air_pressure_at_layer_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_layer_for_RRTMGP
   long_name = air pressure at vertical layer for radiation calculation
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys

--- a/physics/rrtmgp_lw_cloud_optics.meta
+++ b/physics/rrtmgp_lw_cloud_optics.meta
@@ -257,9 +257,9 @@
   intent = in
   optional = F   
 [p_lay]
-  standard_name = air_pressure_at_layer_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_layer_for_RRTMGP
   long_name = air pressure layer
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys

--- a/physics/rrtmgp_lw_gas_optics.F90
+++ b/physics/rrtmgp_lw_gas_optics.F90
@@ -76,7 +76,8 @@ contains
 !! \htmlinclude rrtmgp_lw_gas_optics_init.html
 !!
   subroutine rrtmgp_lw_gas_optics_init(rrtmgp_root_dir, rrtmgp_lw_file_gas, mpicomm,        &
-       mpirank, mpiroot, gas_concentrations, minGPpres, minGPtemp, errmsg, errflg)
+       mpirank, mpiroot, gas_concentrations, minGPpres, maxGPpres, minGPtemp, maxGPtemp,    &
+       errmsg, errflg)
 
     ! Inputs
     type(ty_gas_concs), intent(inout) :: &
@@ -96,7 +97,9 @@ contains
          errflg              ! CCPP error code
     real(kind_phys), intent(out) :: &
          minGPtemp,        & ! Minimum temperature allowed by RRTMGP.
-         minGPpres           ! Minimum pressure allowed by RRTMGP. 
+         maxGPtemp,        & ! Maximum ...
+         minGPpres,        & ! Minimum pressure allowed by RRTMGP. 
+         maxGPpres           ! Maximum pressure allowed by RRTMGP. 
 
     ! Local variables
     integer :: ncid, dimID, varID, status, iGas, ierr, ii, mpierr, iChar
@@ -449,7 +452,9 @@ contains
     ! The minimum pressure allowed in GP RTE calculations. Used to bound uppermost layer
     ! temperature (GFS_rrtmgp_pre.F90)
     minGPpres = lw_gas_props%get_press_min()
+    maxGPpres = lw_gas_props%get_press_max()
     minGPtemp = lw_gas_props%get_temp_min() 
+    maxGPtemp = lw_gas_props%get_temp_max()
 
   end subroutine rrtmgp_lw_gas_optics_init
 
@@ -469,10 +474,10 @@ contains
          ncol,                &  ! Number of horizontal points
          nLev                    ! Number of vertical levels
     real(kind_phys), dimension(ncol,nLev), intent(in) :: &
-         p_lay,                & ! Pressure @ model layer-centers (hPa)
+         p_lay,                & ! Pressure @ model layer-centers (Pa)
          t_lay                   ! Temperature (K)
     real(kind_phys), dimension(ncol,nLev+1), intent(in) :: &
-         p_lev,                & ! Pressure @ model layer-interfaces (hPa)
+         p_lev,                & ! Pressure @ model layer-interfaces (Pa)
          t_lev                   ! Temperature @ model levels
     real(kind_phys), dimension(ncol), intent(in) :: &
          tsfg                    ! Surface ground temperature (K)

--- a/physics/rrtmgp_lw_gas_optics.meta
+++ b/physics/rrtmgp_lw_gas_optics.meta
@@ -83,9 +83,27 @@
   kind = kind_phys
   intent = out
   optional = F
+[maxGPpres]
+  standard_name = maximum_pressure_in_RRTMGP
+  long_name = maximum pressure allowed in RRTMGP
+  units = Pa
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = out
+  optional = F
 [minGPtemp]
   standard_name = minimum_temperature_in_RRTMGP
   long_name = minimum temperature allowed in RRTMGP
+  units = K
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = out
+  optional = F
+[maxGPtemp]
+  standard_name = maximum_temperature_in_RRTMGP
+  long_name = maximum temperature allowed in RRTMGP
   units = K
   dimensions = ()
   type = real
@@ -122,18 +140,18 @@
   intent = in
   optional = F
 [p_lay]
-  standard_name = air_pressure_at_layer_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_layer_for_RRTMGP
   long_name = air pressure layer
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = in
   optional = F
 [p_lev]
-  standard_name = air_pressure_at_interface_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_interface_for_RRTMGP
   long_name = air pressure level
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys

--- a/physics/rrtmgp_lw_rte.F90
+++ b/physics/rrtmgp_lw_rte.F90
@@ -44,7 +44,7 @@ contains
          nLev,                    & ! Number of vertical levels
          nGauss_angles              ! Number of angles used in Gaussian quadrature
     real(kind_phys), dimension(ncol,nLev+1), intent(in) :: &
-         p_lev                      ! Pressure @ model layer-interfaces (hPa)
+         p_lev                      ! Pressure @ model layer-interfaces (Pa)
     real(kind_phys), dimension(lw_gas_props%get_nband(),ncol), intent(in) :: &
          sfc_emiss_byband           ! Surface emissivity in each band
     type(ty_source_func_lw),intent(in) :: &

--- a/physics/rrtmgp_lw_rte.meta
+++ b/physics/rrtmgp_lw_rte.meta
@@ -65,9 +65,9 @@
   intent = in
   optional = F
 [p_lev]
-  standard_name = air_pressure_at_interface_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_interface_for_RRTMGP
   long_name = air pressure level
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys

--- a/physics/rrtmgp_sw_aerosol_optics.meta
+++ b/physics/rrtmgp_sw_aerosol_optics.meta
@@ -64,18 +64,18 @@
   intent = in
   optional = F
 [p_lev]
-  standard_name = air_pressure_at_interface_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_interface_for_RRTMGP
   long_name = air pressure at vertical interface for radiation calculation
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys
   intent = in
   optional = F
 [p_lay]
-  standard_name = air_pressure_at_layer_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_layer_for_RRTMGP
   long_name = air pressure at vertical layer for radiation calculation
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys

--- a/physics/rrtmgp_sw_gas_optics.F90
+++ b/physics/rrtmgp_sw_gas_optics.F90
@@ -503,10 +503,10 @@ contains
     integer,intent(in),dimension(ncol) :: &
          idxday                  ! Indices for daylit points.
     real(kind_phys), dimension(ncol,nLev), intent(in) :: &
-         p_lay,                & ! Pressure @ model layer-centers (hPa)
+         p_lay,                & ! Pressure @ model layer-centers (Pa)
          t_lay                   ! Temperature (K)
     real(kind_phys), dimension(ncol,nLev+1), intent(in) :: &
-         p_lev,                & ! Pressure @ model layer-interfaces (hPa)
+         p_lev,                & ! Pressure @ model layer-interfaces (Pa)
          t_lev                   ! Temperature @ model levels
     type(ty_gas_concs),intent(in) :: &
          gas_concentrations      ! RRTMGP DDT: trace gas concentrations (vmr)

--- a/physics/rrtmgp_sw_gas_optics.meta
+++ b/physics/rrtmgp_sw_gas_optics.meta
@@ -152,18 +152,18 @@
   intent = in
   optional = F
 [p_lay]
-  standard_name = air_pressure_at_layer_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_layer_for_RRTMGP
   long_name = air pressure layer
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = in
   optional = F
 [p_lev]
-  standard_name = air_pressure_at_interface_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_interface_for_RRTMGP
   long_name = air pressure level
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys

--- a/physics/rrtmgp_sw_rte.meta
+++ b/physics/rrtmgp_sw_rte.meta
@@ -66,18 +66,18 @@
   intent = in
   optional = F
 [p_lay]
-  standard_name = air_pressure_at_layer_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_layer_for_RRTMGP
   long_name = air pressure layer
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = in
   optional = F
 [p_lev]
-  standard_name = air_pressure_at_interface_for_RRTMGP_in_hPa
+  standard_name = air_pressure_at_interface_for_RRTMGP
   long_name = air pressure level
-  units = hPa
+  units = Pa
   dimensions = (horizontal_loop_extent,vertical_interface_dimension)
   type = real
   kind = kind_phys


### PR DESCRIPTION
This PR contains several fixes to the RRTMGP enabled ccpp-physics, along with some cleanup.

Primary issues addressed:
- There was an error in the GP longwave flux adjustment between radiation calls. The history of the adjustment was that I had originally a) only implemented to update the surface flux, b) then I added it to the full profile, c) then I added the damping w/ the logistic function. The leftover pieces from a) are what I'm removing here.
- There was an indexing error in one of the overlap assumptions in rrtmgp_sampling.F90. This was for the case when physics nml option "iovr=3", exponential w/ decorrelation length overlap parameter.
- Added input sanitation for RRTMGP temperature and pressure inputs. GP relies on LUTs that are only valid for a specific temperature/pressure range. If out-of-bounds temperatures/pressures are provided to GP, it reports error. In GPs predecessor, RRTMG, errors were not reported, but rather the out-of-bound values for temperature/pressures are set to their limiting values.
