### PR TITLE
fix decomppsotion issue with cimin

### DIFF
--- a/physics/GFS_radiation_surface.F90
+++ b/physics/GFS_radiation_surface.F90
@@ -101,8 +101,7 @@
       ! Local variables
       integer                             :: i
       real(kind=kind_phys)                :: lndp_alb
-      real(kind=kind_phys)                :: cimin
-      real(kind=kind_phys), dimension(im) :: fracl, fraci, fraco
+      real(kind=kind_phys), dimension(im) :: cimin, fracl, fraci, fraco
       logical,              dimension(im) :: icy
 
       ! Initialize CCPP error handling variables
@@ -114,9 +113,9 @@
 
       do i=1,im
         if (lakefrac(i) > f_zero) then
-          cimin = min_lakeice
+          cimin(i) = min_lakeice
         else
-          cimin = min_seaice
+          cimin(i) = min_seaice
         endif
       enddo
 
@@ -131,7 +130,7 @@
           else
             fracl(i) = f_zero
             fraco(i) = f_one
-            if(fice(i) < cimin) then
+            if(fice(i) < cimin(i)) then
               fraci(i) = f_zero
               icy(i)   = .false.
             else
@@ -145,7 +144,7 @@
         do i=1,im
           fracl(i) = landfrac(i)
           fraco(i) = max(f_zero, f_one - fracl(i))
-          if(fice(i) < cimin) then
+          if(fice(i) < cimin(i)) then
             fraci(i) = f_zero
             icy(i)   = .false.
           else

--- a/physics/sfc_drv_ruc.F90
+++ b/physics/sfc_drv_ruc.F90
@@ -538,7 +538,7 @@ module lsm_ruc
       ! local
       integer :: ims,ime, its,ite, jms,jme, jts,jte, kms,kme, kts,kte
       integer :: l, k, i, j,  fractional_seaice, ilst
-      real (kind=kind_phys) :: dm, cimin
+      real (kind=kind_phys) :: dm, cimin(im)
       logical :: flag(im), flag_ice(im), flag_ice_uncoupled(im)
       logical :: rdlai2d, myj, frpcpn
       logical :: debug_print
@@ -558,11 +558,11 @@ module lsm_ruc
         if (icy(i) .and. .not. flag_cice(i)) then
         ! - uncoupled ice model
           if (oceanfrac(i) > zero) then
-            cimin = min_seaice
+            cimin(i) = min_seaice
           else
-            cimin = min_lakeice
+            cimin(i) = min_lakeice
           endif
-          if (fice(i) >= cimin) then
+          if (fice(i) >= cimin(i)) then
           ! - ice fraction is above the threshold for ice
             flag_ice(i) = .true.
           endif
@@ -1400,10 +1400,10 @@ module lsm_ruc
               fwat =  1.0 - fice(i)
              ! Check if ice fraction is below the minimum value: 15% in GFS
              ! physics.
-              if (fice(i) < cimin) then ! cimin - minimal ice fraction
+              if (fice(i) < cimin(i)) then ! cimin - minimal ice fraction
                         write (0,*)'warning: ice fraction is low:', fice(i)
-                fice(i) = cimin
-                fwat    = 1.0 - cimin
+                fice(i) = cimin(i)
+                fwat    = 1.0 - cimin(i)
                 write (0,*)'fix ice fraction: reset it to:', fice(i), tskin_wat(i)
               endif
 


### PR DESCRIPTION
This PR is to fix the decomposition issue associated with cimin in radiation surface physics.

The following code sets cimin to the last cimin value from im, if decomposition changed, the cimin could get different value.

      do i=1,im
        if (lakefrac(i) > f_zero) then
          cimin = min_lakeice
        else
          cimin = min_seaice
        endif
      enddo