### PR TITLE
fix inconsistent types related with noahmp and log functions

### DIFF
--- a/physics/module_sf_noahmplsm.f90
+++ b/physics/module_sf_noahmplsm.f90
@@ -1769,9 +1769,9 @@ endif   ! croptype == 0
   real (kind=kind_phys)                              , intent(inout) :: cm     !momentum drag coefficient
   real (kind=kind_phys)                              , intent(inout) :: ch     !sensible heat exchange coefficient
   real (kind=kind_phys)                              , intent(inout) :: q1
-  real                              , intent(inout) :: rb     !leaf boundary layer resistance (s/m)
-  real                              , intent(inout) :: laisun !sunlit leaf area index (m2/m2)
-  real                              , intent(inout) :: laisha !shaded leaf area index (m2/m2)
+  real (kind=kind_phys)                              , intent(inout) :: rb     !leaf boundary layer resistance (s/m)
+  real (kind=kind_phys)                              , intent(inout) :: laisun !sunlit leaf area index (m2/m2)
+  real (kind=kind_phys)                              , intent(inout) :: laisha !shaded leaf area index (m2/m2)
 #ifdef CCPP
   character(len=*)                  , intent(inout) :: errmsg
   integer                           , intent(inout) :: errflg
@@ -5868,8 +5868,8 @@ endif   ! croptype == 0
 1001      continue
           if (.not.( (nlog < 10) .and. (kcount == 0)))   goto 1002
           nlog = nlog +1
-          df = alog ( ( parameters%psisat(isoil) * grav / hfus ) * ( ( 1. + ck * swl )**2.) * &
-               ( parameters%smcmax(isoil) / (smc - swl) )** bx) - alog ( - (               &
+          df = log ( ( parameters%psisat(isoil) * grav / hfus ) * ( ( 1. + ck * swl )**2.) * &
+               ( parameters%smcmax(isoil) / (smc - swl) )** bx) - log ( - (               &
                tkelv - tfrz)/ tkelv)
           denom = 2. * ck / ( 1. + ck * swl ) + bx / ( smc - swl )
           swlk = swl - df / denom

--- a/physics/sfc_noahmp_drv.F90
+++ b/physics/sfc_noahmp_drv.F90
@@ -1467,19 +1467,20 @@ SUBROUTINE PEDOTRANSFER_SR2006(nsoil,sand,clay,orgm,parameters)
 ! ----------------------------------------------------------------------
 ! subroutine penman
 ! ----------------------------------------------------------------------
+      use machine, only: kind_phys
       implicit none
       logical, intent(in)     :: snowng, frzgra
-      real, intent(in)        :: ch, dqsdt2,fdown,prcp,ffrozp,          &
+      real(kind=kind_phys), intent(in)        :: ch, dqsdt2,fdown,prcp,ffrozp,          &
      &                           q2, q2sat,ssoil, sfcprs, sfctmp,       &
      &                           t2v, th2,emissi_in,sncovr
-      real, intent(out)       :: etp
-      real                    :: epsca,flx2,rch,rr,t24
-      real                    :: a, delta, fnet,rad,rho,emissi,elcp1,lvs
+      real(kind=kind_phys), intent(out)       :: etp
+      real(kind=kind_phys)                    :: epsca,flx2,rch,rr,t24
+      real(kind=kind_phys)                    :: a, delta, fnet,rad,rho,emissi,elcp1,lvs
 
-      real, parameter :: elcp = 2.4888e+3, lsubc = 2.501000e+6,cp = 1004.6
-      real, parameter :: lsubs = 2.83e+6, rd = 287.05, cph2o = 4.1855e+3
-      real, parameter :: cpice = 2.106e+3, lsubf   = 3.335e5  
-      real, parameter :: sigma = 5.6704e-8
+      real(kind=kind_phys), parameter :: elcp = 2.4888e+3, lsubc = 2.501000e+6,cp = 1004.6
+      real(kind=kind_phys), parameter :: lsubs = 2.83e+6, rd = 287.05, cph2o = 4.1855e+3
+      real(kind=kind_phys), parameter :: cpice = 2.106e+3, lsubf   = 3.335e5  
+      real(kind=kind_phys), parameter :: sigma = 5.6704e-8
 
 ! ----------------------------------------------------------------------
 ! executable code begins here:

--- a/physics/sflx.f
+++ b/physics/sflx.f
@@ -3994,7 +3994,7 @@
           do while ( (nlog < 10) .and. (kcount == 0) )
             nlog = nlog + 1
 
-            df = log( (psis*gs2/lsubf) * ( (1.0 + ck*swl)**2.0 )      &
+            df = log( (psis*gs2/lsubf) * ( (1.0 + ck*swl)**2.0 )        &
      &         * (smcmax/(smc-swl))**bx ) - log(-(tkelv-tfreez)/tkelv)
 
             denom = 2.0*ck/(1.0 + ck*swl) + bx/(smc - swl)

--- a/physics/sflx.f
+++ b/physics/sflx.f
@@ -3994,8 +3994,8 @@
           do while ( (nlog < 10) .and. (kcount == 0) )
             nlog = nlog + 1
 
-            df = alog( (psis*gs2/lsubf) * ( (1.0 + ck*swl)**2.0 )       &
-     &         * (smcmax/(smc-swl))**bx ) - alog(-(tkelv-tfreez)/tkelv)
+            df = log( (psis*gs2/lsubf) * ( (1.0 + ck*swl)**2.0 )      &
+     &         * (smcmax/(smc-swl))**bx ) - log(-(tkelv-tfreez)/tkelv)
 
             denom = 2.0*ck/(1.0 + ck*swl) + bx/(smc - swl)
             swlk  = swl - df/denom


### PR DESCRIPTION
This PR aims to fix couple of minor issue related to the inconsistent data types in the CCPP/physics. If user wants to compile NoahMP and related files outside of the CCPP package, the compiler triggers errors since some of the subroutines uses `real` data type rather than `real(kind=kind_phys)`, which `kind_phys` is set to R8 by default under CCPP.

This is related with the following issue: https://github.com/NCAR/ccpp-physics/issues/750