### PR TITLE
Thompson MP: increase cloud cover, add option for semi-lagrangian sedimentation of graupel

### DIFF
--- a/physics/GFS_rrtmg_pre.F90
+++ b/physics/GFS_rrtmg_pre.F90
@@ -854,6 +854,15 @@
           enddo
         endif
 
+        if(imp_physics == imp_physics_thompson) then
+          do k=1,lm
+            k1 = k + kd
+            do i=1,im
+              cnvw  (i,k1) = cnvw_in(i,k)
+            enddo
+          enddo
+        endif
+
         !mz HWRF physics: icloud=3
         if(icloud == 3) then
 
@@ -1036,7 +1045,7 @@
                          ntrac-1, ntcw-1,ntiw-1,ntrw-1,             &
                          ntsw-1,ntgl-1,                             &
                          im, lmk, lmp, uni_cld, lmfshal, lmfdeep2,  &
-                         cldcov(:,1:LMK), effrl_inout(:,:),         &
+                         cldcov(:,1:LMK), cnvw, effrl_inout(:,:),   &
                          effri_inout(:,:), effrs_inout(:,:),        &
                          dzb, xlat_d, julian, yearlen,              &
                          clouds, cldsa, mtopa ,mbota, de_lgth, alpha) !  --- outputs

--- a/physics/module_mp_thompson.F90
+++ b/physics/module_mp_thompson.F90
@@ -1922,7 +1922,7 @@ MODULE module_mp_thompson
 
       REAL, DIMENSION(kts:kte):: temp, pres, qv
       REAL, DIMENSION(kts:kte):: rc, ri, rr, rs, rg, ni, nr, nc, nwfa, nifa
-      REAL, DIMENSION(kts:kte):: rr_tmp, nr_tmp, rg_tmp, vtgk_tmp 
+      REAL, DIMENSION(kts:kte):: rr_tmp, nr_tmp, rg_tmp
       REAL, DIMENSION(kts:kte):: rho, rhof, rhof2
       REAL, DIMENSION(kts:kte):: qvs, qvsi, delQvs
       REAL, DIMENSION(kts:kte):: satw, sati, ssatw, ssati

--- a/physics/mp_thompson.F90
+++ b/physics/mp_thompson.F90
@@ -33,6 +33,7 @@ module mp_thompson
       subroutine mp_thompson_init(ncol, nlev, con_g, con_rd, con_eps,   &
                                   restart, imp_physics,                 &
                                   imp_physics_thompson, convert_dry_rho,&
+                                  d0s, d0g,                             &
                                   spechum, qc, qr, qi, qs, qg, ni, nr,  &
                                   is_aerosol_aware, nc, nwfa2d, nifa2d, &
                                   nwfa, nifa, tgrs, prsl, phil, area,   &
@@ -52,6 +53,8 @@ module mp_thompson
          integer,                   intent(in   ) :: imp_physics_thompson
          ! Hydrometeors
          logical,                   intent(in   ) :: convert_dry_rho
+         real,                      intent(in   ) :: d0s 
+         real,                      intent(in   ) :: d0g 
          real(kind_phys),           intent(inout) :: spechum(:,:)
          real(kind_phys),           intent(inout) :: qc(:,:)
          real(kind_phys),           intent(inout) :: qr(:,:)
@@ -120,8 +123,10 @@ module mp_thompson
             end if
          end if
 
+         if (mpirank==mpiroot) write(*,*) 'D0s, d0g: ',d0s,d0g 
          ! Call Thompson init
-         call thompson_init(is_aerosol_aware_in=is_aerosol_aware, mpicomm=mpicomm, &
+         call thompson_init(d0s=D0s, d0g=D0g, is_aerosol_aware_in=is_aerosol_aware,& 
+                            mpicomm=mpicomm,                                       &
                             mpirank=mpirank, mpiroot=mpiroot, threads=threads,     &
                             errmsg=errmsg, errflg=errflg)
          if (errflg /= 0) return
@@ -336,7 +341,8 @@ module mp_thompson
                               nwfa2d, nifa2d,                      &
                               tgrs, prsl, phii, omega,             &
                               sedi_semi, sedi_semi_update,         &
-                              sedi_semi_decfl, dtp, dt_inner,      & 
+                              sedi_semi_decfl, crt_sati, d0s, d0g, & 
+                              dtp, dt_inner,                       & 
                               first_time_step, istep, nsteps,      &
                               prcp, rain, graupel, ice, snow, sr,  &
                               refl_10cm, reset_dBZ, do_radar_ref,  &
@@ -395,6 +401,9 @@ module mp_thompson
          logical,                   intent(in)    :: sedi_semi
          logical,                   intent(in)    :: sedi_semi_update
          logical,                   intent(in)    :: sedi_semi_decfl
+         real,                      intent(in   ) :: crt_sati
+         real,                      intent(in   ) :: d0s 
+         real,                      intent(in   ) :: d0g 
          ! Cloud effective radii
          real(kind_phys), optional, intent(  out) :: re_cloud(:,:)
          real(kind_phys), optional, intent(  out) :: re_ice(:,:)
@@ -682,6 +691,7 @@ module mp_thompson
                                  tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtstep, dt_inner=dt_inner,  &
                                  sedi_semi=sedi_semi, sedi_semi_update=sedi_semi_update,        &
                                  sedi_semi_decfl=sedi_semi_decfl,                               &
+                                 crt_sati=crt_sati,  d0s=D0s, d0g=D0g,                          &
                                  rainnc=rain_mp, rainncv=delta_rain_mp,                         &
                                  snownc=snow_mp, snowncv=delta_snow_mp,                         &
                                  icenc=ice_mp, icencv=delta_ice_mp,                             &
@@ -724,6 +734,7 @@ module mp_thompson
                                  tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtstep, dt_inner=dt_inner,  &
                                  sedi_semi=sedi_semi, sedi_semi_update=sedi_semi_update,        &
                                  sedi_semi_decfl=sedi_semi_decfl,                               &
+                                 crt_sati=crt_sati,  d0s=D0s, d0g=D0g,                          &
                                  rainnc=rain_mp, rainncv=delta_rain_mp,                         &
                                  snownc=snow_mp, snowncv=delta_snow_mp,                         &
                                  icenc=ice_mp, icencv=delta_ice_mp,                             &
@@ -766,6 +777,7 @@ module mp_thompson
                                  tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtstep, dt_inner=dt_inner,  &
                                  sedi_semi=sedi_semi, sedi_semi_update=sedi_semi_update,        &
                                  sedi_semi_decfl=sedi_semi_decfl,                               &
+                                 crt_sati=crt_sati,  d0s=D0s, d0g=D0g,                          &
                                  rainnc=rain_mp, rainncv=delta_rain_mp,                         &
                                  snownc=snow_mp, snowncv=delta_snow_mp,                         &
                                  icenc=ice_mp, icencv=delta_ice_mp,                             &
@@ -807,6 +819,7 @@ module mp_thompson
                                  tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtstep, dt_inner=dt_inner,  &
                                  sedi_semi=sedi_semi, sedi_semi_update=sedi_semi_update,        &
                                  sedi_semi_decfl=sedi_semi_decfl,                               &
+                                 crt_sati=crt_sati,  d0s=D0s, d0g=D0g,                          &
                                  rainnc=rain_mp, rainncv=delta_rain_mp,                         &
                                  snownc=snow_mp, snowncv=delta_snow_mp,                         &
                                  icenc=ice_mp, icencv=delta_ice_mp,                             &

--- a/physics/mp_thompson.meta
+++ b/physics/mp_thompson.meta
@@ -82,6 +82,22 @@
   type = logical
   intent = in
   optional = F
+[d0s]
+  standard_name = diameter_of_ice_particle_to_be_converted_to_snow
+  long_name =  diameter of ice particle to be converted to snow
+  units = meter
+  dimensions = ()
+  type = real
+  intent = in
+  kind = kind_phys
+[d0g]
+  standard_name = diameter_of_snow_particle_to_be_converted_to_graupel
+  long_name =  diameter of snow particle to be converted to graupel
+  units = meter
+  dimensions = ()
+  type = real
+  intent = in
+  kind = kind_phys
 [spechum]
   standard_name = specific_humidity
   long_name = water vapor specific humidity
@@ -577,6 +593,30 @@
   type = logical
   intent = in
   optional = F
+[crt_sati]
+  standard_name = critical_over_saturation_for_ice_generation
+  long_name = critical over saturation for ice generation
+  units = none
+  dimensions = ()
+  type = real
+  intent = in
+  kind = kind_phys
+[d0s]
+  standard_name = diameter_of_ice_particle_to_be_converted_to_snow
+  long_name =  diameter of ice particle to be converted to snow
+  units = meter
+  dimensions = ()
+  type = real
+  intent = in
+  kind = kind_phys
+[d0g]
+  standard_name = diameter_of_snow_particle_to_be_converted_to_graupel
+  long_name =  diameter of snow particle to be converted to graupel
+  units = meter
+  dimensions = ()
+  type = real
+  intent = in
+  kind = kind_phys
 [dtp]
   standard_name = timestep_for_physics
   long_name = physics timestep

--- a/physics/radiation_clouds.f
+++ b/physics/radiation_clouds.f
@@ -2861,7 +2861,7 @@
      &       xlat,xlon,slmsk,dz,delp,                                   &
      &       ntrac,ntcw,ntiw,ntrw,ntsw,ntgl,                            &
      &       IX, NLAY, NLP1,                                            &
-     &       uni_cld, lmfshal, lmfdeep2, cldcov,                        &
+     &       uni_cld, lmfshal, lmfdeep2, cldcov, cnvw,                  &
      &       re_cloud,re_ice,re_snow,                                   &
      &       dzlay, latdeg, julian, yearlen,                            &
      &       clouds,clds,mtop,mbot,de_lgth,alpha                        &    !  ---  outputs:
@@ -2955,7 +2955,7 @@
 
       real (kind=kind_phys), dimension(:,:), intent(in) :: plvl, plyr,  &
      &       tlyr, qlyr, qstl, rhly, cldcov, delp, dz, dzlay,           &
-     &       re_cloud, re_ice, re_snow
+     &       re_cloud, re_ice, re_snow, cnvw 
 
       real (kind=kind_phys), dimension(:,:,:), intent(in) :: clw
 
@@ -2987,8 +2987,8 @@
       integer :: i, k, id, nf
 
 !  ---  constant values
-!     real (kind=kind_phys), parameter :: xrc3 = 200.
-      real (kind=kind_phys), parameter :: xrc3 = 100.
+      real (kind=kind_phys), parameter :: xrc3 = 200.
+!     real (kind=kind_phys), parameter :: xrc3 = 100.
 
 !
 !===> ... begin here
@@ -3042,6 +3042,7 @@
         do k = 1, NLAY
           do i = 1, IX
             clwf(i,k) = clw(i,k,ntcw) +  clw(i,k,ntiw) + clw(i,k,ntsw)
+     &      +clw(i,k,ntrw) + clw(i,k,ntgl) + cnvw(i,k)
           enddo
         enddo
 !> - Find top pressure for each cloud domain for given latitude.
@@ -3111,24 +3112,29 @@
         else
           do k = 1, NLAY
           do i = 1, IX
-            clwt = 1.0e-6 * (plyr(i,k)*0.001)
+!           clwt = 1.0e-6 * (plyr(i,k)*0.001)
 !           clwt = 2.0e-6 * (plyr(i,k)*0.001)
+            clwt = 1.0e-10 * (plyr(i,k)*0.001)
 
             if (clwf(i,k) > clwt) then
-              onemrh= max( 1.e-10, 1.0-rhly(i,k) )
-              clwm  = clwmin / max( 0.01, plyr(i,k)*0.001 )
-!
-              tem1  = min(max((onemrh*qstl(i,k))**0.49,0.0001),1.0)  !jhan
-              if (lmfdeep2) then
-                tem1  = xrc3 / tem1
+              if(rhly(i,k) > 1.) then
+                cldtot(i,k) = 1.
               else
-                tem1  = 100.0 / tem1
-              endif
+                onemrh= max( 1.e-10, 1.0-rhly(i,k) )
+                clwm  = clwmin / max( 0.01, plyr(i,k)*0.001 )
 !
-              value = max( min( tem1*(clwf(i,k)-clwm), 50.0 ), 0.0 )
-              tem2  = sqrt( sqrt(rhly(i,k)) )
-
-              cldtot(i,k) = max( tem2*(1.0-exp(-value)), 0.0 )
+                tem1  = min(max((onemrh*qstl(i,k))**0.49,0.0001),1.0)  !jhan
+                if (lmfdeep2) then
+                  tem1  = xrc3 / tem1
+                else
+                  tem1  = 100.0 / tem1
+                endif
+!
+                value = max( min( tem1*(clwf(i,k)-clwm), 50.0 ), 0.0 )
+                tem2  = sqrt( sqrt(rhly(i,k)) )
+  
+                cldtot(i,k) = max( tem2*(1.0-exp(-value)), 0.0 )
+              endif 
             endif
           enddo
           enddo


### PR DESCRIPTION
In the gfsv17 based Thompson MP experiments, there is significantly less cloud cover (low and high) compared with CERES data. The radiative flux biases (dsw at surface and OLR) are larger in the Thompson MP experiments than in the gfsv17 control. The purpose of the work is to increase the cloud cover and reduce the radiative flux bias at the surface and TOA. The cloud cover formulation was modified and namelist options were added to three parameters (related to the supersaturation requirement for ice generation and D0s and D0g) in the Thompson MP to control the ice and high cloud.

The semi-lagrangian sedimentation of graupel is also added as an option in the Thompson scheme in this work.