### PR TITLE
Remove extra logic that reduces optimization for radiation_aerosols.f, update CODEOWNERS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,24 +214,6 @@ elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
       list(APPEND SCHEMES_SFX_OPT ${LOCAL_CURRENT_SOURCE_DIR}/physics/module_sf_mynn.F90)
     endif()
 
-    if (${LOCAL_CURRENT_SOURCE_DIR}/physics/radiation_aerosols.f IN_LIST SCHEMES)
-      # Replace -xHost or -xCORE-AVX2 with -xCORE-AVX-I for certain files
-      set(CMAKE_Fortran_FLAGS_LOPT1 ${CMAKE_Fortran_FLAGS_OPT})
-      string(REPLACE "-xHOST" "-xCORE-AVX-I"
-             CMAKE_Fortran_FLAGS_LOPT1
-             "${CMAKE_Fortran_FLAGS_LOPT1}")
-      string(REPLACE "-xCORE-AVX2" "-xCORE-AVX-I"
-             CMAKE_Fortran_FLAGS_LOPT1
-             "${CMAKE_Fortran_FLAGS_LOPT1}")
-      string(REPLACE "-axSSE4.2,CORE-AVX2" "-axSSE4.2,CORE-AVX-I"
-             CMAKE_Fortran_FLAGS_LOPT1
-             "${CMAKE_Fortran_FLAGS_LOPT1}")
-      SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/radiation_aerosols.f
-                                  PROPERTIES COMPILE_FLAGS "${CMAKE_Fortran_FLAGS_LOPT1}")
-      # Add all of the above files to the list of schemes with special compiler flags
-      list(APPEND SCHEMES_SFX_OPT ${LOCAL_CURRENT_SOURCE_DIR}/physics/radiation_aerosols.f)
-    endif()
-
     # Remove files with special compiler flags from list of files with standard compiler flags
     if (SCHEMES_SFX_OPT)
       list(REMOVE_ITEM SCHEMES ${SCHEMES_SFX_OPT})
@@ -302,7 +284,7 @@ elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
 else()
   message ("CMAKE_Fortran_COMPILER full path: " ${CMAKE_Fortran_COMPILER})
   message ("Fortran compiler: " ${CMAKE_Fortran_COMPILER_ID})
-  message (FATAL_ERROR "This program has only been compiled with gfortran, pgf90 and ifort. If another compiler is needed, the appropriate flags must be added in ${GFS_PHYS_SRC}/CMakeLists.txt")
+  message (FATAL_ERROR "This program has only been compiled with gfortran and ifort. If another compiler is needed, the appropriate flags must be added in ${GFS_PHYS_SRC}/CMakeLists.txt")
 endif()
 
 #------------------------------------------------------------------------------

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # These owners will be the default owners for everything in the repo.
 #*       @defunkt
-*       @climbfuji @llpcarson @grantfirl
+*       @climbfuji @llpcarson @grantfirl @mzhangw @panll
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners


### PR DESCRIPTION
Remove extra logic that reduces optimization for `radiation_aerosols.f` from AVX2 to AVX-I.

In the distant past, this was required to maintain run-to-run reproducibility with an old version of the Intel compiler (v15?) on one of the WCOSS systems (I think). Tests on Hera with Intel 18 show that the code runs fine when using AVX2 for `radiation_aerosols.f`

This change changes the baseline of all model runs.

Also: add @mzhangw and @panll to CODEOWNERS file.