### PR TITLE
Single precision suite-4 from NEPTUNE -- branch jm-nrl-32bitfp-24cc09e -> main

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,20 @@ foreach(typedef_module ${TYPEDEFS})
     list(APPEND MODULES_F90 ${CMAKE_CURRENT_BINARY_DIR}/${typedef_module})
 endforeach()
 
+# This is a hack because I don't know how to get the pre_build to add these
+# modules to the install list --PAR
+if (PROJECT STREQUAL "CCPP-NEPTUNE")
+    # added for CCPP 5: ozne_def.mod, h2o_def.mod, module_radiation_surface.mod
+    list(APPEND MODULES_F90 ${CMAKE_CURRENT_BINARY_DIR}/namelist_soilveg.mod
+                            ${CMAKE_CURRENT_BINARY_DIR}/set_soilveg_mod.mod
+                            ${CMAKE_CURRENT_BINARY_DIR}/physcons.mod
+                            ${CMAKE_CURRENT_BINARY_DIR}/funcphys.mod
+                            ${CMAKE_CURRENT_BINARY_DIR}/ozne_def.mod
+                            ${CMAKE_CURRENT_BINARY_DIR}/h2o_def.mod
+                            ${CMAKE_CURRENT_BINARY_DIR}/module_radiation_surface.mod
+        )
+endif (PROJECT STREQUAL "CCPP-NEPTUNE")
+
 #------------------------------------------------------------------------------
 # Set the sources: physics schemes
 set(SCHEMES $ENV{CCPP_SCHEMES})
@@ -291,30 +305,52 @@ elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
                  APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_DEFAULT_PREC} ${OpenMP_Fortran_FLAGS} ")
 
   else (PROJECT STREQUAL "CCPP-FV3")
-    SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_bfmicrophysics.f
-                                ${LOCAL_CURRENT_SOURCE_DIR}/physics/sflx.f
-                                ${LOCAL_CURRENT_SOURCE_DIR}/physics/sfc_diff.f
-                                ${LOCAL_CURRENT_SOURCE_DIR}/physics/sfc_diag.f
-                                PROPERTIES COMPILE_FLAGS "-r8 ${OpenMP_Fortran_FLAGS} ")
-    SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_nst_model.f90
-                                ${LOCAL_CURRENT_SOURCE_DIR}/physics/calpreciptype.f90
-                                PROPERTIES COMPILE_FLAGS "-r8 -free ${OpenMP_Fortran_FLAGS} ")
     SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/mersenne_twister.f
                                 PROPERTIES COMPILE_FLAGS "-r8 -ftz ${OpenMP_Fortran_FLAGS} ")
-    SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_nst_water_prop.f90
-                                PROPERTIES COMPILE_FLAGS "-extend-source 132 -r8 -free ${OpenMP_Fortran_FLAGS} ")
-    SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/aer_cloud.F
-                                ${LOCAL_CURRENT_SOURCE_DIR}/physics/wv_saturation.F
-                                ${LOCAL_CURRENT_SOURCE_DIR}/physics/cldwat2m_micro.F
-                                ${LOCAL_CURRENT_SOURCE_DIR}/physics/surface_perturbation.F90
-                                PROPERTIES COMPILE_FLAGS "-r8 ${OpenMP_Fortran_FLAGS} ")
-    SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_mp_thompson_make_number_concentrations.F90
-                                PROPERTIES COMPILE_FLAGS "-r8 ${OpenMP_Fortran_FLAGS} ")
-    SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_SF_JSFC.F90
-                                ${LOCAL_CURRENT_SOURCE_DIR}/physics/module_BL_MYJPBL.F90
-                                PROPERTIES COMPILE_FLAGS "-r8 ${OpenMP_Fortran_FLAGS} ")
+    if ( $ENV{SINGLE} MATCHES "t" )
+      SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_bfmicrophysics.f
+                                  ${LOCAL_CURRENT_SOURCE_DIR}/physics/sflx.f
+                                  ${LOCAL_CURRENT_SOURCE_DIR}/physics/sfc_diff.f
+                                  ${LOCAL_CURRENT_SOURCE_DIR}/physics/sfc_diag.f
+                                  PROPERTIES COMPILE_FLAGS " ${OpenMP_Fortran_FLAGS} ")
+      SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_nst_model.f90
+                                  ${LOCAL_CURRENT_SOURCE_DIR}/physics/calpreciptype.f90
+                                  PROPERTIES COMPILE_FLAGS " -free ${OpenMP_Fortran_FLAGS} ")
+      SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_nst_water_prop.f90
+                                  PROPERTIES COMPILE_FLAGS "-extend-source 132 -free ${OpenMP_Fortran_FLAGS} ")
+      SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/aer_cloud.F
+                                  ${LOCAL_CURRENT_SOURCE_DIR}/physics/wv_saturation.F
+                                  ${LOCAL_CURRENT_SOURCE_DIR}/physics/cldwat2m_micro.F
+                                  ${LOCAL_CURRENT_SOURCE_DIR}/physics/surface_perturbation.F90
+                                  PROPERTIES COMPILE_FLAGS " ${OpenMP_Fortran_FLAGS} ")
+      SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_mp_thompson_make_number_concentrations.F90
+                                  PROPERTIES COMPILE_FLAGS "${OpenMP_Fortran_FLAGS} ")
+      SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_SF_JSFC.F90
+                                  ${LOCAL_CURRENT_SOURCE_DIR}/physics/module_BL_MYJPBL.F90
+                                  PROPERTIES COMPILE_FLAGS " ${OpenMP_Fortran_FLAGS} ")
+    else ( $ENV{SINGLE} MATCHES "t" )
+      SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_bfmicrophysics.f
+                                  ${LOCAL_CURRENT_SOURCE_DIR}/physics/sflx.f
+                                  ${LOCAL_CURRENT_SOURCE_DIR}/physics/sfc_diff.f
+                                  ${LOCAL_CURRENT_SOURCE_DIR}/physics/sfc_diag.f
+                                  PROPERTIES COMPILE_FLAGS "-r8 ${OpenMP_Fortran_FLAGS} ")
+      SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_nst_model.f90
+                                  ${LOCAL_CURRENT_SOURCE_DIR}/physics/calpreciptype.f90
+                                  PROPERTIES COMPILE_FLAGS "-r8 -free ${OpenMP_Fortran_FLAGS} ")
+      SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_nst_water_prop.f90
+                                  PROPERTIES COMPILE_FLAGS "-r8 -extend-source 132 -free ${OpenMP_Fortran_FLAGS} ")
+      SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/aer_cloud.F
+                                  ${LOCAL_CURRENT_SOURCE_DIR}/physics/wv_saturation.F
+                                  ${LOCAL_CURRENT_SOURCE_DIR}/physics/cldwat2m_micro.F
+                                  ${LOCAL_CURRENT_SOURCE_DIR}/physics/surface_perturbation.F90
+                                  PROPERTIES COMPILE_FLAGS "-r8 ${OpenMP_Fortran_FLAGS} ")
+      SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_mp_thompson_make_number_concentrations.F90
+                                  PROPERTIES COMPILE_FLAGS "-r8 ${OpenMP_Fortran_FLAGS} ")
+      SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_SF_JSFC.F90
+                                  ${LOCAL_CURRENT_SOURCE_DIR}/physics/module_BL_MYJPBL.F90
+                                  PROPERTIES COMPILE_FLAGS "-r8 ${OpenMP_Fortran_FLAGS} ")
+    endif ( $ENV{SINGLE} MATCHES "t" )
   endif (PROJECT STREQUAL "CCPP-FV3")
-
 else()
   message ("CMAKE_Fortran_COMPILER full path: " ${CMAKE_Fortran_COMPILER})
   message ("Fortran compiler: " ${CMAKE_Fortran_COMPILER_ID})
@@ -348,7 +384,7 @@ endforeach()
 set_target_properties(ccppphys PROPERTIES VERSION ${PROJECT_VERSION}
                                      SOVERSION ${PROJECT_VERSION_MAJOR})
 
-if (PROJECT STREQUAL "CCPP-FV3")
+if (PROJECT STREQUAL "CCPP-FV3" OR PROJECT STREQUAL "CCPP-NEPTUNE")
   # Define where to install the library
   install(TARGETS ccppphys
           EXPORT ccppphys-targets
@@ -364,4 +400,4 @@ if (PROJECT STREQUAL "CCPP-FV3")
   # Define where to install the C headers and Fortran modules
   #install(FILES ${HEADERS_C} DESTINATION include)
   install(FILES ${MODULES_F90} DESTINATION include)
-endif (PROJECT STREQUAL "CCPP-FV3")
+endif (PROJECT STREQUAL "CCPP-FV3" OR PROJECT STREQUAL "CCPP-NEPTUNE")

--- a/physics/GFS_MP_generic.F90
+++ b/physics/GFS_MP_generic.F90
@@ -94,6 +94,7 @@
         graupelprv, draincprv, drainncprv, diceprv, dsnowprv, dgraupelprv, dtp, errmsg, errflg)
 !
       use machine, only: kind_phys
+      use mod_calpreciptype
 
       implicit none
 

--- a/physics/GFS_rad_time_vary.fv3.F90
+++ b/physics/GFS_rad_time_vary.fv3.F90
@@ -10,12 +10,21 @@
 
       contains
 
+!>\defgroup GFS_rad_time_vary GFS RRTMG Update
+!!\ingroup RRTMG
+!! @{
+!! \section arg_table_GFS_rad_time_vary_init Argument Table
+!!
+      subroutine GFS_rad_time_vary_init
+      end subroutine GFS_rad_time_vary_init
+
 !>\defgroup mod_GFS_rad_time_vary GFS Radiation Time Update
 !> @{
 !> \section arg_table_GFS_rad_time_vary_timestep_init Argument Table
 !! \htmlinclude GFS_rad_time_vary_timestep_init.html
 !!
-      subroutine GFS_rad_time_vary_timestep_init (                                     &
+      subroutine GFS_rad_time_vary_timestep_init (nthrds, blksz, lrseeds, &
+               rseeds,      &
               lslwr, lsswr, isubc_lw, isubc_sw, icsdsw, icsdlw, cnx, cny, isc, jsc,    &
               imap, jmap, sec, kdt, imp_physics, imp_physics_zhao_carr, ps_2delt,      &
               ps_1delt, t_2delt, t_1delt, qv_2delt, qv_1delt, t, qv, ps, errmsg, errflg)
@@ -28,6 +37,10 @@
          implicit none
 
          ! Interface variables
+         integer,                intent(in)    :: nthrds
+         integer,                intent(in)    :: blksz(:)
+         logical,                intent(in)    :: lrseeds
+         integer,                intent(in)    :: rseeds(:,:)
          integer,                intent(in)    :: isubc_lw, isubc_sw, cnx, cny, isc, jsc, kdt
          integer,                intent(in)    :: imp_physics, imp_physics_zhao_carr
          logical,                intent(in)    :: lslwr, lsswr
@@ -46,7 +59,7 @@
 
          ! Local variables
          type (random_stat) :: stat
-         integer :: ix, j, i, nblks, ipseed
+         integer :: ii, ix, nb, j, i, nblks, ipseed
          integer :: numrdm(cnx*cny*2)
 
          ! Initialize CCPP error handling variables
@@ -55,23 +68,49 @@
 
          if (lsswr .or. lslwr) then
 
-           !--- call to GFS_radupdate_timestep_init is now in GFS_rrtmg_setup_timestep_init
+           nblks = size(blksz)
+
+           !--- call to GFS_radupdate_run is now in GFS_rrtmg_setup_run
+
+!$OMP parallel num_threads(nthrds) default(none)        &
+!$OMP          private (nb,ix,ii, i,j)                      &
+!$OMP          shared (lrseeds,isubc_lw,isubc_sw,ipsdlim,ipsd0,ipseed) &
+!$OMP          shared (cnx,cny,sec,numrdm,stat,nblks,isc,jsc)  &
+!$OMP          shared (blksz,icsdsw,icsdlw,jmap,imap)
 
            !--- set up random seed index in a reproducible way for entire cubed-sphere face (lat-lon grid)
            if ((isubc_lw==2) .or. (isubc_sw==2)) then
-             ipseed = mod(nint(con_100*sqrt(sec)), ipsdlim) + 1 + ipsd0
-             call random_setseed (ipseed, stat)
-             call random_index (ipsdlim, numrdm, stat)
+!NRL If random seeds supplied by NEPTUNE
+             if(lrseeds) then
+               ii = 1
+               do nb=1,nblks
+                 do ix=1,blksz(nb)
+                   icsdsw(ix) = rseeds(ix,1)
+                   icsdlw(ix) = rseeds(ix,2)
+                 end do
+               enddo
+             else
+!$OMP single
+               ipseed = mod(nint(con_100*sqrt(sec)), ipsdlim) + 1 + ipsd0
+               call random_setseed (ipseed, stat)
+               call random_index (ipsdlim, numrdm, stat)
+!$OMP end single
 
-             do ix=1,size(jmap)
-               j = jmap(ix)
-               i = imap(ix)
-               !--- for testing purposes, replace numrdm with '100'
-               icsdsw(ix) = numrdm(i+isc-1 + (j+jsc-2)*cnx)
-               icsdlw(ix) = numrdm(i+isc-1 + (j+jsc-2)*cnx + cnx*cny)
-             enddo
-
+!$OMP do schedule (dynamic,1)
+               do nb=1,nblks
+                 do ix=1,blksz(nb)
+                   j = jmap(ix)
+                   i = imap(ix)
+                   !--- for testing purposes, replace numrdm with '100'
+                   icsdsw(ix) = numrdm(i+isc-1 + (j+jsc-2)*cnx)
+                   icsdlw(ix) = numrdm(i+isc-1 + (j+jsc-2)*cnx + cnx*cny)
+                 enddo
+               enddo
+!$OMP end do
+             end if
            endif  ! isubc_lw and isubc_sw
+
+!$OMP end parallel
 
            if (imp_physics == imp_physics_zhao_carr) then
              if (kdt == 1) then

--- a/physics/GFS_rad_time_vary.fv3.meta
+++ b/physics/GFS_rad_time_vary.fv3.meta
@@ -7,6 +7,38 @@
 [ccpp-arg-table]
   name = GFS_rad_time_vary_timestep_init
   type = scheme
+[nthrds]
+  standard_name = omp_threads
+  long_name = number of OpenMP threads available for physics schemes
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
+[blksz]
+  standard_name = ccpp_block_sizes
+  long_name = for explicit data blocking: block sizes of all blocks
+  units = count
+  dimensions = (ccpp_block_count)
+  type = integer
+  intent = in
+  optional = F
+[lrseeds]
+  standard_name = flag_for_model_specific_random_seeds
+  long_name = flag for model specific random seeds
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+  optional = F
+[rseeds]
+  standard_name = model_specific_random_seeds
+  long_name = model specific random seeds
+  units = none
+  dimensions = (horizontal_dimension,number_of_random_streams)
+  type = integer
+  intent = in
+  optional = F
 [lslwr]
   standard_name = flag_to_calc_lw
   long_name = logical flags for lw radiation calls

--- a/physics/GFS_rrtmg_post.meta
+++ b/physics/GFS_rrtmg_post.meta
@@ -42,7 +42,7 @@
 [ltp]
   standard_name = extra_top_layer
   long_name = extra top layers
-  units = none
+  units = count
   dimensions = ()
   type = integer
   intent = in

--- a/physics/GFS_rrtmg_pre.F90
+++ b/physics/GFS_rrtmg_pre.F90
@@ -16,7 +16,7 @@
 !!
       ! Attention - the output arguments lm, im, lmk, lmp must not be set
       ! in the CCPP version - they are defined in the interstitial_create routine
-      subroutine GFS_rrtmg_pre_run (im, levs, lm, lmk, lmp, n_var_lndp,        &
+      subroutine GFS_rrtmg_pre_run (im, levs, lm, lmk, lmp, lextop, ltp, n_var_lndp,        &
         imfdeepcnv, imfdeepcnv_gf, me, ncnd, ntrac, num_p3d, npdf3d, ncnvcld3d,&
         ntqv, ntcw,ntiw, ntlnc, ntinc, ncld, ntrw, ntsw, ntgl, ntwa, ntoz,     &
         ntclamt, nleffr, nieffr, nseffr, lndp_type, kdt, imp_physics,          &
@@ -37,11 +37,10 @@
         clouds9, cldsa, cldfra, faersw1, faersw2, faersw3, faerlw1, faerlw2,   &
         faerlw3, alpha, errmsg, errflg)
 
-      use machine,                   only: kind_phys
+      use machine,                   only: kind_phys, r8=>kind_dbl_prec
 
       use physparam
-
-      use radcons,                   only: itsfc,ltp, lextop, qmin,  &
+      use radcons,                   only: itsfc, qmin,  &
                                            qme5, qme6, epsq, prsmin
       use funcphys,                  only: fpvs
 
@@ -79,7 +78,7 @@
 
       implicit none
 
-      integer,              intent(in)  :: im, levs, lm, lmk, lmp, n_var_lndp, &
+      integer,              intent(in)  :: im, levs, lm, lmk, lmp, ltp, n_var_lndp, &
                                            imfdeepcnv,                         &
                                            imfdeepcnv_gf, me, ncnd, ntrac,     &
                                            num_p3d, npdf3d, ncnvcld3d, ntqv,   &
@@ -98,7 +97,7 @@
 
       character(len=3), dimension(:), intent(in) :: lndp_var_list
 
-      logical,              intent(in) :: lsswr, lslwr, ltaerosol, lgfdlmprad, &
+      logical,              intent(in) :: lextop, lsswr, lslwr, ltaerosol, lgfdlmprad, &
                                           uni_cld, effr_in, do_mynnedmf,       &
                                           lmfshal, lmfdeep2, pert_clds
 
@@ -295,6 +294,8 @@
           plyr(i,k1)    = prsl(i,k2)    * 0.01   ! pa to mb (hpa)
           tlyr(i,k1)    = tgrs(i,k2)
           prslk1(i,k1)  = prslk(i,k2)
+          rho(i,k1)     = prsl(i,k2)/(con_rd*tlyr(i,k1))
+          orho(i,k1)    = 1.0/rho(i,k1)
 
 !>  - Compute relative humidity.
           es  = min( prsl(i,k2),  fpvs( tgrs(i,k2) ) )  ! fpvs and prsl in pa
@@ -343,7 +344,6 @@
           enddo
         endif
       endif
-!
       if ( lextop ) then                 ! values for extra top layer
         do i = 1, IM
           plvl(i,llb) = prsmin
@@ -351,6 +351,8 @@
           plyr(i,lyb)   = 0.5 * plvl(i,lla)
           tlyr(i,lyb)   = tlyr(i,lya)
           prslk1(i,lyb) = (plyr(i,lyb)*0.001) ** rocp ! plyr in hPa
+          rho(i,lyb)    = plyr(i,lyb) *100.0/(con_rd*tlyr(i,lyb))
+          orho(i,lyb)   = 1.0/rho(i,lyb)
           rhly(i,lyb)   = rhly(i,lya)
           qstl(i,lyb)   = qstl(i,lya)
         enddo

--- a/physics/GFS_rrtmg_pre.meta
+++ b/physics/GFS_rrtmg_pre.meta
@@ -49,6 +49,18 @@
   type = integer
   intent = in
   optional = F
+[lextop]
+  standard_name = flag_for_extra_top_layer_for_radiation_calculations
+  long_name = flag for extra top layer for radiation calculations
+  units = flag
+  dimensions = ()
+  type = logical
+[ltp]
+  standard_name = extra_top_layer
+  long_name = extra top layer
+  units = count
+  dimensions = ()
+  type = integer
 [n_var_lndp]
   standard_name = number_of_land_surface_variables_perturbed
   long_name = number of land surface variables perturbed

--- a/physics/GFS_rrtmg_setup.F90
+++ b/physics/GFS_rrtmg_setup.F90
@@ -11,8 +11,6 @@ module GFS_rrtmg_setup
    &             iswcliq,                                             &
    &             kind_phys
 
-   use radcons, only: ltp, lextop
-
    implicit none
 
    public GFS_rrtmg_setup_init, GFS_rrtmg_setup_timestep_init, GFS_rrtmg_setup_finalize
@@ -46,7 +44,7 @@ module GFS_rrtmg_setup
           si, levr, ictm, isol, ico2, iaer, ntcw,             &
           num_p3d, npdf3d, ntoz, iovr, isubc_sw, isubc_lw,    &
           icliq_sw, crick_proof, ccnorm,                      &
-          imp_physics,                                        &
+          imp_physics, ltp,                                   &
           norad_precip, idate, iflip,                         &
           do_RRTMGP, im, faerlw, faersw, aerodp,              & ! for consistency checks
           me, errmsg, errflg)
@@ -169,6 +167,7 @@ module GFS_rrtmg_setup
       logical, intent(in) :: crick_proof
       logical, intent(in) :: ccnorm
       integer, intent(in) :: imp_physics
+      integer, intent(in) :: ltp
       logical, intent(in) :: norad_precip
       integer, intent(in) :: idate(:)
       integer, intent(in) :: iflip
@@ -293,7 +292,7 @@ module GFS_rrtmg_setup
 
       call radinit                                                      &
 !  ---  inputs:
-     &     ( si, levr, imp_physics, me )
+     &     ( si, levr, imp_physics, ltp, me )
 !  ---  outputs:
 !          ( none )
 
@@ -374,7 +373,7 @@ module GFS_rrtmg_setup
 ! Private functions
 
 
-   subroutine radinit( si, NLAY, imp_physics, me )
+   subroutine radinit( si, NLAY, imp_physics, ltp, me )
 !...................................
 
 !  ---  inputs:
@@ -487,7 +486,7 @@ module GFS_rrtmg_setup
       implicit none
 
 !  ---  inputs:
-      integer, intent(in) :: NLAY, me, imp_physics 
+      integer, intent(in) :: NLAY, me, imp_physics, ltp
 
       real (kind=kind_phys), intent(in) :: si(:)
 
@@ -517,7 +516,7 @@ module GFS_rrtmg_setup
         print *,' IVFLIP=',ivflip,' IOVR=',iovrRad,                     &
      &    ' ISUBCSW=',isubcsw,' ISUBCLW=',isubclw
         print *,' LCRICK=',lcrick,' LCNORM=',lcnorm,' LNOPREC=',lnoprec
-        print *,' LTP =',ltp,', add extra top layer =',lextop
+        print *,' LTP =',ltp,', add extra top layer =', ltp == 1
 
         if ( ictmflg==0 .or. ictmflg==-2 ) then
           print *,'   Data usage is limited by initial condition!'

--- a/physics/GFS_rrtmg_setup.meta
+++ b/physics/GFS_rrtmg_setup.meta
@@ -145,6 +145,14 @@
   type = integer
   intent = in
   optional = F
+[ltp]
+  standard_name = extra_top_layer
+  long_name = extra top layer for radiation calculations
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
 [norad_precip]
   standard_name = flag_for_precipitation_effect_on_radiation
   long_name = radiation precip flag for Ferrier/Moorthi

--- a/physics/calpreciptype.f90
+++ b/physics/calpreciptype.f90
@@ -1,3 +1,5 @@
+      module mod_calpreciptype
+      contains
 !>\file calpreciptype.f90
 !! This file contains the subroutines that calculates dominant precipitation type.
 
@@ -29,14 +31,14 @@
 !- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       implicit none
 !
-      real,   parameter :: pthresh = 0.0, oneog = 1.0/con_g
+      real(kind=kind_phys),   parameter :: pthresh = 0.0, oneog = 1.0/con_g
       integer,parameter :: nalg    = 5
 !     
 !     declare variables.
 !     
       integer,intent(in) :: kdt,nrcm,im,ix,lm,lp1
-      real,intent(in)    :: xlat(im),xlon(im)
-      real,intent(in)    :: randomno(ix,nrcm)
+      real(kind=kind_phys),intent(in)    :: xlat(im),xlon(im)
+      real(kind=kind_phys),intent(in)    :: randomno(ix,nrcm)
       real(kind=kind_phys),dimension(im),    intent(in)  :: prec,tskin
       real(kind=kind_phys),dimension(ix,lm), intent(in)  :: gt0,gq0,prsl
       real(kind=kind_phys),dimension(ix,lp1),intent(in)  :: prsi,phii
@@ -160,7 +162,6 @@
 
 !> - Call calwxt_ramer() to calculate instantaneous precipitation type component 2.
         call calwxt_ramer(lm,lp1,t,q,pmid,rh,td,pint,iwx)
-
 !
         snow(2)   = mod(iwx,2)
         sleet(2)  = mod(iwx,4)/2
@@ -220,8 +221,9 @@
 !! This subroutine computes precipitation type using a decision tree approach that uses 
 !! variables such as integrated wet bulb temperatue below freezing and lowest layer 
 !! temperature (Baldwin et al. 1994 \cite baldwin_et_al_1994)
-       subroutine calwxt(lm,lp1,t,q,pmid,pint,              &
-                         d608,rog,epsq,zint,iwx,twet)
+      subroutine calwxt(lm,lp1,t,q,pmid,pint,              &
+                        d608,rog,epsq,zint,iwx,twet)
+      use physcons
 ! 
 !     file: calwxt.f
 !     written: 11 november 1993, michael baldwin
@@ -247,10 +249,10 @@
 !      t,q,pmid,htm,lmh,zint
 !
       integer,intent(in)             :: lm,lp1
-      real,dimension(lm),intent(in)  :: t,q,pmid,twet
-      real,dimension(lp1),intent(in) :: zint,pint
+      real(kind=kind_phys),dimension(lm),intent(in)  :: t,q,pmid,twet
+      real(kind=kind_phys),dimension(lp1),intent(in) :: zint,pint
       integer,intent(out)            :: iwx
-      real,intent(in)                :: d608,rog,epsq
+      real(kind=kind_phys),intent(in)                :: d608,rog,epsq
 
 
 !    output:
@@ -264,10 +266,10 @@
 !
 !    internal:
 !
-!     real, allocatable :: twet(:)
-      real, parameter :: d00=0.0 
+!     real(kind=kind_phys), allocatable :: twet(:)
+      real(kind=kind_phys), parameter :: d00=0.0 
       integer karr,licee
-      real    tcold,twarm
+      real(kind=kind_phys)    tcold,twarm
 
 !    subroutines called:
 !     wetbulb
@@ -282,7 +284,7 @@
 !
 
       integer l,lice,iwrml,ifrzl
-      real    psfck,tdchk,a,tdkl,tdpre,tlmhk,twrmk,areas8,areap4,       &
+      real(kind=kind_phys)    psfck,tdchk,a,tdkl,tdpre,tlmhk,twrmk,areas8,areap4,       &
               surfw,surfc,dzkl,area1,pintk1,pintk2,pm150,pkl,tkl,qkl
 
 !      allocate ( twet(lm) )
@@ -486,27 +488,28 @@
 !      use params_mod
 !      use ctlblk_mod 
 !- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+      use physcons
       implicit none
 !
-      real,parameter :: twice=266.55,rhprcp=0.80,deltag=1.02,             &
+      real(kind=kind_phys),parameter :: twice=266.55,rhprcp=0.80,deltag=1.02,             &
      &                  emelt=0.045,rlim=0.04,slim=0.85
-      real,parameter :: twmelt=273.15,tz=273.15,efac=1.0 ! specify in params now 
+      real(kind=kind_phys),parameter :: twmelt=273.15,tz=273.15,efac=1.0 ! specify in params now 
 !
       integer*4 i, k1, lll, k2, toodry
 !
-      real xxx ,mye, icefrac
+      real(kind=kind_phys) xxx ,mye, icefrac
       integer,            intent(in)  :: lm,lp1
-      real,dimension(lm), intent(in)  :: t,q,pmid,rh,td
-      real,dimension(lp1),intent(in)  :: pint
+      real(kind=kind_phys),dimension(lm), intent(in)  :: t,q,pmid,rh,td
+      real(kind=kind_phys),dimension(lp1),intent(in)  :: pint
       integer,            intent(out) :: ptyp
 !
-      real,dimension(lm)              :: tq,pq,rhq,twq
+      real(kind=kind_phys),dimension(lm)              :: tq,pq,rhq,twq
 !
       integer j,l,lev,ii
-      real    rhmax,twmax,ptop,dpdrh,twtop,rhtop,wgt1,wgt2,    &
+      real(kind=kind_phys)    rhmax,twmax,ptop,dpdrh,twtop,rhtop,wgt1,wgt2,    &
               rhavg,dtavg,dpk,ptw,pbot
-!     real b,qtmp,rate,qc
-      real,external :: xmytw
+!     real(kind=kind_phys) b,qtmp,rate,qc
+!     real(kind=kind_phys),external :: xmytw  (now inside the module)
 !
 !  initialize.
       icefrac = -9999.
@@ -521,7 +524,7 @@
 !       causing problems later in this subroutine
 !        qtmp=max(h1m12,q(l))	
 !        rhqtmp(lev)=qtmp/qc
-	rhq(lev) = rh(l)
+        rhq(lev) = rh(l)
         pq(lev)  = pmid(l) * 0.01
         tq(lev)  = t(l)
       enddo
@@ -753,10 +756,11 @@
 !--------------------------------------------------------------------------
       function xmytw(t,td,p)
 !
+      use physcons
       implicit none
 !
       integer*4 cflag, l
-      real   f, c0, c1, c2, k, kd, kw, ew, t, td, p, ed, fp, s,        &
+      real(kind=kind_phys)   f, c0, c1, c2, k, kd, kw, ew, t, td, p, ed, fp, s,        &
      &          de, xmytw
       data f, c0, c1, c2 /0.0006355, 26.66082, 0.0091379024, 6106.3960/
 !
@@ -877,19 +881,20 @@
 !! \cite bourgouin_2000.
 !of aes (canada) 1992
       subroutine calwxt_bourg(lm,lp1,rn,g,t,q,pmid,pint,zint,ptype)
+      use physcons
       implicit none
 !
 !    input:
       integer,intent(in)              :: lm,lp1
-      real,intent(in)                 :: g,rn(2)
-      real,intent(in), dimension(lm)  :: t, q, pmid
-      real,intent(in), dimension(lp1) :: pint, zint
+      real(kind=kind_phys),intent(in)                 :: g,rn(2)
+      real(kind=kind_phys),intent(in), dimension(lm)  :: t, q, pmid
+      real(kind=kind_phys),intent(in), dimension(lp1) :: pint, zint
 !
 !    output:
       integer, intent(out)            :: ptype
 !
       integer ifrzl,iwrml,l,lhiwrm
-      real    pintk1,areane,tlmhk,areape,pintk2,surfw,area1,dzkl,psfck,r1,r2
+      real(kind=kind_phys)    pintk1,areane,tlmhk,areape,pintk2,surfw,area1,dzkl,psfck,r1,r2
 !
 !     initialize weather type array to zero (ie, off).
 !     we do this since we want ptype to represent the
@@ -1076,6 +1081,7 @@
 !     use params_mod
 !     use ctlblk_mod
 !- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+      use physcons
       implicit none
 !
 !  list of variables needed
@@ -1087,9 +1093,9 @@
 !      t,q,pmid,htm,lmh,zint
 
       integer,intent(in)             :: lm,lp1
-      real,dimension(lm),intent(in)  ::  t,q,pmid,twet
-      real,dimension(lp1),intent(in) ::  pint,zint 
-      real,intent(in)                ::  d608,rog,epsq
+      real(kind=kind_phys),dimension(lm),intent(in)  ::  t,q,pmid,twet
+      real(kind=kind_phys),dimension(lp1),intent(in) ::  pint,zint 
+      real(kind=kind_phys),intent(in)                ::  d608,rog,epsq
 !    output:
 !      iwx - instantaneous weather type.
 !        acts like a 4 bit binary
@@ -1101,12 +1107,12 @@
       integer, intent(out) ::  iwx
 !    internal:
 !
-      real, parameter :: d00=0.0  
+      real(kind=kind_phys), parameter :: d00=0.0  
       integer karr,licee
-      real    tcold,twarm
+      real(kind=kind_phys)    tcold,twarm
 !
       integer l,lmhk,lice,iwrml,ifrzl
-      real    psfck,tdchk,a,tdkl,tdpre,tlmhk,twrmk,areas8,areap4,area1,   &
+      real(kind=kind_phys)    psfck,tdchk,a,tdkl,tdpre,tlmhk,twrmk,areas8,areap4,area1,   &
               surfw,surfc,dzkl,pintk1,pintk2,pm150,qkl,tkl,pkl,area0,areap0
 
 !    subroutines called:
@@ -1316,14 +1322,15 @@
 !       algorithms and sums them up to give a dominant type
 !
 !- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+      use physcons
       implicit none
 !
 !    input:
       integer,intent(in)                 :: nalg
-      real,intent(out)                   :: doms,domr,domzr,domip
+      real(kind=kind_phys),intent(out)                   :: doms,domr,domzr,domip
       integer,dimension(nalg),intent(in) :: rain,snow,sleet,freezr
       integer l
-      real totsn,totip,totr,totzr
+      real(kind=kind_phys) totsn,totip,totr,totzr
 !--------------------------------------------------------------------------
 !      print* , 'into dominant'
       domr  = 0.
@@ -1377,3 +1384,4 @@
       return
       end
 !! @}
+      end module mod_calpreciptype

--- a/physics/cires_orowam2017.f
+++ b/physics/cires_orowam2017.f
@@ -1,3 +1,5 @@
+      module mod_cires_orowam2017
+      contains
       subroutine oro_wam_2017(im, levs,npt,ipt, kref,kdt,me,master,
      &   dtp,dxres, taub, u1, v1, t1, xn, yn, bn2, rho, prsi, prsL, 
      &   del, sigma, hprime, gamma, theta,
@@ -384,3 +386,4 @@
       enddo
 !                
       end subroutine ugwpv0_tofd1d
+      end module mod_cires_orowam2017

--- a/physics/cires_ugwp.F90
+++ b/physics/cires_ugwp.F90
@@ -19,6 +19,10 @@ module cires_ugwp
 
     use gwdps, only: gwdps_run
 
+    use mod_cires_ugwp_triggers
+
+    use mod_ugwp_driver_v0
+
     implicit none
 
     private

--- a/physics/cires_ugwp_triggers.F90
+++ b/physics/cires_ugwp_triggers.F90
@@ -1,3 +1,5 @@
+      module mod_cires_ugwp_triggers
+      contains
 !
       subroutine slat_geos5_tamp_v0(im, tau_amp, xlatdeg, tau_gw)
 !=================
@@ -97,3 +99,4 @@
           yaz(4) =-1.0     !S
       endif      
       end  subroutine init_nazdir_v0
+      end module mod_cires_ugwp_triggers

--- a/physics/cires_ugwpv1_sporo.F90
+++ b/physics/cires_ugwpv1_sporo.F90
@@ -1,4 +1,5 @@
-
+      module mod_cires_ugwpv1_sporo
+      contains
       subroutine oro_spectral_solver(im, levs,npt,ipt, kref,kdt,me,master, &
         dtp,dxres, taub, u1, v1, t1, xn, yn, bn2, rho, prsi, prsL,         &
         del, sigma, hprime, gamma, theta,                                  &
@@ -348,4 +349,4 @@
       dzi(k)  =  dzi(k-1)
 
       end subroutine oro_meanflow
-
+      end module mod_cires_ugwpv1_sporo

--- a/physics/cu_gf_deep.F90
+++ b/physics/cu_gf_deep.F90
@@ -2623,10 +2623,10 @@ contains
         p,t,q
      real(kind=kind_phys),    dimension (its:ite,kts:kte)                &
         ,intent (out  )                   ::             &
-        he,hes,qes
+        hes,qes
      real(kind=kind_phys),    dimension (its:ite,kts:kte)                &
         ,intent (inout)                   ::             &
-        z
+        he,z
      real(kind=kind_phys),    dimension (its:ite)                        &
         ,intent (in   )                   ::             &
         psur,z1

--- a/physics/funcphys.f90
+++ b/physics/funcphys.f90
@@ -260,7 +260,7 @@ module funcphys
 !   Language: Fortran 90
 !
 !$$$
-  use machine,only:kind_phys
+  use machine,only:kind_phys,r8=>kind_dbl_prec,r4=>kind_sngl_prec
   use physcons
   implicit none
   private
@@ -308,6 +308,13 @@ module funcphys
   public grkap,frkap,frkapq,frkapx
   public gtlcl,ftlcl,ftlclq,ftlclo,ftlclx
   public gfuncphys
+
+  interface fpvsl
+     module procedure fpvsl_r4, fpvsl_r8 
+  end interface fpvsl
+  interface fpvsi
+     module procedure fpvsi_r4, fpvsi_r8 
+  end interface fpvsi
 contains
 !-------------------------------------------------------------------------------
 !> This subroutine computes saturation vapor pressure table as a function of
@@ -364,7 +371,8 @@ contains
 !! in gpvsl(). See documentation for fpvslx() for details. Input values
 !! outside table range are reset to table extrema. 
 !>\author N phillips
-  elemental function fpvsl(t)
+
+  elemental function fpvsl_r4(t)
 !$$$     Subprogram Documentation Block
 !
 ! Subprogram: fpvsl        Compute saturation vapor pressure over liquid
@@ -396,16 +404,62 @@ contains
 !
 !$$$
     implicit none
-    real(krealfp) fpvsl
-    real(krealfp),intent(in):: t
+    real(r4) fpvsl_r4
+    real(r4),intent(in):: t
     integer jx
-    real(krealfp) xj
+    real(r4) xj
 ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    xj=min(max(c1xpvsl+c2xpvsl*t,1._krealfp),real(nxpvsl,krealfp))
-    jx=min(xj,nxpvsl-1._krealfp)
-    fpvsl=tbpvsl(jx)+(xj-jx)*(tbpvsl(jx+1)-tbpvsl(jx))
+    xj=min(max(c1xpvsl+c2xpvsl*t,1._r4),real(nxpvsl,r4))
+    jx=min(xj,nxpvsl-1._r4)
+    fpvsl_r4=tbpvsl(jx)+(xj-jx)*(tbpvsl(jx+1)-tbpvsl(jx))
 ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  end function
+  end function fpvsl_r4
+
+  elemental function fpvsl_r8(t)
+!$$$     Subprogram Documentation Block
+!
+! Subprogram: fpvsl        Compute saturation vapor pressure over liquid
+!   Author: N Phillips            w/NMC2X2   Date: 30 dec 82
+!
+! Abstract: Compute saturation vapor pressure from the temperature.
+!   A linear interpolation is done between values in a lookup table
+!   computed in gpvsl. See documentation for fpvslx for details.
+!   Input values outside table range are reset to table extrema.
+!   The interpolation accuracy is almost 6 decimal places.
+!   On the Cray, fpvsl is about 4 times faster than exact calculation.
+!   This function should be expanded inline in the calling routine.
+!
+! Program History Log:
+!   91-05-07  Iredell             made into inlinable function
+!   94-12-30  Iredell             expand table
+! 1999-03-01  Iredell             f90 module
+!
+! Usage:   pvsl=fpvsl(t)
+!
+!   Input argument list:
+!     t          Real(krealfp) temperature in Kelvin
+!
+!   Output argument list:
+!     fpvsl      Real(krealfp) saturation vapor pressure in Pascals
+!
+! Attributes:
+!   Language: Fortran 90.
+!
+!$$$
+    implicit none
+    real(r8) fpvsl_r8
+    real(r8),intent(in):: t
+    integer jx
+    real(r8) xj
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    xj=min(max(c1xpvsl+c2xpvsl*t,1._r8),real(nxpvsl,r8))
+    jx=min(xj,nxpvsl-1._r8)
+    fpvsl_r8=tbpvsl(jx)+(xj-jx)*(tbpvsl(jx+1)-tbpvsl(jx))
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  end function fpvsl_r8
+
+
+
 !-------------------------------------------------------------------------------
 !> This function computes saturation vapor pressure from the temperature. 
 !! A quadratic interpolation is done between values in a lookup table 
@@ -576,7 +630,8 @@ contains
 !! computed in gpvsi(). See documentation for fpvsix() for details.
 !! Input values outside table range are reset to table extrema.
 !>\author N Phillips
-  elemental function fpvsi(t)
+
+  elemental function fpvsi_r4(t)
 !$$$     Subprogram Documentation Block
 !
 ! Subprogram: fpvsi        Compute saturation vapor pressure over ice
@@ -609,16 +664,61 @@ contains
 !
 !$$$
     implicit none
-    real(krealfp) fpvsi
-    real(krealfp),intent(in):: t
+    real(r4) fpvsi_r4
+    real(r4),intent(in):: t
     integer jx
-    real(krealfp) xj
+    real(r4) xj
 ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    xj=min(max(c1xpvsi+c2xpvsi*t,1._krealfp),real(nxpvsi,krealfp))
-    jx=min(xj,nxpvsi-1._krealfp)
-    fpvsi=tbpvsi(jx)+(xj-jx)*(tbpvsi(jx+1)-tbpvsi(jx))
+    xj=min(max(c1xpvsi+c2xpvsi*t,1._r4),real(nxpvsi,r4))
+    jx=min(xj,nxpvsi-1._r4)
+    fpvsi_r4=tbpvsi(jx)+(xj-jx)*(tbpvsi(jx+1)-tbpvsi(jx))
 ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  end function
+  end function fpvsi_r4
+
+  elemental function fpvsi_r8(t)
+!$$$     Subprogram Documentation Block
+!
+! Subprogram: fpvsi        Compute saturation vapor pressure over ice
+!   Author: N Phillips            w/NMC2X2   Date: 30 dec 82
+!
+! Abstract: Compute saturation vapor pressure from the temperature.
+!   A linear interpolation is done between values in a lookup table
+!   computed in gpvsi. See documentation for fpvsix for details.
+!   Input values outside table range are reset to table extrema.
+!   The interpolation accuracy is almost 6 decimal places.
+!   On the Cray, fpvsi is about 4 times faster than exact calculation.
+!   This function should be expanded inline in the calling routine.
+!
+! Program History Log:
+!   91-05-07  Iredell             made into inlinable function
+!   94-12-30  Iredell             expand table
+! 1999-03-01  Iredell             f90 module
+! 2001-02-26  Iredell             ice phase
+!
+! Usage:   pvsi=fpvsi(t)
+!
+!   Input argument list:
+!     t          Real(krealfp) temperature in Kelvin
+!
+!   Output argument list:
+!     fpvsi      Real(krealfp) saturation vapor pressure in Pascals
+!
+! Attributes:
+!   Language: Fortran 90.
+!
+!$$$
+    implicit none
+    real(r8) fpvsi_r8
+    real(r8),intent(in):: t
+    integer jx
+    real(r8) xj
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    xj=min(max(c1xpvsi+c2xpvsi*t,1._r8),real(nxpvsi,r8))
+    jx=min(xj,nxpvsi-1._r8)
+    fpvsi_r8=tbpvsi(jx)+(xj-jx)*(tbpvsi(jx+1)-tbpvsi(jx))
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  end function fpvsi_r8
+
 !-------------------------------------------------------------------------------
 !> This function computes saturation vapor pressure from the temperature.
 !! A quadratic interpolation is done between values in a lookup table
@@ -2375,7 +2475,7 @@ contains
 !>\param[in]  pk    real, pressure over 1e5 Pa to the kappa power
 !>\param[out] tma   real, parcel temperature in Kelvin
 !>\param[out] qma   real, parcel specific humidity in kg/kg
-  elemental subroutine stmax(the,pk,tma,qma)
+  subroutine stmax(the,pk,tma,qma)
 !$$$     Subprogram Documentation Block
 !
 ! Subprogram: stmax        Compute moist adiabat temperature
@@ -2443,7 +2543,7 @@ contains
 !>\param[in]  pk   real, pressure over 1e5 Pa to the kappa power
 !>\param[out] tma  real, parcel temperature in Kelvin 
 !>\param[out] qma  real, parcel specific humidity in kg/kg
-  elemental subroutine stmaxg(tg,the,pk,tma,qma)
+  subroutine stmaxg(tg,the,pk,tma,qma)
 !$$$     Subprogram Documentation Block
 !
 ! Subprogram: stmaxg       Compute moist adiabat temperature

--- a/physics/gcycle.F90
+++ b/physics/gcycle.F90
@@ -167,7 +167,8 @@ contains
         endif
       end do
 !
-#ifndef INTERNAL_FILE_NML
+#if 0
+# ifndef INTERNAL_FILE_NML
       inquire (file=trim(Model%fn_nml),exist=exists)
       if (.not. exists) then
         write(6,*) 'gcycle:: namelist file: ',trim(Model%fn_nml),' does not exist'
@@ -176,6 +177,7 @@ contains
         open (unit=Model%nlunit, file=trim(Model%fn_nml), action='READ', status='OLD', iostat=ios)
         rewind (Model%nlunit)
       endif
+# endif
 #endif
       CALL SFCCYCLE (9998, npts, max(lsoil,lsoil_lsm), sig1t, fhcyc, &
                      idate(4), idate(2), idate(3), idate(1),         &
@@ -191,8 +193,10 @@ contains
                      lake, min_lakeice, min_seaice,                  &
                      ialb, isot, ivegsrc,                            &
                      trim(tile_num_ch), imap, jmap)
-#ifndef INTERNAL_FILE_NML
+#if 0
+# ifndef INTERNAL_FILE_NML
       close (Model%nlunit)
+# endif
 #endif
 !
       if ( nsst > 0 ) then

--- a/physics/h2ophys.f
+++ b/physics/h2ophys.f
@@ -123,7 +123,7 @@
           enddo
         endif
         do i=1,im
-          if (prsl(i,l) < prsmax) then
+          if (prsl(i,l) < prsmax .and. pltc(i,2).ne.0.) then    ! TODO JM  20211104
             h2oib(i)  = h2o(i,l)            ! no filling
             tem       = 1.0 / pltc(i,2)     ! 1/teff
             h2o(i,l)  = (h2oib(i) + (pltc(i,1)+pltc(i,3)*tem)*dt)

--- a/physics/iounitdef.f
+++ b/physics/iounitdef.f
@@ -57,7 +57,7 @@
       integer, parameter :: NISIGI2 = 12
       integer, parameter :: NISFCI  = 14
       integer, parameter :: NICO2TR = 15
-      integer, parameter :: NICO2CN = 102
+      integer, parameter :: NICO2CN = 113 ! CCE (Cray) forbids 100-102 20211112 JM
       integer, parameter :: NIMTNVR = 24
       integer, parameter :: NIDTBTH = 27
       integer, parameter :: NIO3PRD = 28

--- a/physics/iounitdef.f
+++ b/physics/iounitdef.f
@@ -66,9 +66,9 @@
       integer, parameter :: NICLTUN = 43
       integer, parameter :: NIO3CLM = 48
       integer, parameter :: NIMICPH = 1
-      integer, parameter :: NISFCYC = 101
-      integer, parameter :: NIAERCM = 102
-      integer, parameter :: NIRADSF = 102
+      integer, parameter :: NISFCYC = 111 ! CCE (Cray) forbids 100-102 20210701 JM
+      integer, parameter :: NIAERCM = 112 ! CCE (Cray) forbids 100-102 20210701 JM
+      integer, parameter :: NIRADSF = 112 ! CCE (Cray) forbids 100-102 20210701 JM
 
 !  --- ... output units
 

--- a/physics/machine.F
+++ b/physics/machine.F
@@ -9,11 +9,12 @@
 #ifndef SINGLE_PREC
       integer, parameter :: kind_io4  = 4, kind_io8  = 8 , kind_ior = 8 &
      &,                     kind_evod = 8, kind_dbl_prec = 8            &
-#ifdef __PGI
+     &,                     kind_sngl_prec = 4
+# ifdef __PGI
      &,                     kind_qdt_prec = 8                           &
-#else
+# else
      &,                     kind_qdt_prec = 16                          &
-#endif
+# endif
      &,                     kind_rad  = 8                               &
      &,                     kind_phys = 8     ,kind_taum=8              &
      &,                     kind_grid = 8                               &
@@ -24,11 +25,12 @@
 #else
       integer, parameter :: kind_io4  = 4, kind_io8  = 8 , kind_ior = 8 &
      &,                     kind_evod = 4, kind_dbl_prec = 8            &
-#ifdef __PGI
+     &,                     kind_sngl_prec = 4
+# ifdef __PGI
      &,                     kind_qdt_prec = 8                           &
-#else
+# else
      &,                     kind_qdt_prec = 16                          &
-#endif
+# endif
      &,                     kind_rad  = 4                               &
      &,                     kind_phys = 4     ,kind_taum=4              &
      &,                     kind_grid = 4                               &

--- a/physics/mfpbl.f
+++ b/physics/mfpbl.f
@@ -1,3 +1,5 @@
+      module mod_mfpbl
+      contains
 !>  \file mfpbl.f
 !!  This file contains the subroutine that calculates the updraft properties and mass flux for use in the Hybrid EDMF PBL scheme.
 
@@ -396,3 +398,4 @@ c
       return
       end
 !> @}
+      end module mod_mfpbl

--- a/physics/mfpblt.f
+++ b/physics/mfpblt.f
@@ -1,3 +1,5 @@
+      module mod_mfpblt
+      contains
 !>\file mfpblt.f
 !! This file contains the subroutine that calculates mass flux and
 !! updraft parcel properties for thermals driven by surface heating 
@@ -452,3 +454,4 @@ c  local variables and arrays
       return
       end
 !> @}
+      end module mod_mfpblt

--- a/physics/mfpbltq.f
+++ b/physics/mfpbltq.f
@@ -1,3 +1,5 @@
+      module mod_mfpbltq
+      contains
 !>\file mfpbltq.f
 !! This file contains the subroutine that calculates mass flux and
 !! updraft parcel properties for thermals driven by surface heating 
@@ -451,3 +453,4 @@ c  local variables and arrays
       return
       end
 !> @}
+      end module mod_mfpbltq

--- a/physics/mfscu.f
+++ b/physics/mfscu.f
@@ -1,3 +1,5 @@
+      module mod_mfscu
+      contains
 !>\file mfscu.f
 !! This file contains the mass flux and downdraft parcel preperties
 !! parameterization for stratocumulus-top-driven turbulence.
@@ -554,3 +556,4 @@ c
       return
       end
 !> @}
+      end module mod_mfscu

--- a/physics/mfscuq.f
+++ b/physics/mfscuq.f
@@ -1,3 +1,5 @@
+      module mod_mfscuq
+      contains
 !>\file mfscuq.f
 !! This file contains the mass flux and downdraft parcel preperties
 !! parameterization for stratocumulus-top-driven turbulence (updated version).
@@ -548,3 +550,4 @@ c
       return
       end
 !> @}
+      end module mod_mfscuq

--- a/physics/module_SGSCloud_RadPre.F90
+++ b/physics/module_SGSCloud_RadPre.F90
@@ -63,7 +63,7 @@
                         eps   => con_eps, & ! Rd/Rv
                       epsm1 => con_epsm1    ! Rd/Rv-1
       use module_radiation_clouds, only : gethml
-      use radcons, only: qmin               ! Minimum vlaues for varius calculations
+      use radcons, only: qmin               ! Minimum values for various calculations
       use funcphys, only: fpvs              ! Function ot compute sat. vapor pressure over liq.
 !------------------------------------------------------------------- 
       implicit none

--- a/physics/module_bl_mynn.F90
+++ b/physics/module_bl_mynn.F90
@@ -2525,7 +2525,7 @@ CONTAINS
            !CLOUD FRACTION. rr2 = 1/SQRT(2) = 0.707
            cldfra_bl1D(k) = 0.5*( 1.0+erf( q1(k)*rr2 ) )
 
-           eq1  = rrp*EXP( -0.5*q1k*q1k )
+           eq1  = rrp*EXP( -0.5*q1k*q1k )  ! TODO q1k is used before defined, 20211112 JM
            qll  = MAX( cldfra_bl1D(k)*q1k + eq1, 0.0 )
            !ESTIMATED LIQUID WATER CONTENT (UNNORMALIZED)
            ql(k) = alp(k)*sgm(k)*qll

--- a/physics/module_mp_thompson.F90
+++ b/physics/module_mp_thompson.F90
@@ -1351,69 +1351,69 @@ MODULE module_mp_thompson
              jmax_qc = j
              kmax_qc = k
              qc_max = qc1d(k)
-            elseif (qc1d(k) .lt. 0.0) then
-             write(*,'(a,e16.7,a,3i8)') 'WARNING, negative qc ', qc1d(k),        &
-                        ' at i,j,k=', i,j,k
+            !elseif (qc1d(k) .lt. 0.0) then
+            ! write(*,'(a,e16.7,a,3i8)') 'WARNING, negative qc ', qc1d(k),        &
+            !            ' at i,j,k=', i,j,k
             endif
             if (qr1d(k) .gt. qr_max) then
              imax_qr = i
              jmax_qr = j
              kmax_qr = k
              qr_max = qr1d(k)
-            elseif (qr1d(k) .lt. 0.0) then
-             write(*,'(a,e16.7,a,3i8)') 'WARNING, negative qr ', qr1d(k),        &
-                        ' at i,j,k=', i,j,k
+            !elseif (qr1d(k) .lt. 0.0) then
+            ! write(*,'(a,e16.7,a,3i8)') 'WARNING, negative qr ', qr1d(k),        &
+            !            ' at i,j,k=', i,j,k
             endif
             if (nr1d(k) .gt. nr_max) then
              imax_nr = i
              jmax_nr = j
              kmax_nr = k
              nr_max = nr1d(k)
-            elseif (nr1d(k) .lt. 0.0) then
-             write(*,'(a,e16.7,a,3i8)') 'WARNING, negative nr ', nr1d(k),        &
-                        ' at i,j,k=', i,j,k
+            !elseif (nr1d(k) .lt. 0.0) then
+            ! write(*,'(a,e16.7,a,3i8)') 'WARNING, negative nr ', nr1d(k),        &
+            !            ' at i,j,k=', i,j,k
             endif
             if (qs1d(k) .gt. qs_max) then
              imax_qs = i
              jmax_qs = j
              kmax_qs = k
              qs_max = qs1d(k)
-            elseif (qs1d(k) .lt. 0.0) then
-             write(*,'(a,e16.7,a,3i8)') 'WARNING, negative qs ', qs1d(k),        &
-                        ' at i,j,k=', i,j,k
+            !elseif (qs1d(k) .lt. 0.0) then
+            ! write(*,'(a,e16.7,a,3i8)') 'WARNING, negative qs ', qs1d(k),        &
+            !            ' at i,j,k=', i,j,k
             endif
             if (qi1d(k) .gt. qi_max) then
              imax_qi = i
              jmax_qi = j
              kmax_qi = k
              qi_max = qi1d(k)
-            elseif (qi1d(k) .lt. 0.0) then
-             write(*,'(a,e16.7,a,3i8)') 'WARNING, negative qi ', qi1d(k),        &
-                        ' at i,j,k=', i,j,k
+            !elseif (qi1d(k) .lt. 0.0) then
+            ! write(*,'(a,e16.7,a,3i8)') 'WARNING, negative qi ', qi1d(k),        &
+            !            ' at i,j,k=', i,j,k
             endif
             if (qg1d(k) .gt. qg_max) then
              imax_qg = i
              jmax_qg = j
              kmax_qg = k
              qg_max = qg1d(k)
-            elseif (qg1d(k) .lt. 0.0) then
-             write(*,'(a,e16.7,a,3i8)') 'WARNING, negative qg ', qg1d(k),        &
-                        ' at i,j,k=', i,j,k
+            !elseif (qg1d(k) .lt. 0.0) then
+            ! write(*,'(a,e16.7,a,3i8)') 'WARNING, negative qg ', qg1d(k),        &
+            !            ' at i,j,k=', i,j,k
             endif
             if (ni1d(k) .gt. ni_max) then
              imax_ni = i
              jmax_ni = j
              kmax_ni = k
              ni_max = ni1d(k)
-            elseif (ni1d(k) .lt. 0.0) then
-             write(*,'(a,e16.7,a,3i8)') 'WARNING, negative ni ', ni1d(k),        &
-                        ' at i,j,k=', i,j,k
+            !elseif (ni1d(k) .lt. 0.0) then
+            ! write(*,'(a,e16.7,a,3i8)') 'WARNING, negative ni ', ni1d(k),        &
+            !            ' at i,j,k=', i,j,k
             endif
             if (qv1d(k) .lt. 0.0) then
-             write(*,'(a,e16.7,a,3i8)') 'WARNING, negative qv ', qv1d(k),        &
-                        ' at i,j,k=', i,j,k
+            ! write(*,'(a,e16.7,a,3i8)') 'WARNING, negative qv ', qv1d(k),        &
+            !            ' at i,j,k=', i,j,k
              if (k.lt.kte-2 .and. k.gt.kts+1) then
-                write(*,*) '   below and above are: ', qv(i,k-1,j), qv(i,k+1,j)
+            !    write(*,*) '   below and above are: ', qv(i,k-1,j), qv(i,k+1,j)
                 qv(i,k,j) = MAX(1.E-7, 0.5*(qv(i,k-1,j) + qv(i,k+1,j)))
              else
                 qv(i,k,j) = 1.E-7

--- a/physics/module_mp_thompson.F90
+++ b/physics/module_mp_thompson.F90
@@ -1221,7 +1221,7 @@ MODULE module_mp_thompson
             m = RSHIFT(ABS(rand_perturb_on),1)
             if (MOD(m,2) .ne. 0) rand2 = rand_pert(i,1,j)*2.
             m = RSHIFT(ABS(rand_perturb_on),2)
-            if (MOD(m,2) .ne. 0) rand3 = 0.25*(rand_pert(i,1,j)+ABS(min_rand))
+            if (MOD(m,2) .ne. 0) rand3 = 0.25*(rand_pert(i,1,j)+ABS(min_rand)) !TODO min_rand used before set 2021112 JM
             m = RSHIFT(ABS(rand_perturb_on),3)
          endif
 !+---+-----------------------------------------------------------------+

--- a/physics/moninedmf.f
+++ b/physics/moninedmf.f
@@ -6,6 +6,9 @@
 !! scheme.
       module hedmf
 
+      use mod_mfpbl
+      use mod_tridi
+
       contains
 
 !> \section arg_table_hedmf_init Argument Table

--- a/physics/physcons.F90
+++ b/physics/physcons.F90
@@ -35,7 +35,7 @@
 !! constants for GCM models.
           module physcons                
 !
-  use machine, only: kind_phys, kind_dyn
+  use machine
 !
   implicit none
 !

--- a/physics/radiation_astronomy.f
+++ b/physics/radiation_astronomy.f
@@ -898,7 +898,9 @@
 
       do i = 1, IM
         coszdg(i) = coszen(i) * rstp
-        if (istsun(i) > 0) coszen(i) = coszen(i) / istsun(i)
+        if (istsun(i) > 0 .and. coszen(i).ne.0) then
+          coszen(i) = coszen(i) / istsun(i)
+        endif
       enddo
 !
       return

--- a/physics/radlw_main.F90
+++ b/physics/radlw_main.F90
@@ -286,7 +286,8 @@
      &                             random_stat
 !mz
       use machine,          only : kind_phys,                           &
-     &                             im => kind_io4, rb => kind_phys
+     &                             im => kind_io4, rb => kind_phys,     &
+     &                             kind_dbl_prec
 
       use module_radlw_parameters
 !
@@ -2071,9 +2072,10 @@
       logical, dimension(ngptlw,nlay), intent(out) :: lcloudy
 
 !  ---  locals:
-      real (kind=kind_phys) :: cdfunc(ngptlw,nlay), rand1d(ngptlw),     &
-     &       rand2d(nlay*ngptlw), tem1, fac_lcf(nlay),                  &
+      real (kind=kind_phys) :: cdfunc(ngptlw,nlay),                     &
+     &                            tem1, fac_lcf(nlay),                  &
      &       cdfun2(ngptlw,nlay)
+      real (kind=kind_dbl_prec) rand2d(nlay*ngptlw), rand1d(ngptlw)
 
       type (random_stat) :: stat          ! for thread safe random generator
 

--- a/physics/radsw_main.F90
+++ b/physics/radsw_main.F90
@@ -310,7 +310,7 @@
       use physcons,         only : con_g, con_cp, con_avgd, con_amd,    &
      &                             con_amw, con_amo3
       use machine,          only : rb => kind_phys, im => kind_io4,     &
-     &                             kind_phys
+     &                             kind_phys, kind_dbl_prec
 
       use module_radsw_parameters
       use mersenne_twister, only : random_setseed, random_number,       &
@@ -1733,6 +1733,10 @@
         tfn = float(i) / float(NTBMX-i)
         tau = bpade * tfn
         exp_tbl(i) = exp( -tau )
+#ifdef SINGLE_PREC
+        ! from WRF version, prevents zero at single prec
+        if (exp_tbl(i) .le. expeps) exp_tbl(i) = expeps
+#endif
       enddo
 
       return
@@ -2213,8 +2217,9 @@
 
 !  ---  locals:
       real (kind=kind_phys) :: cdfunc(nlay,ngptsw), tem1,               &
-     &       rand2d(nlay*ngptsw), rand1d(ngptsw), fac_lcf(nlay),        &
+     &                                            fac_lcf(nlay),        &
      &       cdfun2(nlay,ngptsw)
+      real (kind=kind_dbl_prec) :: rand2d(nlay*ngptsw), rand1d(ngptsw)
 
       type (random_stat) :: stat          ! for thread safe random generator
 

--- a/physics/samfdeepcnv.f
+++ b/physics/samfdeepcnv.f
@@ -1431,6 +1431,13 @@ c
                 ktcon1(i) = k
                 flg(i) = .false.
               endif
+!NRL MNM: Limit overshooting not to be deeper than the actual cloud
+              tem  = zi(i,ktcon(i))-zi(i,kbcon(i))
+              tem1 = zi(i,ktcon1(i))-zi(i,ktcon(i))
+              if(tem1.ge.tem) then
+                ktcon1(i) = k
+                flg(i) = .false.
+              endif
             endif
           endif
         enddo
@@ -2629,6 +2636,9 @@ c
               dellat = (dellah(i,k) - hvap * dellaq(i,k)) / cp
               t1(i,k) = t1(i,k) + dellat * xmb(i) * dt2
               q1(i,k) = q1(i,k) + dellaq(i,k) * xmb(i) * dt2
+! NRL MNM: Limit q1
+              val = epsilon(1.0_kind_phys)
+              q1(i,k) = max(q1(i,k), val  )
 !             tem = 1./rcs(i)
 !             u1(i,k) = u1(i,k) + dellau(i,k) * xmb(i) * dt2 * tem
 !             v1(i,k) = v1(i,k) + dellav(i,k) * xmb(i) * dt2 * tem

--- a/physics/sascnvn.F
+++ b/physics/sascnvn.F
@@ -1008,6 +1008,13 @@
                 ktcon1(i) = k
                 flg(i) = .false.
               endif
+!NRL MNM: Limit overshooting not to be deeper than the actual cloud
+              tem  = zi(i,ktcon(i))-zi(i,kbcon(i))
+              tem1 = zi(i,ktcon1(i))-zi(i,ktcon(i))
+              if(tem1.ge.tem) then
+                ktcon1(i) = k
+                flg(i) = .false.
+              endif
             endif
           endif
         enddo
@@ -1874,6 +1881,9 @@
               dellat = (dellah(i,k) - hvap * dellaq(i,k)) / cp
               t1(i,k) = t1(i,k) + dellat * xmb(i) * dt2
               q1(i,k) = q1(i,k) + dellaq(i,k) * xmb(i) * dt2
+! NRL MNM: Limit q1
+              val = epsilon(1.0_kind_phys)
+              q1(i,k) = max(q1(i,k), val  )
 !             tem = 1./rcs(i)
 !             u1(i,k) = u1(i,k) + dellau(i,k) * xmb(i) * dt2 * tem
 !             v1(i,k) = v1(i,k) + dellav(i,k) * xmb(i) * dt2 * tem

--- a/physics/sfc_diag_post.F90
+++ b/physics/sfc_diag_post.F90
@@ -19,7 +19,7 @@
                          t2mmp, q2mp, t2m, q2m, u10m, v10m, tmpmin, tmpmax, spfhmin, spfhmax,&
                          wind10mmax, u10mmax, v10mmax, dpt2m, errmsg, errflg)
 
-        use machine,               only: kind_phys
+        use machine,               only: kind_phys, kind_dbl_prec
 
         implicit none
 
@@ -36,7 +36,7 @@
         integer,                              intent(out) :: errflg
 
         integer :: i
-        real(kind=kind_phys) :: tem
+        real(kind=kind_dbl_prec) :: tem    ! made dbl prec always, JM 20211104
 
         ! Initialize CCPP error handling variables
         errmsg = ''
@@ -67,8 +67,9 @@
                 v10mmax(i)    = v10m(i)
              endif
              ! Compute dew point, first using vapor pressure
-             tem = max(pgr(i) * q2m(i) / ( con_eps - con_epsm1 *q2m(i)), 1.e-8)
-             dpt2m(i) = 243.5 / ( ( 17.67 / log(tem/611.2) ) - 1.) + 273.14
+             tem = max(pgr(i) * q2m(i) / ( con_eps - con_epsm1 *q2m(i)), 1.d-8)
+             dpt2m(i) = 243.5_kind_dbl_prec / &
+                ( ( 17.67_kind_dbl_prec / log(tem/611.2_kind_dbl_prec) ) - 1.) + 273.14
           enddo
         endif
 

--- a/physics/sfc_drv.f
+++ b/physics/sfc_drv.f
@@ -7,6 +7,7 @@
       use machine,          only: kind_phys
       use set_soilveg_mod,  only: set_soilveg
       use namelist_soilveg
+      use mod_sflx
 
       implicit none
 

--- a/physics/sfc_drv_ruc.meta
+++ b/physics/sfc_drv_ruc.meta
@@ -83,7 +83,6 @@
   optional = F
 [im]
   standard_name = horizontal_dimension
-  long_name = horizontal dimension
   units = count
   dimensions = ()
   type = integer

--- a/physics/sflx.f
+++ b/physics/sflx.f
@@ -1,3 +1,5 @@
+      module mod_sflx
+      contains
 !>\file sflx.f
 !! This file is the entity of GFS Noah LSM Model(Version 2.7).
 
@@ -906,7 +908,14 @@
         eta = etp
       endif
 
-      beta = eta / etp
+!      beta = eta / etp
+!  guard against div zero (from WRF, JM 20211104)
+      IF (ETP == 0.0) THEN
+        BETA = 0.0
+      ELSE
+        BETA = ETA/ETP
+      ENDIF
+
 
 !>  - Convert the sign of soil heat flux so that:
 !!   -  ssoil>0: warm the surface  (night time)
@@ -3994,8 +4003,8 @@
           do while ( (nlog < 10) .and. (kcount == 0) )
             nlog = nlog + 1
 
-            df = alog( (psis*gs2/lsubf) * ( (1.0 + ck*swl)**2.0 )       &
-     &         * (smcmax/(smc-swl))**bx ) - alog(-(tkelv-tfreez)/tkelv)
+            df = log( (psis*gs2/lsubf) * ( (1.0 + ck*swl)**2.0 )        &
+     &         * (smcmax/(smc-swl))**bx ) - log(-(tkelv-tfreez)/tkelv)
 
             denom = 2.0*ck/(1.0 + ck*swl) + bx/(smc - swl)
             swlk  = swl - df/denom
@@ -5800,3 +5809,4 @@ c ----------------------------------------------------------------------
       end subroutine gfssflx
 !! @}
 !-----------------------------------
+      end module mod_sflx

--- a/physics/sflx.f
+++ b/physics/sflx.f
@@ -3556,7 +3556,6 @@
 !  --- ...  store ice content at each soil layer before calling srt & sstep
 
       do i = 1, nsoil
-        smc(i) = 0. ! TODO tmpfix for smc used-before-set warning JM 20211112
         sice(i) = smc(i) - sh2o(i)
       enddo
 

--- a/physics/sflx.f
+++ b/physics/sflx.f
@@ -3556,6 +3556,7 @@
 !  --- ...  store ice content at each soil layer before calling srt & sstep
 
       do i = 1, nsoil
+        smc(i) = 0. ! TODO tmpfix for smc used-before-set warning JM 20211112
         sice(i) = smc(i) - sh2o(i)
       enddo
 

--- a/physics/surface_perturbation.F90
+++ b/physics/surface_perturbation.F90
@@ -48,7 +48,7 @@ module surface_perturbation
           cdfz = 0.5
         else
           x = 0.5*z*z
-          call cdfgam(x,0.5,del,iflag, cdfx)
+          call cdfgam(x,0.5_kind_phys,del,iflag, cdfx)
           if (iflag.ne.0) return
           if (z.gt.0.0) then
             cdfz = 0.5+0.5*cdfx

--- a/physics/tridi.f
+++ b/physics/tridi.f
@@ -1,3 +1,5 @@
+      module mod_tridi
+      contains
 !>\file tridi.f
 !! These subroutines are originally internal subroutines in moninedmf.f
 
@@ -220,3 +222,4 @@
       return
       end subroutine tridit
 !> @}
+      end module mod_tridi

--- a/physics/ugwp_driver_v0.F
+++ b/physics/ugwp_driver_v0.F
@@ -1,3 +1,6 @@
+      module mod_ugwp_driver_v0
+      use mod_cires_orowam2017
+      contains
 !>\file ugwp_driver_v0.F
 
 !
@@ -1336,7 +1339,7 @@
               else
                 kzw2 = zero
               endif
-              if ( kzw2 > zero ) then
+              if ( kzw2 > zero .and. cdf2 > zero ) then  ! JM, should always be case but ...  20211020
                 v_kzw = sqrt(kzw2)
 !	       
 !linsatdis:  kzw2, kzw3, kdsat, c2f2,  cdf2, cdf1
@@ -1484,4 +1487,4 @@
        return
        end subroutine fv3_ugwp_solv2_v0
 
-      
+       end module mod_ugwp_driver_v0


### PR DESCRIPTION
	Changes that allows CCPP physics to be compiled and run in the
	NRL NEPTUNE model. These changes are relative to CCPP repository
	hash 24cc09e (Thu May 27 13:02:47 2021 -0600).

	Note that some of the changes here are NRL-specific and may not
	relate to the changes for 32-bit floating point. Rather than
	take these out, I erred on the side of caution and left them in
	to avoid introducing errors.

	A few highlights:

	  - Autopromotion using -r8 is turned off except for
            mersenne_twister when SINGLE_PREC is defined

          - A number of source files that contained bare subroutines
            and functions are turned to modules and use-associated where
            needed. This is valuable for checking dummy/actual argument
            lists for precision type-agreement

          - Conditional guard-rails added where needed to prevent div-zero
            and neg args to log, sqrt, etc.

	Status is that this compiles and runs in NEPTUNE for 150 steps
	(75 minutes) without floating point exceptions or NaNs using CCPP
	physics suite four.  More careful meteorological V&V is a TODO.
	On Narwhal, an AMD Epyc Rome system at NAVO, these changes halved
	the time spent in physics.

        J. Michalakes, 20211107

 Changes to be committed:
	modified:   CMakeLists.txt
	modified:   physics/GFS_MP_generic.F90
	modified:   physics/GFS_rad_time_vary.fv3.F90
	modified:   physics/GFS_rad_time_vary.fv3.meta
	modified:   physics/GFS_rrtmg_post.meta
	modified:   physics/GFS_rrtmg_pre.F90
	modified:   physics/GFS_rrtmg_pre.meta
	modified:   physics/GFS_rrtmg_setup.F90
	modified:   physics/GFS_rrtmg_setup.meta
	modified:   physics/calpreciptype.f90
	modified:   physics/cires_orowam2017.f
	modified:   physics/cires_ugwp.F90
	modified:   physics/cires_ugwp_triggers.F90
	modified:   physics/cires_ugwpv1_sporo.F90
	modified:   physics/funcphys.f90
	modified:   physics/gcycle.F90
	modified:   physics/h2ophys.f
	modified:   physics/iounitdef.f
	modified:   physics/machine.F
	modified:   physics/mfpbl.f
	modified:   physics/mfpblt.f
	modified:   physics/mfpbltq.f
	modified:   physics/mfscu.f
	modified:   physics/mfscuq.f
	modified:   physics/module_SGSCloud_RadPre.F90
	modified:   physics/module_bl_mynn.F90
	modified:   physics/module_mp_thompson.F90
	modified:   physics/moninedmf.f
	modified:   physics/physcons.F90
	modified:   physics/radiation_astronomy.f
	modified:   physics/radlw_main.F90
	modified:   physics/radsw_main.F90
	modified:   physics/samfdeepcnv.f
	modified:   physics/sascnvn.F
	modified:   physics/sfc_diag_post.F90
	modified:   physics/sfc_drv.f
	modified:   physics/sfc_drv_ruc.meta
	modified:   physics/sflx.f
	modified:   physics/surface_perturbation.F90
	modified:   physics/tridi.f
	modified:   physics/ugwp_driver_v0.F