### PR TITLE
Cleanup CCPP cmake flags part 1, remove extra logic that reduces optimization for radiation_aerosols.f, update CODEOWNERS, update README.md

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,25 +143,6 @@ set(SCHEMES_OPENMP_OFF ${LOCAL_CURRENT_SOURCE_DIR}/physics/rte-rrtmgp/rrtmgp/mo_
 #------------------------------------------------------------------------------
 if (${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
 
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-none")
-
-  SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_bfmicrophysics.f
-                              ${LOCAL_CURRENT_SOURCE_DIR}/physics/sflx.f
-                              ${LOCAL_CURRENT_SOURCE_DIR}/physics/sfc_diff.f
-                              ${LOCAL_CURRENT_SOURCE_DIR}/physics/sfc_diag.f
-                              ${LOCAL_CURRENT_SOURCE_DIR}/physics/module_nst_model.f90
-                              ${LOCAL_CURRENT_SOURCE_DIR}/physics/calpreciptype.f90
-                              ${LOCAL_CURRENT_SOURCE_DIR}/physics/mersenne_twister.f
-                              ${LOCAL_CURRENT_SOURCE_DIR}/physics/module_nst_water_prop.f90
-                              ${LOCAL_CURRENT_SOURCE_DIR}/physics/aer_cloud.F
-                              ${LOCAL_CURRENT_SOURCE_DIR}/physics/wv_saturation.F
-                              ${LOCAL_CURRENT_SOURCE_DIR}/physics/cldwat2m_micro.F
-                              ${LOCAL_CURRENT_SOURCE_DIR}/physics/surface_perturbation.F90
-                              ${LOCAL_CURRENT_SOURCE_DIR}/physics/module_mp_thompson_make_number_concentrations.F90
-                              ${LOCAL_CURRENT_SOURCE_DIR}/physics/module_SF_JSFC.F90
-                              ${LOCAL_CURRENT_SOURCE_DIR}/physics/module_BL_MYJPBL.F90
-                              PROPERTIES COMPILE_FLAGS "-fdefault-real-8 -fdefault-double-8 ${OpenMP_Fortran_FLAGS}")
-
   if (PROJECT STREQUAL "CCPP-FV3")
     # Set 32-bit floating point precision flags for certain files
     # that are executed in the dynamics (fast physics part)
@@ -274,29 +255,6 @@ elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
     SET_PROPERTY(SOURCE ${SCHEMES2} ${CAPS}
                  APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_DEFAULT_PREC} ${OpenMP_Fortran_FLAGS} ")
 
-  else (PROJECT STREQUAL "CCPP-FV3")
-    SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_bfmicrophysics.f
-                                ${LOCAL_CURRENT_SOURCE_DIR}/physics/sflx.f
-                                ${LOCAL_CURRENT_SOURCE_DIR}/physics/sfc_diff.f
-                                ${LOCAL_CURRENT_SOURCE_DIR}/physics/sfc_diag.f
-                                PROPERTIES COMPILE_FLAGS "-r8 ${OpenMP_Fortran_FLAGS} ")
-    SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_nst_model.f90
-                                ${LOCAL_CURRENT_SOURCE_DIR}/physics/calpreciptype.f90
-                                PROPERTIES COMPILE_FLAGS "-r8 -free ${OpenMP_Fortran_FLAGS} ")
-    SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/mersenne_twister.f
-                                PROPERTIES COMPILE_FLAGS "-r8 -ftz ${OpenMP_Fortran_FLAGS} ")
-    SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_nst_water_prop.f90
-                                PROPERTIES COMPILE_FLAGS "-extend-source 132 -r8 -free ${OpenMP_Fortran_FLAGS} ")
-    SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/aer_cloud.F
-                                ${LOCAL_CURRENT_SOURCE_DIR}/physics/wv_saturation.F
-                                ${LOCAL_CURRENT_SOURCE_DIR}/physics/cldwat2m_micro.F
-                                ${LOCAL_CURRENT_SOURCE_DIR}/physics/surface_perturbation.F90
-                                PROPERTIES COMPILE_FLAGS "-r8 ${OpenMP_Fortran_FLAGS} ")
-    SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_mp_thompson_make_number_concentrations.F90
-                                PROPERTIES COMPILE_FLAGS "-r8 ${OpenMP_Fortran_FLAGS} ")
-    SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_SF_JSFC.F90
-                                ${LOCAL_CURRENT_SOURCE_DIR}/physics/module_BL_MYJPBL.F90
-                                PROPERTIES COMPILE_FLAGS "-r8 ${OpenMP_Fortran_FLAGS} ")
   endif (PROJECT STREQUAL "CCPP-FV3")
 
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,24 +195,6 @@ elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
       list(APPEND SCHEMES_SFX_OPT ${LOCAL_CURRENT_SOURCE_DIR}/physics/module_sf_mynn.F90)
     endif()
 
-    if (${LOCAL_CURRENT_SOURCE_DIR}/physics/radiation_aerosols.f IN_LIST SCHEMES)
-      # Replace -xHost or -xCORE-AVX2 with -xCORE-AVX-I for certain files
-      set(CMAKE_Fortran_FLAGS_LOPT1 ${CMAKE_Fortran_FLAGS_OPT})
-      string(REPLACE "-xHOST" "-xCORE-AVX-I"
-             CMAKE_Fortran_FLAGS_LOPT1
-             "${CMAKE_Fortran_FLAGS_LOPT1}")
-      string(REPLACE "-xCORE-AVX2" "-xCORE-AVX-I"
-             CMAKE_Fortran_FLAGS_LOPT1
-             "${CMAKE_Fortran_FLAGS_LOPT1}")
-      string(REPLACE "-axSSE4.2,CORE-AVX2" "-axSSE4.2,CORE-AVX-I"
-             CMAKE_Fortran_FLAGS_LOPT1
-             "${CMAKE_Fortran_FLAGS_LOPT1}")
-      SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/radiation_aerosols.f
-                                  PROPERTIES COMPILE_FLAGS "${CMAKE_Fortran_FLAGS_LOPT1}")
-      # Add all of the above files to the list of schemes with special compiler flags
-      list(APPEND SCHEMES_SFX_OPT ${LOCAL_CURRENT_SOURCE_DIR}/physics/radiation_aerosols.f)
-    endif()
-
     # Remove files with special compiler flags from list of files with standard compiler flags
     if (SCHEMES_SFX_OPT)
       list(REMOVE_ITEM SCHEMES ${SCHEMES_SFX_OPT})
@@ -260,7 +242,7 @@ elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
 else()
   message ("CMAKE_Fortran_COMPILER full path: " ${CMAKE_Fortran_COMPILER})
   message ("Fortran compiler: " ${CMAKE_Fortran_COMPILER_ID})
-  message (FATAL_ERROR "This program has only been compiled with gfortran, pgf90 and ifort. If another compiler is needed, the appropriate flags must be added in ${GFS_PHYS_SRC}/CMakeLists.txt")
+  message (FATAL_ERROR "This program has only been compiled with gfortran and ifort. If another compiler is needed, the appropriate flags must be added in ${GFS_PHYS_SRC}/CMakeLists.txt")
 endif()
 
 #------------------------------------------------------------------------------

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # These owners will be the default owners for everything in the repo.
 #*       @defunkt
-*       @climbfuji @llpcarson @grantfirl
+*       @climbfuji @llpcarson @grantfirl @mzhangw @panll
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners

--- a/README.md
+++ b/README.md
@@ -5,16 +5,24 @@ The Common Community Physics Package (CCPP) is designed to facilitate the implem
 Please see more information about the CCPP at the locations below.
 
 - [CCPP website hosted by the Developmental Testbed Center (DTC)](https://dtcenter.org/ccpp)
-- [CCPP public release information](https://dtcenter.org/community-code/common-community-physics-package-ccpp/ccpp-scm-version-4-0)
-- [CCPP Technical Documentation](https://ccpp-techdoc.readthedocs.io/en/latest/)
-- [CCPP Scientific Documentation](https://dtcenter.org/GMTB/v4.0/sci_doc/)
-- [CCPP Physics GutHub wiki](https://github.com/NCAR/ccpp-physics/wiki)
+- [CCPP public release information](https://dtcenter.org/community-code/common-community-physics-package-ccpp/download)
+- [CCPP Technical Documentation](https://ccpp-techdoc.readthedocs.io/en/latest)
+- [CCPP Scientific Documentation](https://dtcenter.ucar.edu/GMTB/v5.0.0/sci_doc)
+- [CCPP Physics GitHub wiki](https://github.com/NCAR/ccpp-physics/wiki)
 - [CCPP Framework GitHub wiki](https://github.com/NCAR/ccpp-framework/wiki)
 
-For the use of CCPP with its Single Column Model, see the [Single Column Model User's Guide](https://dtcenter.org/GMTB/v4.0/scm-ccpp-guide-v4.0.pdf).
+For the use of CCPP with its Single Column Model, see the [Single Column Model User's Guide](http://dtcenter.org/sites/default/files/paragraph/scm-ccpp-guide-v5.0.0.pdf).
 
-For the use of CCPP with NOAA's Unified Forecast System (UFS), see the [UFS Medium-Range Application User's Guide](https://ufs-mrweather-app.readthedocs.io/en/latest/) and the [UFS Weather Model User's Guide](https://ufs-weather-model.readthedocs.io/en/latest/).
+For the use of CCPP with NOAA's Unified Forecast System (UFS), see the [UFS Medium-Range Application User's Guide](https://ufs-mrweather-app.readthedocs.io/en/latest), the [UFS Short-Range Application User's Guide](https://ufs-srweather-app.readthedocs.io/en/latest) and the [UFS Weather Model User's Guide](https://ufs-weather-model.readthedocs.io/en/latest).
+
+Questions can be directed to the [CCPP User Support Forum](https://dtcenter.org/forum/ccpp-user-support) or posted in the [CCPP Physics GitHub discussions](https://github.com/NCAR/ccpp-physics/discussions) or [CCPP Framework GitHub discussions](https://github.com/NCAR/ccpp-framework/discussions). When using the CCPP with NOAA's UFS, questions can be posted in the [UFS Weather Model](https://forums.ufscommunity.org/forum/ufs-weather-model) section of the [UFS Forum](https://forums.ufscommunity.org).
+
+## Corresponding CCPP Standard Names dictionary
+
+This revision of the CCPP physics library is compliant with [version 0.1.1 of the CCPP Standard Names dictionary](https://github.com/ESCOMP/CCPPStandardNames/releases/tag/v0.1.1).
+
+## Licensing
 
 The Apache license will be in effect unless superseded by an existing license in specific files.
 
-Questions can be directed to the [CCPP Help Desk](mailto:gmtb-help@ucar.edu). When using the CCPP with NOAA's UFS, questions can be posted in the [UFS Weather Model](https://forums.ufscommunity.org/forum/ufs-weather-model) section of the [UFS Forum](https://forums.ufscommunity.org/)
+### Last updated by Dom Heinzeller, 11/04/2021


### PR DESCRIPTION
This PR removes unnecessary cmake compiler settings from ccpp-physics' top-level `CMakeLists.txt`, updates `CODEOWNERS` and `README.md`, and contains the changes frorm #771 (remove extra logic that reduces optimization for radiation_aerosols.f). While #771 changes the results for all tests, this PR does not (verified by creating a temporary baseline with the code in #771, and then verifying against it with the code in this PR).

Associated PRs:

https://github.com/NCAR/ccpp-physics/pull/773
https://github.com/NOAA-EMC/fv3atm/pull/417
https://github.com/ufs-community/ufs-weather-model/pull/897

For regression testing, see https://github.com/ufs-community/ufs-weather-model/pull/897