### PR TITLE
Update several units in CCPP metadata, contains "Expanded format fields for percentages ..." (#777), update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # These owners will be the default owners for everything in the repo.
 #*       @defunkt
-*       @climbfuji @llpcarson @grantfirl @mzhangw @panll
+*       @climbfuji @llpcarson @grantfirl @mzhangw @panll @mkavulich
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners

--- a/physics/GFS_DCNV_generic.meta
+++ b/physics/GFS_DCNV_generic.meta
@@ -422,7 +422,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/GFS_GWD_generic.meta
+++ b/physics/GFS_GWD_generic.meta
@@ -31,7 +31,7 @@
 [mntvar]
   standard_name = statistical_measures_of_subgrid_orography_collection_array
   long_name = array of statistical measures of subgrid height_above_mean_sea_level
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,number_of_statistical_measures_of_subgrid_orography)
   type = real
   kind = kind_phys
@@ -165,7 +165,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys
@@ -327,7 +327,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/GFS_MP_generic.meta
+++ b/physics/GFS_MP_generic.meta
@@ -730,7 +730,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/GFS_PBL_generic.meta
+++ b/physics/GFS_PBL_generic.meta
@@ -721,7 +721,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/GFS_SCNV_generic.meta
+++ b/physics/GFS_SCNV_generic.meta
@@ -383,7 +383,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/GFS_phys_time_vary.fv3.meta
+++ b/physics/GFS_phys_time_vary.fv3.meta
@@ -127,7 +127,7 @@
 [ozpl]
   standard_name = ozone_forcing
   long_name = ozone forcing data
-  units = various
+  units = mixed
   dimensions = (horizontal_dimension,vertical_dimension_of_ozone_forcing_data,number_of_coefficients_in_ozone_forcing_data)
   type = real
   kind = kind_phys
@@ -157,7 +157,7 @@
 [h2opl]
   standard_name = stratospheric_water_vapor_forcing
   long_name = water forcing data
-  units = various
+  units = mixed
   dimensions = (horizontal_dimension,vertical_dimension_of_h2o_forcing_data,number_of_coefficients_in_h2o_forcing_data)
   type = real
   kind = kind_phys
@@ -1116,7 +1116,7 @@
 [ozpl]
   standard_name = ozone_forcing
   long_name = ozone forcing data
-  units = various
+  units = mixed
   dimensions = (horizontal_dimension,vertical_dimension_of_ozone_forcing_data,number_of_coefficients_in_ozone_forcing_data)
   type = real
   kind = kind_phys
@@ -1146,7 +1146,7 @@
 [h2opl]
   standard_name = stratospheric_water_vapor_forcing
   long_name = water forcing data
-  units = various
+  units = mixed
   dimensions = (horizontal_dimension,vertical_dimension_of_h2o_forcing_data,number_of_coefficients_in_h2o_forcing_data)
   type = real
   kind = kind_phys
@@ -1826,7 +1826,7 @@
 [tau_amf]
   standard_name = absolute_momentum_flux_due_to_nonorographic_gravity_wave_drag
   long_name = ngw_absolute_momentum_flux
-  units = various
+  units = mixed
   dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys

--- a/physics/GFS_phys_time_vary.scm.meta
+++ b/physics/GFS_phys_time_vary.scm.meta
@@ -127,7 +127,7 @@
 [ozpl]
   standard_name = ozone_forcing
   long_name = ozone forcing data
-  units = various
+  units = mixed
   dimensions = (horizontal_dimension,vertical_dimension_of_ozone_forcing_data,number_of_coefficients_in_ozone_forcing_data)
   type = real
   kind = kind_phys
@@ -157,7 +157,7 @@
 [h2opl]
   standard_name = stratospheric_water_vapor_forcing
   long_name = water forcing data
-  units = various
+  units = mixed
   dimensions = (horizontal_dimension,vertical_dimension_of_h2o_forcing_data,number_of_coefficients_in_h2o_forcing_data)
   type = real
   kind = kind_phys
@@ -1109,7 +1109,7 @@
 [ozpl]
   standard_name = ozone_forcing
   long_name = ozone forcing data
-  units = various
+  units = mixed
   dimensions = (horizontal_dimension,vertical_dimension_of_ozone_forcing_data,number_of_coefficients_in_ozone_forcing_data)
   type = real
   kind = kind_phys
@@ -1139,7 +1139,7 @@
 [h2opl]
   standard_name = stratospheric_water_vapor_forcing
   long_name = water forcing data
-  units = various
+  units = mixed
   dimensions = (horizontal_dimension,vertical_dimension_of_h2o_forcing_data,number_of_coefficients_in_h2o_forcing_data)
   type = real
   kind = kind_phys
@@ -1333,7 +1333,7 @@
 [tau_amf]
   standard_name = absolute_momentum_flux_due_to_nonorographic_gravity_wave_drag
   long_name = ngw_absolute_momentum_flux
-  units = various
+  units = mixed
   dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys

--- a/physics/GFS_rrtmg_post.meta
+++ b/physics/GFS_rrtmg_post.meta
@@ -253,7 +253,7 @@
 [fluxr]
   standard_name = cumulative_radiation_diagnostic
   long_name = time-accumulated 2D radiation-related diagnostic fields
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,number_of_diagnostics_variables_for_radiation)
   type = real
   kind = kind_phys

--- a/physics/GFS_rrtmgp_lw_post.meta
+++ b/physics/GFS_rrtmgp_lw_post.meta
@@ -163,7 +163,7 @@
 [fluxr]
   standard_name = cumulative_radiation_diagnostic
   long_name = time-accumulated 2D radiation-related diagnostic fields
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,number_of_diagnostics_variables_for_radiation)
   type = real
   kind = kind_phys

--- a/physics/GFS_rrtmgp_pre.meta
+++ b/physics/GFS_rrtmgp_pre.meta
@@ -328,7 +328,7 @@
 [q_lay]
   standard_name = water_vapor_mixing_ratio
   long_name = water vaport mixing ratio
-  units = kg/kg
+  units = kg kg-1
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys

--- a/physics/GFS_rrtmgp_sw_post.meta
+++ b/physics/GFS_rrtmgp_sw_post.meta
@@ -218,7 +218,7 @@
 [fluxr]
   standard_name = cumulative_radiation_diagnostic
   long_name = time-accumulated 2D radiation-related diagnostic fields
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,number_of_diagnostics_variables_for_radiation)
   type = real
   kind = kind_phys

--- a/physics/GFS_rrtmgp_thompsonmp_pre.meta
+++ b/physics/GFS_rrtmgp_thompsonmp_pre.meta
@@ -194,7 +194,7 @@
 [q_lay]
   standard_name = water_vapor_mixing_ratio
   long_name = water vaport mixing ratio
-  units = kg/kg
+  units = kg kg-1
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys

--- a/physics/GFS_suite_interstitial.meta
+++ b/physics/GFS_suite_interstitial.meta
@@ -595,7 +595,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys
@@ -1768,7 +1768,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/cires_ugwp.meta
+++ b/physics/cires_ugwp.meta
@@ -780,7 +780,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/cu_gf_driver.meta
+++ b/physics/cu_gf_driver.meta
@@ -389,7 +389,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/drag_suite.meta
+++ b/physics/drag_suite.meta
@@ -576,7 +576,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/gfdl_fv_sat_adj.meta
+++ b/physics/gfdl_fv_sat_adj.meta
@@ -340,7 +340,7 @@
   intent = inout
 [pkz]
   standard_name = finite_volume_mean_edge_pressure_raised_to_the_power_of_kappa
-  long_name = finite-volume mean edge pressure raised to the power of kappa
+  long_name = finite-volume mean edge pressure in Pa raised to the power of kappa
   units = 1
   dimensions = (starting_x_direction_index:ending_x_direction_index,starting_y_direction_index:ending_y_direction_index,1:vertical_dimension_for_fast_physics)
   type = real

--- a/physics/gfdl_fv_sat_adj.meta
+++ b/physics/gfdl_fv_sat_adj.meta
@@ -341,7 +341,7 @@
 [pkz]
   standard_name = finite_volume_mean_edge_pressure_raised_to_the_power_of_kappa
   long_name = finite-volume mean edge pressure raised to the power of kappa
-  units = Pa**kappa
+  units = 1
   dimensions = (starting_x_direction_index:ending_x_direction_index,starting_y_direction_index:ending_y_direction_index,1:vertical_dimension_for_fast_physics)
   type = real
   kind = kind_dyn

--- a/physics/gwdc.meta
+++ b/physics/gwdc.meta
@@ -529,7 +529,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/h2o_def.meta
+++ b/physics/h2o_def.meta
@@ -22,7 +22,7 @@
 [h2o_pres]
   standard_name = natural_log_of_h2o_forcing_data_pressure_levels
   long_name = natural log of h2o forcing data pressure levels
-  units = log(Pa)
+  units = 1
   dimensions = (vertical_dimension_of_h2o_forcing_data)
   type = real
   kind = kind_phys

--- a/physics/h2o_def.meta
+++ b/physics/h2o_def.meta
@@ -21,7 +21,7 @@
   type = integer
 [h2o_pres]
   standard_name = natural_log_of_h2o_forcing_data_pressure_levels
-  long_name = natural log of h2o forcing data pressure levels
+  long_name = natural log of h2o forcing data pressure levels in Pa
   units = 1
   dimensions = (vertical_dimension_of_h2o_forcing_data)
   type = real

--- a/physics/h2ophys.meta
+++ b/physics/h2ophys.meta
@@ -74,7 +74,7 @@
 [ph2o]
   standard_name = natural_log_of_h2o_forcing_data_pressure_levels
   long_name = natural log of h2o forcing data pressure levels
-  units = log(Pa)
+  units = 1
   dimensions = (vertical_dimension_of_h2o_forcing_data)
   type = real
   kind = kind_phys
@@ -90,7 +90,7 @@
 [h2opltc]
   standard_name = stratospheric_water_vapor_forcing
   long_name = water forcing data
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_dimension_of_h2o_forcing_data,number_of_coefficients_in_h2o_forcing_data)
   type = real
   kind = kind_phys

--- a/physics/m_micro.meta
+++ b/physics/m_micro.meta
@@ -135,7 +135,7 @@
 [mg_qcvar]
   standard_name = relative_variance_of_subgrid_cloud_condensate_distribution
   long_name = cloud water relative variance for MG microphysics
-  units = 
+  units = frac
   dimensions = ()
   type = real
   kind = kind_phys
@@ -151,7 +151,7 @@
 [mg_rhmini]
   standard_name = relative_humidity_threshold_for_ice_nucleation
   long_name = relative humidity threshold parameter for nucleating ice for MG microphysics
-  units = none
+  units = frac
   dimensions = ()
   type = real
   kind = kind_phys

--- a/physics/maximum_hourly_diagnostics.meta
+++ b/physics/maximum_hourly_diagnostics.meta
@@ -194,7 +194,7 @@
 [rh02max]
   standard_name = maximum_relative_humidity_at_2m_over_maximum_hourly_time_interval
   long_name = maximum relative humidity at 2m over maximum hourly time interval
-  units = 1
+  units = frac
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
@@ -202,7 +202,7 @@
 [rh02min]
   standard_name = minimum_relative_humidity_at_2m_over_maximum_hourly_time_interval
   long_name = minumum relative humidity at 2m over maximum hourly time interval
-  units = 1
+  units = frac
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys

--- a/physics/maximum_hourly_diagnostics.meta
+++ b/physics/maximum_hourly_diagnostics.meta
@@ -194,7 +194,7 @@
 [rh02max]
   standard_name = maximum_relative_humidity_at_2m_over_maximum_hourly_time_interval
   long_name = maximum relative humidity at 2m over maximum hourly time interval
-  units = %
+  units = 1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
@@ -202,7 +202,7 @@
 [rh02min]
   standard_name = minimum_relative_humidity_at_2m_over_maximum_hourly_time_interval
   long_name = minumum relative humidity at 2m over maximum hourly time interval
-  units = %
+  units = 1
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys

--- a/physics/module_MYJPBL_wrapper.meta
+++ b/physics/module_MYJPBL_wrapper.meta
@@ -589,7 +589,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/module_MYNNPBL_wrapper.meta
+++ b/physics/module_MYNNPBL_wrapper.meta
@@ -1004,7 +1004,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/module_mp_thompson.F90
+++ b/physics/module_mp_thompson.F90
@@ -1425,7 +1425,7 @@ MODULE module_mp_thompson
 #endif
                       rand1, rand2, rand3, &
                       kts, kte, dt, i, j, ext_diag,                    & 
-                      sedi_semi, decfl, &
+                      sedi_semi, decfl,                                &
                       !vtsk1, txri1, txrc1,                            &
                       prw_vcdc1, prw_vcde1,                            &
                       tpri_inu1, tpri_ide1_d, tpri_ide1_s, tprs_ide1,  &
@@ -1821,7 +1821,7 @@ MODULE module_mp_thompson
                           ! Extended diagnostics, most arrays only
                           ! allocated if ext_diag flag is .true.
                           ext_diag,                                        & 
-                          sedi_semi, decfl, &
+                          sedi_semi, decfl,                                &
                           !vtsk1, txri1, txrc1,                            &
                           prw_vcdc1, prw_vcde1,                            &
                           tpri_inu1, tpri_ide1_d, tpri_ide1_s, tprs_ide1,  &

--- a/physics/moninedmf.meta
+++ b/physics/moninedmf.meta
@@ -526,7 +526,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/moninshoc.meta
+++ b/physics/moninshoc.meta
@@ -452,7 +452,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/mp_fer_hires.meta
+++ b/physics/mp_fer_hires.meta
@@ -274,7 +274,7 @@
 [rhgrd]
   standard_name = relative_humidity_threshold_for_condensation
   long_name = relative humidity threshold parameter for condensation for FA scheme
-  units = none
+  units = frac
   dimensions = ()
   type = real
   kind = kind_phys

--- a/physics/ozne_def.meta
+++ b/physics/ozne_def.meta
@@ -21,7 +21,7 @@
   type = integer
 [oz_pres]
   standard_name = natural_log_of_ozone_forcing_data_pressure_levels
-  long_name = natural log of ozone forcing data pressure levels
+  long_name = natural log of ozone forcing data pressure levels in Pa
   units = 1
   dimensions = (vertical_dimension_of_ozone_forcing_data)
   type = real

--- a/physics/ozne_def.meta
+++ b/physics/ozne_def.meta
@@ -22,7 +22,7 @@
 [oz_pres]
   standard_name = natural_log_of_ozone_forcing_data_pressure_levels
   long_name = natural log of ozone forcing data pressure levels
-  units = log(Pa)
+  units = 1
   dimensions = (vertical_dimension_of_ozone_forcing_data)
   type = real
   kind = kind_phys

--- a/physics/ozphys.meta
+++ b/physics/ozphys.meta
@@ -82,7 +82,7 @@
 [po3]
   standard_name = natural_log_of_ozone_forcing_data_pressure_levels
   long_name = natural log of ozone forcing data pressure levels
-  units = log(Pa)
+  units = 1
   dimensions = (vertical_dimension_of_ozone_forcing_data)
   type = real
   kind = kind_phys
@@ -98,7 +98,7 @@
 [prdout]
   standard_name = ozone_forcing
   long_name = ozone forcing coefficients
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_dimension_of_ozone_forcing_data,number_of_coefficients_in_ozone_forcing_data)
   type = real
   kind = kind_phys
@@ -128,7 +128,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/ozphys_2015.meta
+++ b/physics/ozphys_2015.meta
@@ -82,7 +82,7 @@
 [po3]
   standard_name = natural_log_of_ozone_forcing_data_pressure_levels
   long_name = natural log of ozone forcing data pressure levels
-  units = log(Pa)
+  units = 1
   dimensions = (vertical_dimension_of_ozone_forcing_data)
   type = real
   kind = kind_phys
@@ -98,7 +98,7 @@
 [prdout]
   standard_name = ozone_forcing
   long_name = ozone forcing data
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_dimension_of_ozone_forcing_data,number_of_coefficients_in_ozone_forcing_data)
   type = real
   kind = kind_phys
@@ -128,7 +128,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/phys_tend.meta
+++ b/physics/phys_tend.meta
@@ -17,7 +17,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/rayleigh_damp.meta
+++ b/physics/rayleigh_damp.meta
@@ -133,7 +133,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/satmedmfvdif.meta
+++ b/physics/satmedmfvdif.meta
@@ -499,7 +499,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/satmedmfvdifq.meta
+++ b/physics/satmedmfvdifq.meta
@@ -583,7 +583,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/shinhongvdif.meta
+++ b/physics/shinhongvdif.meta
@@ -439,7 +439,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/ugwpv1_gsldrag.meta
+++ b/physics/ugwpv1_gsldrag.meta
@@ -716,7 +716,7 @@
 [tau_amf]
   standard_name = absolute_momentum_flux_due_to_nonorographic_gravity_wave_drag
   long_name = ngw_absolute_momentum_flux
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys  
@@ -1021,7 +1021,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/unified_ugwp.meta
+++ b/physics/unified_ugwp.meta
@@ -1068,7 +1068,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys

--- a/physics/ysuvdif.meta
+++ b/physics/ysuvdif.meta
@@ -462,7 +462,7 @@
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = various
+  units = mixed
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys


### PR DESCRIPTION
## Description

With the metadata parser update in https://github.com/NCAR/ccpp-framework/pull/415, a stricter checking of units will be enforced. This includes the replacement of "convenience units" such as `log(Pa)` with `1`. All changes:
- Replace units 'various' with 'mixed' as agreed upon on the ccpp-framework developer committee
- Update several invalid convenience units of non-physical quantities with `1`
- Correct the units of the relative humidity variables of the maximum hourly diagnostics from `%` to `1`
- Revert undesired whitespace changes in `module_mp_thomson.F90` from PR https://github.com/NCAR/ccpp-physics/pull/770

Contains all changes from PR #777.

Fixes #776.

Last-minute change: add @mkavulich to CODEOWNERS

## Associated PRs

https://github.com/NCAR/ccpp-framework/pull/415
https://github.com/NCAR/ccpp-physics/pull/775
https://github.com/NOAA-EMC/fv3atm/pull/422
https://github.com/ufs-community/ufs-weather-model/pull/907

## Testing

See https://github.com/ufs-community/ufs-weather-model/pull/907