### PR TITLE
Major cleanup of cmake build config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,6 @@ set(SCHEMES_OPENMP_OFF ${LOCAL_CURRENT_SOURCE_DIR}/physics/rte-rrtmgp/rrtmgp/mo_
                        ${LOCAL_CURRENT_SOURCE_DIR}/physics/rte-rrtmgp/tests/mo_testing_io.F90
                        ${LOCAL_CURRENT_SOURCE_DIR}/physics/rte-rrtmgp/tests/clear_sky_regression.F90
                        ${LOCAL_CURRENT_SOURCE_DIR}/physics/rte-rrtmgp/extensions/mo_rrtmgp_clr_all_sky.F90
-                       ${LOCAL_CURRENT_SOURCE_DIR}/physics/rte-rrtmgp/extensions/mo_fluxes_byband_kernels.F90
                        ${LOCAL_CURRENT_SOURCE_DIR}/physics/rte-rrtmgp/extensions/mo_fluxes_byband.F90
                        ${LOCAL_CURRENT_SOURCE_DIR}/physics/rte-rrtmgp/extensions/solar_variability/mo_solar_variability.F90
                        ${LOCAL_CURRENT_SOURCE_DIR}/physics/rte-rrtmgp/extensions/mo_heating_rates.F90
@@ -153,8 +152,8 @@ if(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_sf_mynn.F90 IN_LIST SCHEMES AND
                               APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_PHYSICS} ${OpenMP_Fortran_FLAGS} -O1")
 endif()
 
-# Reduce optimization for module_sf_mynn.F90 (to avoid an apparent compiler bug with Intel 18 on Hera)
-if(${LOCAL_CURRENT_SOURCE_DIR}/physics/rte-rrtmgp/rrtmgp/kernels/mo_gas_optics_kernels.F90 IN_LIST SCHEMES AND
+# Reduce optimization for mo_gas_optics_kernels.F90 (to avoid an apparent compiler bug with Intel 19+)
+if(${LOCAL_CURRENT_SOURCE_DIR}/physics/rte-rrtmgp/rrtmgp/kernels/mo_gas_optics_kernels.F90 IN_LIST SCHEMES_OPENMP_OFF AND
     (CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "Bitforbit") AND
     ${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
   SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/rte-rrtmgp/rrtmgp/kernels/mo_gas_optics_kernels.F90

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,8 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.3)
 
 project(ccpp_physics
         VERSION 5.0.0
         LANGUAGES Fortran)
-
-# CMP0057: Support new IN_LIST if() operator
-if(POLICY CMP0057)
-    cmake_policy(SET CMP0057 NEW)
-endif(POLICY CMP0057)
 
 #------------------------------------------------------------------------------
 set(PACKAGE "ccpp-physics")
@@ -42,10 +37,10 @@ option(BUILD_SHARED_LIBS "Build a shared library" OFF)
 # Set the sources: physics type definitions
 set(TYPEDEFS $ENV{CCPP_TYPEDEFS})
 if(TYPEDEFS)
-  message(STATUS "Got CCPP TYPEDEFS from environment variable: ${TYPEDEFS}")
+  message(STATUS "Got CCPP TYPEDEFS from environment variable")
 else(TYPEDEFS)
   include(${CMAKE_CURRENT_BINARY_DIR}/CCPP_TYPEDEFS.cmake)
-  message(STATUS "Got CCPP TYPEDEFS from cmakefile include file: ${TYPEDEFS}")
+  message(STATUS "Got CCPP TYPEDEFS from cmakefile include file")
 endif(TYPEDEFS)
 
 # Generate list of Fortran modules from the CCPP type
@@ -58,19 +53,19 @@ endforeach()
 # Set the sources: physics schemes
 set(SCHEMES $ENV{CCPP_SCHEMES})
 if(SCHEMES)
-  message(STATUS "Got CCPP SCHEMES from environment variable: ${SCHEMES}")
+  message(STATUS "Got CCPP SCHEMES from environment variable")
 else(SCHEMES)
   include(${CMAKE_CURRENT_BINARY_DIR}/CCPP_SCHEMES.cmake)
-  message(STATUS "Got CCPP SCHEMES from cmakefile include file: ${SCHEMES}")
+  message(STATUS "Got CCPP SCHEMES from cmakefile include file")
 endif(SCHEMES)
 
 # Set the sources: physics scheme caps
 set(CAPS $ENV{CCPP_CAPS})
 if(CAPS)
-  message(STATUS "Got CCPP CAPS from environment variable: ${CAPS}")
+  message(STATUS "Got CCPP CAPS from environment variable")
 else(CAPS)
   include(${CMAKE_CURRENT_BINARY_DIR}/CCPP_CAPS.cmake)
-  message(STATUS "Got CCPP CAPS from cmakefile include file: ${CAPS}")
+  message(STATUS "Got CCPP CAPS from cmakefile include file")
 endif(CAPS)
 
 # Schemes and caps from the CCPP code generator use full paths with symlinks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,8 @@
-# Set default project to unknown
-if(NOT PROJECT)
-  message(STATUS "Setting CCPP project to 'unknown' as none was specified.")
-  set(PROJECT "Unknown")
-endif (NOT PROJECT)
-
-#------------------------------------------------------------------------------
 cmake_minimum_required(VERSION 3.0)
 
 project(ccpp_physics
         VERSION 5.0.0
         LANGUAGES Fortran)
-
-# Use rpaths on MacOSX
-set(CMAKE_MACOSX_RPATH 1)
-if(POLICY CMP0042)
-    cmake_policy(SET CMP0042 NEW)
-endif(POLICY CMP0042)
 
 # CMP0057: Support new IN_LIST if() operator
 if(POLICY CMP0057)
@@ -29,11 +16,7 @@ set(AUTHORS "Grant Firl" "Dom Heinzeller" "Man Zhang" "Laurie Carson")
 #------------------------------------------------------------------------------
 # Set OpenMP flags for C/C++/Fortran
 if (OPENMP)
-  include(detect_openmp)
-  detect_openmp()
-  message(STATUS "Enable OpenMP support")
-else (OPENMP)
-  message (STATUS "Disable OpenMP support")
+  find_package(OpenMP REQUIRED)
 endif()
 
 #------------------------------------------------------------------------------
@@ -41,9 +24,14 @@ endif()
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     message(STATUS "Setting build type to 'Release' as none was specified.")
     set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
-
     # Set the possible values of build type for cmake-gui
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Bitforbit" "Release" "Coverage")
+endif()
+
+#------------------------------------------------------------------------------
+# Pass debug/release flag to Fortran files for preprocessor
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  add_definitions(-DDEBUG)
 endif()
 
 #------------------------------------------------------------------------------
@@ -85,17 +73,12 @@ else(CAPS)
   message(STATUS "Got CCPP CAPS from cmakefile include file: ${CAPS}")
 endif(CAPS)
 
-# Create empty lists for schemes with special compiler optimization flags
-set(SCHEMES_SFX_OPT "")
-# Create empty lists for schemes with special floating point precision flags
-set(SCHEMES_SFX_PREC "")
-# Create a duplicate of the SCHEMES list for handling floating point precision flags
-set(SCHEMES2 ${SCHEMES})
-
 # Schemes and caps from the CCPP code generator use full paths with symlinks
 # resolved, we need to do the same here for the below logic to work
 get_filename_component(FULL_PATH_TO_CMAKELISTS CMakeLists.txt REALPATH BASE_DIR ${LOCAL_CURRENT_SOURCE_DIR})
 get_filename_component(LOCAL_CURRENT_SOURCE_DIR ${FULL_PATH_TO_CMAKELISTS} DIRECTORY)
+
+#------------------------------------------------------------------------------
 
 # List of files that need to be compiled without OpenMP
 set(SCHEMES_OPENMP_OFF ${LOCAL_CURRENT_SOURCE_DIR}/physics/rte-rrtmgp/rrtmgp/mo_gas_optics.F90
@@ -140,113 +123,44 @@ set(SCHEMES_OPENMP_OFF ${LOCAL_CURRENT_SOURCE_DIR}/physics/rte-rrtmgp/rrtmgp/mo_
                        ${LOCAL_CURRENT_SOURCE_DIR}/physics/rte-rrtmgp/rte/mo_rte_kind.F90
                        ${LOCAL_CURRENT_SOURCE_DIR}/physics/rte-rrtmgp/rte/mo_optical_props.F90)
 
-#------------------------------------------------------------------------------
-if (${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
+# List of files that need to be compiled with different precision
+set(SCHEMES_DYNAMICS)
 
-  if (PROJECT STREQUAL "CCPP-FV3")
-    # Set 32-bit floating point precision flags for certain files
-    # that are executed in the dynamics (fast physics part)
-    if (DYN32)
-      if (${LOCAL_CURRENT_SOURCE_DIR}/physics/gfdl_fv_sat_adj.F90 IN_LIST SCHEMES)
-      # Reduce floating point precision from 64-bit to 32-bit, if necessary
-      set(CMAKE_Fortran_FLAGS_PREC32 ${CMAKE_Fortran_FLAGS_DEFAULT_PREC})
-      string(REPLACE "-fdefault-real-8" ""
-             CMAKE_Fortran_FLAGS_PREC32 "${CMAKE_Fortran_FLAGS_PREC32}")
-      string(REPLACE "-fdefault-double-8" ""
-             CMAKE_Fortran_FLAGS_PREC32 "${CMAKE_Fortran_FLAGS_PREC32}")
-      SET_PROPERTY(SOURCE ${LOCAL_CURRENT_SOURCE_DIR}/physics/gfdl_fv_sat_adj.F90
-                   APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_PREC32} ${OpenMP_Fortran_FLAGS} ")
-      # Add all of the above files to the list of schemes with special floating point precision flags
-      list(APPEND SCHEMES_SFX_PREC ${LOCAL_CURRENT_SOURCE_DIR}/physics/gfdl_fv_sat_adj.F90)
-      endif()
-    endif()
+if(${LOCAL_CURRENT_SOURCE_DIR}/physics/gfdl_fv_sat_adj.F90 IN_LIST SCHEMES)
+  list(APPEND SCHEMES_DYNAMICS ${LOCAL_CURRENT_SOURCE_DIR}/physics/gfdl_fv_sat_adj.F90)
+endif()
 
-    # Remove files with special floating point precision flags from list
-    # of files with standard floating point precision flags
-    if (SCHEMES_SFX_PREC)
-      list(REMOVE_ITEM SCHEMES2 ${SCHEMES_SFX_PREC})
-    endif ()
+# Remove files that need to be compiled with different precision
+# of files with standard compiler flags, and assign OpenMP flags
+if(SCHEMES_DYNAMICS)
+  SET_PROPERTY(SOURCE ${SCHEMES_DYNAMICS}
+               APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_DYNAMICS} ${OpenMP_Fortran_FLAGS}")
+  list(REMOVE_ITEM SCHEMES ${SCHEMES_DYNAMICS})
+endif()
 
-    if (PROJECT STREQUAL "CCPP-FV3")
-      # Remove files that need to be compiled without OpenMP from list
-      # of files with standard compiler flags, and assign no-OpenMP flags
-      if (SCHEMES_OPENMP_OFF)
-        list(REMOVE_ITEM SCHEMES2 ${SCHEMES_OPENMP_OFF})
-      endif ()
-      # Assign standard floating point precision flags to all remaining schemes and caps
-      SET_PROPERTY(SOURCE ${SCHEMES_OPENMP_OFF}
-                   APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_DEFAULT_PREC} ")
-    endif()
+# Remove files that need to be compiled without OpenMP from list
+# of files with standard compiler flags, and assign no-OpenMP flags
+if(SCHEMES_OPENMP_OFF)
+  SET_PROPERTY(SOURCE ${SCHEMES_OPENMP_OFF}
+               APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_PHYSICS}")
+  list(REMOVE_ITEM SCHEMES ${SCHEMES_OPENMP_OFF})
+endif()
 
-    # Assign standard floating point precision flags to all remaining schemes and caps
-    SET_PROPERTY(SOURCE ${SCHEMES2} ${CAPS}
-                 APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_DEFAULT_PREC} ${OpenMP_Fortran_FLAGS} ")
+# Assign standard floating point precision flags to all remaining schemes and caps
+SET_PROPERTY(SOURCE ${SCHEMES} ${CAPS}
+             APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_PHYSICS} ${OpenMP_Fortran_FLAGS}")
 
-  endif (PROJECT STREQUAL "CCPP-FV3")
-
-elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
-  # Adjust settings for bit-for-bit reproducibility of NEMSfv3gfs
-  if (PROJECT STREQUAL "CCPP-FV3")
-
-    if (${LOCAL_CURRENT_SOURCE_DIR}/physics/module_sf_mynn.F90 IN_LIST SCHEMES)
-      # Reduce optimization for module_sf_mynn.F90 (to avoid an apparent compiler bug with Intel 18 on Hera)
-      SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_sf_mynn.F90
-                                  PROPERTIES COMPILE_FLAGS "${CMAKE_Fortran_FLAGS_OPT} -O1")
-      list(APPEND SCHEMES_SFX_OPT ${LOCAL_CURRENT_SOURCE_DIR}/physics/module_sf_mynn.F90)
-    endif()
-
-    # Remove files with special compiler flags from list of files with standard compiler flags
-    if (SCHEMES_SFX_OPT)
-      list(REMOVE_ITEM SCHEMES ${SCHEMES_SFX_OPT})
-    endif(SCHEMES_SFX_OPT)
-    # Assign standard compiler flags to all remaining schemes and caps
-    SET_SOURCE_FILES_PROPERTIES(${SCHEMES} ${CAPS}
-                                PROPERTIES COMPILE_FLAGS "${CMAKE_Fortran_FLAGS_OPT}")
-
-    # Set 32-bit floating point precision flags for certain files
-    # that are executed in the dynamics (fast physics part)
-    if (DYN32)
-      if (${LOCAL_CURRENT_SOURCE_DIR}/physics/gfdl_fv_sat_adj.F90 IN_LIST SCHEMES)
-        # Reduce floating point precision from 64-bit to 32-bit, if necessary
-        set(CMAKE_Fortran_FLAGS_PREC32 ${CMAKE_Fortran_FLAGS_DEFAULT_PREC})
-        string(REPLACE "-real-size 64" "-real-size 32"
-               CMAKE_Fortran_FLAGS_PREC32 "${CMAKE_Fortran_FLAGS_PREC32}")
-        SET_PROPERTY(SOURCE ${LOCAL_CURRENT_SOURCE_DIR}/physics/gfdl_fv_sat_adj.F90
-                     APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_PREC32} ${OpenMP_Fortran_FLAGS} ")
-        # Add all of the above files to the list of schemes with special floating point precision flags
-        list(APPEND SCHEMES_SFX_PREC ${LOCAL_CURRENT_SOURCE_DIR}/physics/gfdl_fv_sat_adj.F90)
-      endif()
-    endif()
-
-    # Remove files with special floating point precision flags from list
-    # of files with standard floating point precision flags flags
-    if (SCHEMES_SFX_PREC)
-      list(REMOVE_ITEM SCHEMES2 ${SCHEMES_SFX_PREC})
-    endif (SCHEMES_SFX_PREC)
-
-    # Remove files that need to be compiled without OpenMP from list
-    # of files with standard compiler flags, and assign no-OpenMP flags
-    if (SCHEMES_OPENMP_OFF)
-      list(REMOVE_ITEM SCHEMES2 ${SCHEMES_OPENMP_OFF})
-      # Assign standard floating point precision flags to all remaining schemes and caps
-      SET_PROPERTY(SOURCE ${SCHEMES_OPENMP_OFF}
-                   APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_DEFAULT_PREC} ")
-    endif ()
-
-    # Assign standard floating point precision flags to all remaining schemes and caps
-    SET_PROPERTY(SOURCE ${SCHEMES2} ${CAPS}
-                 APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_DEFAULT_PREC} ${OpenMP_Fortran_FLAGS} ")
-
-  endif (PROJECT STREQUAL "CCPP-FV3")
-
-else()
-  message ("CMAKE_Fortran_COMPILER full path: " ${CMAKE_Fortran_COMPILER})
-  message ("Fortran compiler: " ${CMAKE_Fortran_COMPILER_ID})
-  message (FATAL_ERROR "This program has only been compiled with gfortran and ifort. If another compiler is needed, the appropriate flags must be added in ${GFS_PHYS_SRC}/CMakeLists.txt")
+# Reduce optimization for module_sf_mynn.F90 (to avoid an apparent compiler bug with Intel 18 on Hera)
+if(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_sf_mynn.F90 IN_LIST SCHEMES AND
+    (CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "Bitforbit") AND
+    ${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
+  SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_sf_mynn.F90
+                              APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_PHYSICS} ${OpenMP_Fortran_FLAGS} -O1")
 endif()
 
 #------------------------------------------------------------------------------
-add_library(ccpp_physics STATIC ${SCHEMES} ${SCHEMES_SFX_OPT} ${CAPS})
+
+add_library(ccpp_physics STATIC ${SCHEMES} ${SCHEMES_OPENMP_OFF} ${SCHEMES_DYNAMICS} ${CAPS})
 # Generate list of Fortran modules from defined sources
 foreach(source_f90 ${CAPS})
     get_filename_component(tmp_source_f90 ${source_f90} NAME)
@@ -263,20 +177,18 @@ target_include_directories(ccpp_physics PUBLIC
 
 target_link_libraries(ccpp_physics PUBLIC w3nco::w3nco_d NetCDF::NetCDF_Fortran)
 
-if (PROJECT STREQUAL "CCPP-FV3")
-  # Define where to install the library
-  install(TARGETS ccpp_physics
-          EXPORT ccpp_physics-targets
-          ARCHIVE DESTINATION lib
-          LIBRARY DESTINATION lib
-          RUNTIME DESTINATION lib
-  )
-  # Export our configuration
-  install(EXPORT ccpp_physics-targets
-          FILE ccpp_physics-config.cmake
-          DESTINATION lib/cmake
-  )
-  # Define where to install the C headers and Fortran modules
-  #install(FILES ${HEADERS_C} DESTINATION include)
-  install(FILES ${MODULES_F90} DESTINATION include)
-endif (PROJECT STREQUAL "CCPP-FV3")
+# Define where to install the library
+install(TARGETS ccpp_physics
+        EXPORT ccpp_physics-targets
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION lib
+)
+# Export our configuration
+install(EXPORT ccpp_physics-targets
+        FILE ccpp_physics-config.cmake
+        DESTINATION lib/cmake
+)
+# Define where to install the C headers and Fortran modules
+#install(FILES ${HEADERS_C} DESTINATION include)
+install(FILES ${MODULES_F90} DESTINATION include)


### PR DESCRIPTION
This PR is a major cleanup of the cmake build config, including removing redundant adjustments of compiler flags and removing host-model specific information. A follow-up or parallel PR will be require for CCPP-SCM to adjust to these build config changes.

This PR is related to issue https://github.com/ufs-community/ufs-weather-model/issues/945.

Associated PRs:

https://github.com/NCAR/ccpp-framework/pull/420
https://github.com/NCAR/ccpp-physics/pull/792
https://github.com/NOAA-EMC/fv3atm/pull/436
https://github.com/ufs-community/ufs-weather-model/pull/943

For regression testing with the UFS, see https://github.com/ufs-community/ufs-weather-model/pull/943.