### PR TITLE
fix the tsurf issue in Noah MP driver

### DIFF
--- a/physics/module_sf_noahmp_glacier.f90
+++ b/physics/module_sf_noahmp_glacier.f90
@@ -738,10 +738,10 @@ contains
 ! thermal conductivity of snow
 
   do iz = isnow+1, 0
-     tksno(iz) = 3.2217e-6*bdsnoi(iz)**2.           ! stieglitz(yen,1965)
+!     tksno(iz) = 3.2217e-6*bdsnoi(iz)**2.           ! stieglitz(yen,1965)
 !    tksno(iz) = 2e-2+2.5e-6*bdsnoi(iz)*bdsnoi(iz)   ! anderson, 1976
 !    tksno(iz) = 0.35                                ! constant
-!    tksno(iz) = 2.576e-6*bdsnoi(iz)**2. + 0.074    ! verseghy (1991)
+    tksno(iz) = 2.576e-6*bdsnoi(iz)**2. + 0.074    ! verseghy (1991)
 !    tksno(iz) = 2.22*(bdsnoi(iz)/1000.)**1.88      ! douvill(yen, 1981)
   enddo
 
@@ -2657,7 +2657,7 @@ end if   ! opt_gla == 1
    real (kind=kind_phys), parameter     :: c4 = 0.04     !< [1/k]
    real (kind=kind_phys), parameter     :: c5 = 2.0      !<
    real (kind=kind_phys), parameter     :: dm = 100.0    !< upper limit on destructive metamorphism compaction [kg/m3]
-   real (kind=kind_phys), parameter     :: eta0 = 0.8e+6 !< viscosity coefficient [kg-s/m2] 
+   real (kind=kind_phys), parameter     :: eta0 = 1.8e+6 !< viscosity coefficient [kg-s/m2] 
                                         !according to anderson, it is between 0.52e6~1.38e6
    real (kind=kind_phys) :: burden !< pressure of overlying snow [kg/m2]
    real (kind=kind_phys) :: ddz1   !< rate of settling of snow pack due to destructive metamorphism.

--- a/physics/module_sf_noahmplsm.f90
+++ b/physics/module_sf_noahmplsm.f90
@@ -2532,10 +2532,10 @@ endif   ! croptype == 0
 ! thermal conductivity of snow
 
   do iz = isnow+1, 0
-     tksno(iz) = 3.2217e-6*bdsnoi(iz)**2.           ! stieglitz(yen,1965)
+!     tksno(iz) = 3.2217e-6*bdsnoi(iz)**2.           ! stieglitz(yen,1965)
 !    tksno(iz) = 2e-2+2.5e-6*bdsnoi(iz)*bdsnoi(iz)   ! anderson, 1976
 !    tksno(iz) = 0.35                                ! constant
-!    tksno(iz) = 2.576e-6*bdsnoi(iz)**2. + 0.074    ! verseghy (1991)
+    tksno(iz) = 2.576e-6*bdsnoi(iz)**2. + 0.074    ! verseghy (1991)
 !    tksno(iz) = 2.22*(bdsnoi(iz)/1000.)**1.88      ! douvill(yen, 1981)
   enddo
 
@@ -7365,7 +7365,7 @@ endif   ! croptype == 0
    real (kind=kind_phys), parameter     :: c4 = 0.04     ![1/k]
    real (kind=kind_phys), parameter     :: c5 = 2.0      !
    real (kind=kind_phys), parameter     :: dm = 100.0    !upper limit on destructive metamorphism compaction [kg/m3]
-   real (kind=kind_phys), parameter     :: eta0 = 0.8e+6 !viscosity coefficient [kg-s/m2] 
+   real (kind=kind_phys), parameter     :: eta0 = 1.8e+6 !viscosity coefficient [kg-s/m2] 
                                         !according to anderson, it is between 0.52e6~1.38e6
    real (kind=kind_phys) :: burden !pressure of overlying snow [kg/m2]
    real (kind=kind_phys) :: ddz1   !rate of settling of snow pack due to destructive metamorphism.

--- a/physics/sfc_noahmp_drv.F90
+++ b/physics/sfc_noahmp_drv.F90
@@ -118,7 +118,7 @@
 
 !  ---  in/outs:
       weasd, snwdph, tskin, tprcp, srflag, smc, stc, slc,        &
-      canopy, trans, zorl,                                       &
+      canopy, trans, tsurf, zorl,                                &
       rb1, fm1, fh1, ustar1, stress1, fm101, fh21,               &
 
 ! --- Noah MP specific
@@ -245,6 +245,7 @@
   real(kind=kind_phys), dimension(:,:)   , intent(inout) :: slc        ! liquid soil moisture [m3/m3]
   real(kind=kind_phys), dimension(:)     , intent(inout) :: canopy     ! canopy moisture content [mm]
   real(kind=kind_phys), dimension(:)     , intent(inout) :: trans      ! total plant transpiration [m/s]
+  real(kind=kind_phys), dimension(:)     , intent(inout) :: tsurf      ! surface skin temperature [K]
   real(kind=kind_phys), dimension(:)     , intent(inout) :: zorl       ! surface roughness [cm]
 
   real(kind=kind_phys), dimension(:)     , intent(inout) :: rb1        ! bulk richardson #
@@ -921,6 +922,7 @@ do i = 1, im
       sncovr1   (i)   = snow_cover_fraction
 
 !     qsurf     (i)   = spec_humidity_surface
+      tsurf     (i)   = tskin(i)
 
       tvxy      (i)   = temperature_leaf
       tgxy      (i)   = temperature_ground

--- a/physics/sfc_noahmp_drv.meta
+++ b/physics/sfc_noahmp_drv.meta
@@ -662,6 +662,14 @@
   type = real
   kind = kind_phys
   intent = inout
+[tsurf]
+  standard_name = surface_skin_temperature_after_iteration_over_land
+  long_name = surface skin temperature after iteration over land
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
 [zorl]
   standard_name = surface_roughness_length_over_land
   long_name = surface roughness length over land  (temporary use as interstitial)


### PR DESCRIPTION
tsurf from Noah MP has been used in other routines. It was deleted from the Noah MP driver in the last [PR ](https://github.com/NCAR/ccpp-physics/pull/729) .  tsurf is the same as tskin after the iteration was removed. In the future we should unify tskin and tsurf over land in the meta file. 

Two more updates were made to address some issues found in the P7:
(1) change snow thermal conductivity to verseghy scheme(yellow line in the graphic below) to reduce the warm soil temperature bias
![single_point_lena_soil_lev1](https://user-images.githubusercontent.com/48133472/146848098-eb7e472b-fab4-4ead-ac2e-512a65aafa06.png)

(2)change eta0 to slow snow compaction