### PR TITLE
Add mynn_cloudpdf3 to enable using G. Thompson cloud fraction scheme in place of Chaboureau-Bechtold

### DIFF
--- a/physics/module_MYNNPBL_wrapper.meta
+++ b/physics/module_MYNNPBL_wrapper.meta
@@ -14,6 +14,7 @@
   dimensions = ()
   type = logical
   intent = in
+  optional = F
 [lheatstrg]
   standard_name = flag_for_canopy_heat_storage_in_land_surface_scheme
   long_name = flag for canopy heat storage parameterization
@@ -21,6 +22,7 @@
   dimensions = ()
   type = logical
   intent = in
+  optional = F
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP
@@ -29,6 +31,7 @@
   type = character
   kind = len=*
   intent = out
+  optional = F
 [errflg]
   standard_name = ccpp_error_flag
   long_name = error flag for error handling in CCPP
@@ -36,6 +39,7 @@
   dimensions = ()
   type = integer
   intent = out
+  optional = F
 
 #####################################################################
 [ccpp-arg-table]
@@ -48,6 +52,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [levs]
   standard_name = vertical_layer_dimension
   long_name = vertical layer dimension
@@ -55,6 +60,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [flag_init]
   standard_name = flag_for_first_timestep
   long_name = flag signaling first time step for time integration loop
@@ -62,6 +68,7 @@
   dimensions = ()
   type = logical
   intent = in
+  optional = F
 [flag_restart]
   standard_name = flag_for_restart
   long_name = flag for restart (warmstart) or coldstart
@@ -69,6 +76,7 @@
   dimensions = ()
   type = logical
   intent = in
+  optional = F
 [cp]
   standard_name = specific_heat_of_dry_air_at_constant_pressure
   long_name = specific heat of dry air at constant pressure
@@ -77,6 +85,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [g]
   standard_name = gravitational_acceleration
   long_name = gravitational acceleration
@@ -85,6 +94,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [r_d]
   standard_name = gas_constant_of_dry_air
   long_name = ideal gas constant for dry air
@@ -93,6 +103,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [r_v]
   standard_name = gas_constant_water_vapor
   long_name = ideal gas constant for water vapor
@@ -101,6 +112,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [cpv]
   standard_name = specific_heat_of_water_vapor_at_constant_pressure
   long_name = specific heat of water vapor at constant pressure
@@ -109,6 +121,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [cliq]
   standard_name = specific_heat_of_liquid_water_at_constant_pressure
   long_name = specific heat of liquid water at constant pressure
@@ -117,6 +130,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [Cice]
   standard_name = specific_heat_of_ice_at_constant_pressure
   long_name = specific heat of ice at constant pressure
@@ -125,6 +139,7 @@
   type = real 
   kind = kind_phys
   intent = in
+  optional = F
 [rcp]
   standard_name = ratio_of_gas_constant_dry_air_to_specific_heat_of_dry_air_at_constant_pressure
   long_name = (rd/cp)
@@ -133,6 +148,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [XLV]
   standard_name = latent_heat_of_vaporization_of_water_at_0C
   long_name = latent heat of evaporation/sublimation
@@ -141,6 +157,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [XLF]
   standard_name = latent_heat_of_fusion_of_water_at_0C
   long_name = latent heat of fusion
@@ -149,6 +166,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [EP_1]
   standard_name = ratio_of_vapor_to_dry_air_gas_constants_minus_one
   long_name = (rv/rd) - 1 (rv = ideal gas constant for water vapor)
@@ -157,6 +175,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [EP_2]
   standard_name = ratio_of_dry_air_to_water_vapor_gas_constants
   long_name = rd/rv
@@ -165,6 +184,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [lssav]
   standard_name = flag_for_diagnostics
   long_name = logical flag for storing diagnostics
@@ -172,6 +192,7 @@
   dimensions = ()
   type = logical
   intent = in
+  optional = F
 [ldiag3d]
   standard_name = flag_for_diagnostics_3D
   long_name = flag for 3d diagnostic fields
@@ -179,6 +200,7 @@
   dimensions = ()
   type = logical
   intent = in
+  optional = F
 [qdiag3d]
   standard_name = flag_for_tracer_diagnostics_3D
   long_name = flag for 3d tracer diagnostic fields
@@ -186,6 +208,7 @@
   dimensions = ()
   type = logical
   intent = in
+  optional = F
 [lsidea]
   standard_name = flag_for_integrated_dynamics_through_earths_atmosphere
   long_name = flag for idealized physics
@@ -193,6 +216,7 @@
   dimensions = ()
   type = logical
   intent = in
+  optional = F
 [cplflx]
   standard_name = flag_for_surface_flux_coupling
   long_name = flag controlling cplflx collection (default off)
@@ -200,6 +224,7 @@
   dimensions = ()
   type = logical
   intent = in
+  optional = F
 [delt]
   standard_name = timestep_for_physics
   long_name = time step for physics
@@ -208,6 +233,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [dtf]
   standard_name = timestep_for_dynamics
   long_name = dynamics timestep
@@ -216,6 +242,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [dx]
   standard_name = characteristic_grid_lengthscale
   long_name = size of the grid cell
@@ -224,6 +251,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [zorl]
   standard_name = surface_roughness_length
   long_name = surface roughness length in cm
@@ -232,6 +260,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [phii]
   standard_name = geopotential_at_interface
   long_name = geopotential at model layer interfaces
@@ -240,6 +269,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [U]
   standard_name = x_wind
   long_name = x component of layer wind
@@ -248,6 +278,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [V]
   standard_name = y_wind
   long_name = y component of layer wind
@@ -256,6 +287,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [omega]
   standard_name = lagrangian_tendency_of_air_pressure
   long_name = layer mean vertical velocity
@@ -264,6 +296,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [T3D]
   standard_name = air_temperature
   long_name = layer mean air temperature
@@ -272,6 +305,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [qgrs_water_vapor]
   standard_name = specific_humidity
   long_name = water vapor specific humidity
@@ -280,6 +314,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [qgrs_liquid_cloud]
   standard_name = cloud_liquid_water_mixing_ratio
   long_name = ratio of mass of cloud water to mass of dry air plus vapor (without condensates)
@@ -288,6 +323,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [qgrs_ice_cloud]
   standard_name = cloud_ice_mixing_ratio
   long_name = ratio of mass of ice water to mass of dry air plus vapor (without condensates)
@@ -296,6 +332,16 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
+[qgrs_snow]
+  standard_name = snow_mixing_ratio
+  long_name = ratio of mass of snow water to mass of dry air plus vapor (without condensates)
+  units = kg kg-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+  optional = F
 [qgrs_cloud_droplet_num_conc]
   standard_name = mass_number_concentration_of_cloud_liquid_water_particles_in_air
   long_name = number concentration of cloud droplets (liquid)
@@ -304,6 +350,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [qgrs_cloud_ice_num_conc]
   standard_name = mass_number_concentration_of_cloud_ice_water_crystals_in_air
   long_name = number concentration of ice
@@ -312,6 +359,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [qgrs_ozone]
   standard_name = ozone_mixing_ratio
   long_name = ozone mixing ratio
@@ -320,6 +368,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [qgrs_water_aer_num_conc]
   standard_name = mass_number_concentration_of_hygroscopic_aerosols
   long_name = number concentration of water-friendly aerosols
@@ -328,6 +377,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [qgrs_ice_aer_num_conc]
   standard_name = mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols
   long_name = number concentration of ice-friendly aerosols
@@ -336,6 +386,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [prsl]
   standard_name = air_pressure
   long_name = mean layer pressure
@@ -344,6 +395,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [exner]
   standard_name = dimensionless_exner_function
   long_name = Exner function at layers
@@ -352,6 +404,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [slmsk]
   standard_name = area_type
   long_name = landmask: sea/land/ice=0/1/2
@@ -360,6 +413,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [tsurf]
   standard_name = surface_skin_temperature
   long_name = surface temperature
@@ -368,6 +422,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [qsfc]
   standard_name = surface_specific_humidity
   long_name = surface air saturation specific humidity
@@ -376,6 +431,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [ps]
   standard_name = surface_air_pressure
   long_name = surface pressure
@@ -384,6 +440,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [ust]
   standard_name = surface_friction_velocity
   long_name = boundary layer parameter
@@ -392,6 +449,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [ch]
   standard_name = surface_drag_wind_speed_for_momentum_in_air
   long_name = momentum exchange coefficient
@@ -400,6 +458,7 @@
   type = real
   kind = kind_phys
   intent = out
+  optional = F
 [hflx]
   standard_name = kinematic_surface_upward_sensible_heat_flux_reduced_by_surface_roughness_and_vegetation
   long_name = kinematic surface upward sensible heat flux reduced by surface roughness and vegetation
@@ -408,6 +467,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [qflx]
   standard_name = surface_upward_specific_humidity_flux
   long_name = kinematic surface upward latent heat flux
@@ -416,6 +476,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [wspd]
   standard_name = wind_speed_at_lowest_model_layer
   long_name = wind speed at lowest model level
@@ -424,6 +485,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [rb]
   standard_name = bulk_richardson_number_at_lowest_model_level
   long_name = bulk Richardson number at the surface
@@ -432,6 +494,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [dtsfc1]
   standard_name = instantaneous_surface_upward_sensible_heat_flux
   long_name = surface upward sensible heat flux valid for current call
@@ -440,6 +503,7 @@
   type = real
   kind = kind_phys
   intent = out
+  optional = F
 [dqsfc1]
   standard_name = instantaneous_surface_upward_latent_heat_flux
   long_name = surface upward latent heat flux valid for current call
@@ -448,6 +512,7 @@
   type = real
   kind = kind_phys
   intent = out
+  optional = F
 [dusfc1]
   standard_name = instantaneous_surface_x_momentum_flux
   long_name = surface momentum flux in the x-direction valid for current call
@@ -456,6 +521,7 @@
   type = real
   kind = kind_phys
   intent = out
+  optional = F
 [dvsfc1]
   standard_name = instantaneous_surface_y_momentum_flux
   long_name = surface momentum flux in the y-direction valid for current call
@@ -464,6 +530,7 @@
   type = real
   kind = kind_phys
   intent = out
+  optional = F
 [dusfci_diag]
   standard_name = instantaneous_surface_x_momentum_flux_for_diag
   long_name = instantaneous sfc x momentum flux multiplied by timestep
@@ -472,6 +539,7 @@
   type = real
   kind = kind_phys
   intent = out
+  optional = F
 [dvsfci_diag]
   standard_name = instantaneous_surface_y_momentum_flux_for_diag
   long_name = instantaneous sfc y momentum flux multiplied by timestep
@@ -480,6 +548,7 @@
   type = real
   kind = kind_phys
   intent = out
+  optional = F
 [dtsfci_diag]
   standard_name = instantaneous_surface_upward_sensible_heat_flux_for_diag
   long_name = instantaneous sfc sensible heat flux multiplied by timestep
@@ -488,6 +557,7 @@
   type = real
   kind = kind_phys
   intent = out
+  optional = F
 [dqsfci_diag]
   standard_name = instantaneous_surface_upward_latent_heat_flux_for_diag
   long_name = instantaneous sfc latent heat flux multiplied by timestep
@@ -496,6 +566,7 @@
   type = real
   kind = kind_phys
   intent = out
+  optional = F
 [dusfc_diag]
   standard_name = cumulative_surface_x_momentum_flux_for_diag_multiplied_by_timestep
   long_name = cumulative sfc x momentum flux multiplied by timestep
@@ -504,6 +575,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [dvsfc_diag]
   standard_name = cumulative_surface_y_momentum_flux_for_diag_multiplied_by_timestep
   long_name = cumulative sfc y momentum flux multiplied by timestep
@@ -512,6 +584,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [dtsfc_diag]
   standard_name = cumulative_surface_upward_sensible_heat_flux_for_diag_multiplied_by_timestep
   long_name = cumulative sfc sensible heat flux multiplied by timestep
@@ -520,6 +593,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [dqsfc_diag]
   standard_name = cumulative_surface_upward_latent_heat_flux_for_diag_multiplied_by_timestep
   long_name = cumulative sfc latent heat flux multiplied by timestep
@@ -528,6 +602,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [dusfc_cice]
   standard_name = surface_x_momentum_flux_from_coupled_process
   long_name = sfc x momentum flux for coupling
@@ -536,6 +611,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [dvsfc_cice]
   standard_name = surface_y_momentum_flux_from_coupled_process
   long_name = sfc y momentum flux for coupling
@@ -544,6 +620,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [dtsfc_cice]
   standard_name = surface_upward_sensible_heat_flux_from_coupled_process
   long_name = sfc sensible heat flux for coupling
@@ -552,6 +629,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [dqsfc_cice]
   standard_name = surface_upward_latent_heat_flux_from_coupled_process
   long_name = sfc latent heat flux for coupling
@@ -560,6 +638,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [hflx_wat]
   standard_name = kinematic_surface_upward_sensible_heat_flux_over_water
   long_name = kinematic surface upward sensible heat flux over water
@@ -568,6 +647,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [qflx_wat]
   standard_name = kinematic_surface_upward_latent_heat_flux_over_water
   long_name = kinematic surface upward latent heat flux over water
@@ -576,6 +656,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [stress_wat]
   standard_name = surface_wind_stress_over_water
   long_name = surface wind stress over water
@@ -584,6 +665,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [oceanfrac]
   standard_name = sea_area_fraction
   long_name = fraction of horizontal grid area occupied by ocean
@@ -592,6 +674,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [fice]
   standard_name = sea_ice_area_fraction_of_sea_area_fraction
   long_name = ice fraction over open water
@@ -600,6 +683,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [wet]
   standard_name = flag_nonzero_wet_surface_fraction
   long_name = flag indicating presence of some ocean or lake surface area fraction
@@ -607,6 +691,7 @@
   dimensions = (horizontal_loop_extent)
   type = logical
   intent = in
+  optional = F
 [icy]
   standard_name = flag_nonzero_sea_ice_surface_fraction
   long_name = flag indicating presence of some sea ice surface area fraction
@@ -614,6 +699,7 @@
   dimensions = (horizontal_loop_extent)
   type = logical
   intent = in
+  optional = F
 [dry]
   standard_name = flag_nonzero_land_surface_fraction
   long_name = flag indicating presence of some land surface area fraction
@@ -621,6 +707,7 @@
   dimensions = (horizontal_loop_extent)
   type = logical
   intent = in
+  optional = F
 [dusfci_cpl]
   standard_name = surface_x_momentum_flux_for_coupling
   long_name = instantaneous sfc u momentum flux
@@ -629,6 +716,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [dvsfci_cpl]
   standard_name = surface_y_momentum_flux_for_coupling
   long_name = instantaneous sfc v momentum flux
@@ -637,6 +725,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [dtsfci_cpl]
   standard_name = surface_upward_sensible_heat_flux_for_coupling
   long_name = instantaneous sfc sensible heat flux
@@ -645,6 +734,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [dqsfci_cpl]
   standard_name = surface_upward_latent_heat_flux_for_coupling
   long_name = instantaneous sfc latent heat flux
@@ -653,6 +743,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [dusfc_cpl]
   standard_name = cumulative_surface_x_momentum_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative sfc u momentum flux multiplied by timestep
@@ -661,6 +752,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [dvsfc_cpl]
   standard_name = cumulative_surface_y_momentum_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative sfc v momentum flux multiplied by timestep
@@ -669,6 +761,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [dtsfc_cpl]
   standard_name = cumulative_surface_upward_sensible_heat_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative sfc sensible heat flux multiplied by timestep
@@ -677,6 +770,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [dqsfc_cpl]
   standard_name = cumulative_surface_upward_latent_heat_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative sfc latent heat flux multiplied by timestep
@@ -685,6 +779,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [recmol]
   standard_name = reciprocal_of_obukhov_length
   long_name = one over obukhov length
@@ -693,6 +788,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [qke]
   standard_name = nonadvected_turbulent_kinetic_energy_multiplied_by_2
   long_name = 2 x tke at mass points
@@ -701,6 +797,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [qke_adv]
   standard_name = turbulent_kinetic_energy
   long_name = turbulent kinetic energy
@@ -709,6 +806,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [tsq]
   standard_name = variance_of_air_temperature
   long_name = temperature fluctuation squared
@@ -717,6 +815,7 @@
   type = real
   kind = kind_phys
   intent = out
+  optional = F
 [qsq]
   standard_name = variance_of_specific_humidity
   long_name = water vapor fluctuation squared
@@ -725,6 +824,7 @@
   type = real
   kind = kind_phys
   intent = out
+  optional = F
 [cov]
   standard_name = covariance_of_air_temperature_and_specific_humidity
   long_name = covariance of temperature and moisture
@@ -733,6 +833,7 @@
   type = real
   kind = kind_phys
   intent = out
+  optional = F
 [el_pbl]
   standard_name = turbulent_mixing_length
   long_name = mixing length in meters
@@ -741,6 +842,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [Sh3D]
   standard_name = stability_function_for_heat
   long_name = stability function for heat
@@ -749,6 +851,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [exch_h]
   standard_name = atmosphere_heat_diffusivity_for_mynnpbl
   long_name = diffusivity for heat for MYNN PBL (defined for all mass levels)
@@ -757,6 +860,7 @@
   type = real
   kind = kind_phys
   intent = out
+  optional = F
 [exch_m]
   standard_name = atmosphere_momentum_diffusivity_for_mynnpbl
   long_name = diffusivity for momentum for MYNN PBL (defined for all mass levels)
@@ -765,6 +869,7 @@
   type = real
   kind = kind_phys
   intent = out
+  optional = F
 [PBLH]
   standard_name = atmosphere_boundary_layer_thickness
   long_name = PBL thickness
@@ -773,6 +878,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [kpbl]
   standard_name = vertical_index_at_top_of_atmosphere_boundary_layer
   long_name = PBL top model level index
@@ -780,6 +886,7 @@
   dimensions = (horizontal_loop_extent)
   type = integer
   intent = inout
+  optional = F
 [QC_BL]
   standard_name = subgrid_scale_cloud_liquid_water_mixing_ratio
   long_name = subgrid cloud water mixing ratio from PBL scheme
@@ -788,6 +895,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [QI_BL]
   standard_name = subgrid_scale_cloud_ice_mixing_ratio
   long_name = subgrid cloud ice mixing ratio from PBL scheme
@@ -796,6 +904,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [CLDFRA_BL]
   standard_name = subgrid_scale_cloud_area_fraction_in_atmosphere_layer
   long_name = subgrid cloud fraction from PBL scheme
@@ -804,6 +913,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [edmf_a]
   standard_name = emdf_updraft_area
   long_name = updraft area from mass flux scheme
@@ -812,6 +922,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [edmf_w]
   standard_name = emdf_updraft_vertical_velocity
   long_name = updraft vertical velocity from mass flux scheme
@@ -820,6 +931,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [edmf_qt]
   standard_name = emdf_updraft_total_water
   long_name = updraft total water from mass flux scheme
@@ -828,6 +940,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [edmf_thl]
   standard_name = emdf_updraft_theta_l
   long_name = updraft theta-l from mass flux scheme
@@ -836,6 +949,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [edmf_ent]
   standard_name = emdf_updraft_entrainment_rate
   long_name = updraft entrainment rate from mass flux scheme
@@ -844,6 +958,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [edmf_qc]
   standard_name = emdf_updraft_cloud_water
   long_name = updraft cloud water from mass flux scheme
@@ -852,6 +967,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [sub_thl]
   standard_name = theta_subsidence_tendency
   long_name = updraft theta subsidence tendency
@@ -860,6 +976,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [sub_sqv]
   standard_name = water_vapor_subsidence_tendency
   long_name = updraft water vapor subsidence tendency
@@ -868,6 +985,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [det_thl]
   standard_name = theta_detrainment_tendency
   long_name = updraft theta detrainment tendency
@@ -876,6 +994,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [det_sqv]
   standard_name = water_vapor_detrainment_tendency
   long_name = updraft water vapor detrainment tendency
@@ -884,6 +1003,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [nupdraft]
   standard_name = number_of_plumes
   long_name = number of plumes per grid column
@@ -891,6 +1011,7 @@
   dimensions = (horizontal_loop_extent)
   type = integer
   intent = inout
+  optional = F
 [maxMF]
   standard_name = maximum_mass_flux
   long_name = maximum mass flux within a column
@@ -899,6 +1020,7 @@
   type = real
   kind = kind_phys
   intent = out
+  optional = F
 [ktop_plume]
   standard_name = k_level_of_highest_plume
   long_name = k-level of highest plume
@@ -906,6 +1028,7 @@
   dimensions = (horizontal_loop_extent)
   type = integer
   intent = inout
+  optional = F
 [dudt]
   standard_name = process_split_cumulative_tendency_of_x_wind
   long_name = updated tendency of the x wind
@@ -914,6 +1037,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [dvdt]
   standard_name = process_split_cumulative_tendency_of_y_wind
   long_name = updated tendency of the y wind
@@ -922,6 +1046,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [dtdt]
   standard_name = process_split_cumulative_tendency_of_air_temperature
   long_name = updated tendency of the temperature
@@ -930,6 +1055,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [dqdt_water_vapor]
   standard_name = process_split_cumulative_tendency_of_specific_humidity
   long_name = water vapor specific humidity tendency due to model physics
@@ -938,6 +1064,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [dqdt_liquid_cloud]
   standard_name = process_split_cumulative_tendency_of_cloud_liquid_water_mixing_ratio
   long_name = cloud condensed water mixing ratio tendency due to model physics
@@ -946,6 +1073,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [dqdt_ice_cloud]
   standard_name = process_split_cumulative_tendency_of_cloud_ice_mixing_ratio
   long_name = cloud condensed water mixing ratio tendency due to model physics
@@ -954,6 +1082,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [dqdt_ozone]
   standard_name = process_split_cumulative_tendency_of_ozone_mixing_ratio
   long_name = ozone mixing ratio tendency due to model physics
@@ -962,6 +1091,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [dqdt_cloud_droplet_num_conc]
   standard_name = process_split_cumulative_tendency_of_mass_number_concentration_of_cloud_liquid_water_particles_in_air
   long_name = number conc. of cloud droplets (liquid) tendency due to model physics
@@ -970,6 +1100,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [dqdt_ice_num_conc]
   standard_name = process_split_cumulative_tendency_of_mass_number_concentration_of_cloud_ice_water_crystals_in_air
   long_name = number conc. of ice tendency due to model physics
@@ -978,6 +1109,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [dqdt_water_aer_num_conc]
   standard_name = process_split_cumulative_tendency_of_mass_number_concentration_of_hygroscopic_aerosols
   long_name = number conc. of water-friendly aerosols tendency due to model physics
@@ -986,6 +1118,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [dqdt_ice_aer_num_conc]
   standard_name = process_split_cumulative_tendency_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols
   long_name = number conc. of ice-friendly aerosols tendency due to model physics
@@ -994,6 +1127,7 @@
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [flag_for_pbl_generic_tend]
   standard_name = flag_for_generic_tendency_due_to_planetary_boundary_layer
   long_name = true if GFS_PBL_generic should calculate tendencies
@@ -1001,14 +1135,16 @@
   dimensions = ()
   type = logical
   intent = in
+  optional = F
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
-  units = mixed
-  dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
+  units = various
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_cumulative_change_processes)
   type = real
   kind = kind_phys
   intent = inout
+  optional = F
 [dtidx]
   standard_name = cumulative_change_of_state_variables_outer_index
   long_name = index of state-variable and process in last dimension of diagnostic tendencies array AKA cumulative_change_index
@@ -1016,6 +1152,7 @@
   dimensions = (number_of_tracers_plus_one_hundred,number_of_cumulative_change_processes)
   type = integer
   intent = in
+  optional = F
 [index_of_temperature]
   standard_name = index_of_temperature_in_cumulative_change_index
   long_name = index of temperature in first dimension of array cumulative change index
@@ -1023,6 +1160,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [index_of_x_wind]
   standard_name = index_of_x_wind_in_cumulative_change_index
   long_name = index of x-wind in first dimension of array cumulative change index
@@ -1030,6 +1168,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [index_of_y_wind]
   standard_name = index_of_y_wind_in_cumulative_change_index
   long_name = index of x-wind in first dimension of array cumulative change index
@@ -1037,6 +1176,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [ntke]
   standard_name = index_of_turbulent_kinetic_energy_in_tracer_concentration_array
   long_name = tracer index for turbulent kinetic energy
@@ -1044,6 +1184,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [ntoz]
   standard_name = index_of_ozone_mixing_ratio_in_tracer_concentration_array
   long_name = tracer index for ozone mixing ratio
@@ -1051,6 +1192,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [ntqv]
   standard_name = index_of_specific_humidity_in_tracer_concentration_array
   long_name = tracer index for water vapor (specific humidity)
@@ -1058,6 +1200,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [ntcw]
   standard_name = index_of_cloud_liquid_water_mixing_ratio_in_tracer_concentration_array
   long_name = tracer index for cloud condensate (or liquid water)
@@ -1065,6 +1208,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [ntiw]
   standard_name = index_of_cloud_ice_mixing_ratio_in_tracer_concentration_array
   long_name = tracer index for  ice water
@@ -1072,6 +1216,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [ntlnc]
   standard_name = index_of_mass_number_concentration_of_cloud_droplets_in_tracer_concentration_array
   long_name = tracer index for liquid number concentration
@@ -1079,6 +1224,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [ntinc]
   standard_name = index_of_mass_number_concentration_of_cloud_ice_in_tracer_concentration_array
   long_name = tracer index for ice    number concentration
@@ -1086,6 +1232,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [ntwa]
   standard_name = index_of_mass_number_concentration_of_hygroscopic_aerosols_in_tracer_concentration_array
   long_name = tracer index for water friendly aerosol
@@ -1093,6 +1240,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [ntia]
   standard_name = index_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_in_tracer_concentration_array
   long_name = tracer index for ice friendly aerosol
@@ -1100,6 +1248,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [index_of_process_pbl]
   standard_name = index_of_subgrid_scale_vertical_mixing_process_in_cumulative_change_index
   long_name = index of subgrid scale vertical mixing process in second dimension of array cumulative change index
@@ -1107,6 +1256,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [htrsw]
   standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_timestep
   long_name = total sky sw heating rate
@@ -1115,6 +1265,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [htrlw]
   standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_timestep
   long_name = total sky lw heating rate
@@ -1123,6 +1274,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [xmu]
   standard_name = zenith_angle_temporal_adjustment_factor_for_shortwave_fluxes
   long_name = zenith angle temporal adjustment factor for shortwave
@@ -1131,6 +1283,7 @@
   type = real
   kind = kind_phys
   intent = in
+  optional = F
 [grav_settling]
   standard_name = control_for_gravitational_settling_of_cloud_droplets
   long_name = flag to activate gravitational setting of fog
@@ -1138,6 +1291,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [bl_mynn_tkebudget]
   standard_name = control_for_tke_budget_output
   long_name = flag for activating TKE budget
@@ -1145,6 +1299,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [bl_mynn_tkeadvect]
   standard_name = flag_for_tke_advection
   long_name = flag for activating TKE advect
@@ -1152,6 +1307,7 @@
   dimensions = ()
   type = logical
   intent = in
+  optional = F
 [bl_mynn_cloudpdf]
   standard_name = control_for_cloud_pdf_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to determine which cloud PDF to use
@@ -1159,6 +1315,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [bl_mynn_mixlength]
   standard_name = control_for_mixing_length_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to determine which mixing length form to use
@@ -1166,6 +1323,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [bl_mynn_edmf]
   standard_name = control_for_edmf_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to activate the mass-flux scheme
@@ -1173,6 +1331,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [bl_mynn_edmf_mom]
   standard_name = control_for_edmf_momentum_transport_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to activate the transport of momentum
@@ -1180,6 +1339,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [bl_mynn_edmf_tke]
   standard_name = control_for_edmf_tke_transport_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to activate the transport of TKE
@@ -1187,6 +1347,15 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
+[bl_mynn_edmf_part]
+  standard_name = control_for_edmf_partitioning_in_mellor_yamada_nakanishi_niino_pbl_scheme
+  long_name = flag to partitioning of the MF and ED areas
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+  optional = F
 [bl_mynn_cloudmix]
   standard_name = control_for_cloud_species_mixing_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to activate mixing of cloud species
@@ -1194,6 +1363,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [bl_mynn_mixqt]
   standard_name = control_for_total_water_mixing_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to mix total water or individual species
@@ -1201,6 +1371,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [bl_mynn_output]
   standard_name = control_for_additional_diagnostics_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag initialize and output extra 3D variables
@@ -1208,6 +1379,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [icloud_bl]
   standard_name = control_for_sgs_cloud_radiation_coupling_in_mellor_yamamda_nakanishi_niino_pbl_scheme
   long_name = flag for coupling sgs clouds to radiation
@@ -1215,6 +1387,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [do_mynnsfclay]
   standard_name = flag_for_mellor_yamada_nakanishi_niino_surface_layer_scheme
   long_name = flag to activate MYNN surface layer
@@ -1222,6 +1395,7 @@
   dimensions = ()
   type = logical
   intent = in
+  optional = F
 [imp_physics]
   standard_name = control_for_microphysics_scheme
   long_name = choice of microphysics scheme
@@ -1229,6 +1403,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [imp_physics_gfdl]
   standard_name = identifier_for_gfdl_microphysics_scheme
   long_name = choice of GFDL microphysics scheme
@@ -1236,6 +1411,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [imp_physics_thompson]
   standard_name = identifier_for_thompson_microphysics_scheme
   long_name = choice of Thompson microphysics scheme
@@ -1243,6 +1419,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [imp_physics_wsm6]
   standard_name = identifier_for_wsm6_microphysics_scheme
   long_name = choice of WSM6 microphysics scheme
@@ -1250,6 +1427,7 @@
   dimensions = ()
   type = integer
   intent = in
+  optional = F
 [ltaerosol]
   standard_name = flag_for_aerosol_physics
   long_name = flag for aerosol physics
@@ -1257,6 +1435,7 @@
   dimensions = ()
   type = logical
   intent = in
+  optional = F
 [lprnt]
   standard_name = flag_print
   long_name = control flag for diagnostic print out
@@ -1264,14 +1443,7 @@
   dimensions = ()
   type = logical
   intent = in
-[huge]
-  standard_name = netcdf_float_fillvalue
-  long_name = definition of NetCDF float FillValue
-  units = none
-  dimensions = ()
-  type = real
-  kind = kind_phys
-  intent = in
+  optional = F
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP
@@ -1280,6 +1452,7 @@
   type = character
   kind = len=*
   intent = out
+  optional = F
 [errflg]
   standard_name = ccpp_error_flag
   long_name = error flag for error handling in CCPP
@@ -1287,3 +1460,4 @@
   dimensions = ()
   type = integer
   intent = out
+  optional = F

--- a/physics/module_MYNNPBL_wrapper.meta
+++ b/physics/module_MYNNPBL_wrapper.meta
@@ -14,7 +14,6 @@
   dimensions = ()
   type = logical
   intent = in
-  optional = F
 [lheatstrg]
   standard_name = flag_for_canopy_heat_storage_in_land_surface_scheme
   long_name = flag for canopy heat storage parameterization
@@ -22,7 +21,6 @@
   dimensions = ()
   type = logical
   intent = in
-  optional = F
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP
@@ -31,7 +29,6 @@
   type = character
   kind = len=*
   intent = out
-  optional = F
 [errflg]
   standard_name = ccpp_error_flag
   long_name = error flag for error handling in CCPP
@@ -39,7 +36,6 @@
   dimensions = ()
   type = integer
   intent = out
-  optional = F
 
 #####################################################################
 [ccpp-arg-table]
@@ -52,7 +48,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [levs]
   standard_name = vertical_layer_dimension
   long_name = vertical layer dimension
@@ -60,7 +55,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [flag_init]
   standard_name = flag_for_first_timestep
   long_name = flag signaling first time step for time integration loop
@@ -68,7 +62,6 @@
   dimensions = ()
   type = logical
   intent = in
-  optional = F
 [flag_restart]
   standard_name = flag_for_restart
   long_name = flag for restart (warmstart) or coldstart
@@ -76,7 +69,6 @@
   dimensions = ()
   type = logical
   intent = in
-  optional = F
 [cp]
   standard_name = specific_heat_of_dry_air_at_constant_pressure
   long_name = specific heat of dry air at constant pressure
@@ -85,7 +77,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [g]
   standard_name = gravitational_acceleration
   long_name = gravitational acceleration
@@ -94,7 +85,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [r_d]
   standard_name = gas_constant_of_dry_air
   long_name = ideal gas constant for dry air
@@ -103,7 +93,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [r_v]
   standard_name = gas_constant_water_vapor
   long_name = ideal gas constant for water vapor
@@ -112,7 +101,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [cpv]
   standard_name = specific_heat_of_water_vapor_at_constant_pressure
   long_name = specific heat of water vapor at constant pressure
@@ -121,7 +109,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [cliq]
   standard_name = specific_heat_of_liquid_water_at_constant_pressure
   long_name = specific heat of liquid water at constant pressure
@@ -130,7 +117,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [Cice]
   standard_name = specific_heat_of_ice_at_constant_pressure
   long_name = specific heat of ice at constant pressure
@@ -139,7 +125,6 @@
   type = real 
   kind = kind_phys
   intent = in
-  optional = F
 [rcp]
   standard_name = ratio_of_gas_constant_dry_air_to_specific_heat_of_dry_air_at_constant_pressure
   long_name = (rd/cp)
@@ -148,7 +133,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [XLV]
   standard_name = latent_heat_of_vaporization_of_water_at_0C
   long_name = latent heat of evaporation/sublimation
@@ -157,7 +141,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [XLF]
   standard_name = latent_heat_of_fusion_of_water_at_0C
   long_name = latent heat of fusion
@@ -166,7 +149,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [EP_1]
   standard_name = ratio_of_vapor_to_dry_air_gas_constants_minus_one
   long_name = (rv/rd) - 1 (rv = ideal gas constant for water vapor)
@@ -175,7 +157,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [EP_2]
   standard_name = ratio_of_dry_air_to_water_vapor_gas_constants
   long_name = rd/rv
@@ -184,7 +165,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [lssav]
   standard_name = flag_for_diagnostics
   long_name = logical flag for storing diagnostics
@@ -192,7 +172,6 @@
   dimensions = ()
   type = logical
   intent = in
-  optional = F
 [ldiag3d]
   standard_name = flag_for_diagnostics_3D
   long_name = flag for 3d diagnostic fields
@@ -200,7 +179,6 @@
   dimensions = ()
   type = logical
   intent = in
-  optional = F
 [qdiag3d]
   standard_name = flag_for_tracer_diagnostics_3D
   long_name = flag for 3d tracer diagnostic fields
@@ -208,7 +186,6 @@
   dimensions = ()
   type = logical
   intent = in
-  optional = F
 [lsidea]
   standard_name = flag_for_integrated_dynamics_through_earths_atmosphere
   long_name = flag for idealized physics
@@ -216,7 +193,6 @@
   dimensions = ()
   type = logical
   intent = in
-  optional = F
 [cplflx]
   standard_name = flag_for_surface_flux_coupling
   long_name = flag controlling cplflx collection (default off)
@@ -224,7 +200,6 @@
   dimensions = ()
   type = logical
   intent = in
-  optional = F
 [delt]
   standard_name = timestep_for_physics
   long_name = time step for physics
@@ -233,7 +208,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [dtf]
   standard_name = timestep_for_dynamics
   long_name = dynamics timestep
@@ -242,7 +216,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [dx]
   standard_name = characteristic_grid_lengthscale
   long_name = size of the grid cell
@@ -251,7 +224,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [zorl]
   standard_name = surface_roughness_length
   long_name = surface roughness length in cm
@@ -260,7 +232,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [phii]
   standard_name = geopotential_at_interface
   long_name = geopotential at model layer interfaces
@@ -269,7 +240,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [U]
   standard_name = x_wind
   long_name = x component of layer wind
@@ -278,7 +248,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [V]
   standard_name = y_wind
   long_name = y component of layer wind
@@ -287,7 +256,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [omega]
   standard_name = lagrangian_tendency_of_air_pressure
   long_name = layer mean vertical velocity
@@ -296,7 +264,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [T3D]
   standard_name = air_temperature
   long_name = layer mean air temperature
@@ -305,7 +272,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [qgrs_water_vapor]
   standard_name = specific_humidity
   long_name = water vapor specific humidity
@@ -314,7 +280,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [qgrs_liquid_cloud]
   standard_name = cloud_liquid_water_mixing_ratio
   long_name = ratio of mass of cloud water to mass of dry air plus vapor (without condensates)
@@ -323,7 +288,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [qgrs_ice_cloud]
   standard_name = cloud_ice_mixing_ratio
   long_name = ratio of mass of ice water to mass of dry air plus vapor (without condensates)
@@ -332,7 +296,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [qgrs_snow]
   standard_name = snow_mixing_ratio
   long_name = ratio of mass of snow water to mass of dry air plus vapor (without condensates)
@@ -341,7 +304,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [qgrs_cloud_droplet_num_conc]
   standard_name = mass_number_concentration_of_cloud_liquid_water_particles_in_air
   long_name = number concentration of cloud droplets (liquid)
@@ -350,7 +312,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [qgrs_cloud_ice_num_conc]
   standard_name = mass_number_concentration_of_cloud_ice_water_crystals_in_air
   long_name = number concentration of ice
@@ -359,7 +320,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [qgrs_ozone]
   standard_name = ozone_mixing_ratio
   long_name = ozone mixing ratio
@@ -368,7 +328,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [qgrs_water_aer_num_conc]
   standard_name = mass_number_concentration_of_hygroscopic_aerosols
   long_name = number concentration of water-friendly aerosols
@@ -377,7 +336,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [qgrs_ice_aer_num_conc]
   standard_name = mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols
   long_name = number concentration of ice-friendly aerosols
@@ -386,7 +344,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [prsl]
   standard_name = air_pressure
   long_name = mean layer pressure
@@ -395,7 +352,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [exner]
   standard_name = dimensionless_exner_function
   long_name = Exner function at layers
@@ -404,7 +360,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [slmsk]
   standard_name = area_type
   long_name = landmask: sea/land/ice=0/1/2
@@ -413,7 +368,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [tsurf]
   standard_name = surface_skin_temperature
   long_name = surface temperature
@@ -422,7 +376,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [qsfc]
   standard_name = surface_specific_humidity
   long_name = surface air saturation specific humidity
@@ -431,7 +384,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [ps]
   standard_name = surface_air_pressure
   long_name = surface pressure
@@ -440,7 +392,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [ust]
   standard_name = surface_friction_velocity
   long_name = boundary layer parameter
@@ -449,7 +400,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [ch]
   standard_name = surface_drag_wind_speed_for_momentum_in_air
   long_name = momentum exchange coefficient
@@ -458,7 +408,6 @@
   type = real
   kind = kind_phys
   intent = out
-  optional = F
 [hflx]
   standard_name = kinematic_surface_upward_sensible_heat_flux_reduced_by_surface_roughness_and_vegetation
   long_name = kinematic surface upward sensible heat flux reduced by surface roughness and vegetation
@@ -467,7 +416,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [qflx]
   standard_name = surface_upward_specific_humidity_flux
   long_name = kinematic surface upward latent heat flux
@@ -476,7 +424,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [wspd]
   standard_name = wind_speed_at_lowest_model_layer
   long_name = wind speed at lowest model level
@@ -485,7 +432,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [rb]
   standard_name = bulk_richardson_number_at_lowest_model_level
   long_name = bulk Richardson number at the surface
@@ -494,7 +440,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [dtsfc1]
   standard_name = instantaneous_surface_upward_sensible_heat_flux
   long_name = surface upward sensible heat flux valid for current call
@@ -503,7 +448,6 @@
   type = real
   kind = kind_phys
   intent = out
-  optional = F
 [dqsfc1]
   standard_name = instantaneous_surface_upward_latent_heat_flux
   long_name = surface upward latent heat flux valid for current call
@@ -512,7 +456,6 @@
   type = real
   kind = kind_phys
   intent = out
-  optional = F
 [dusfc1]
   standard_name = instantaneous_surface_x_momentum_flux
   long_name = surface momentum flux in the x-direction valid for current call
@@ -521,7 +464,6 @@
   type = real
   kind = kind_phys
   intent = out
-  optional = F
 [dvsfc1]
   standard_name = instantaneous_surface_y_momentum_flux
   long_name = surface momentum flux in the y-direction valid for current call
@@ -530,7 +472,6 @@
   type = real
   kind = kind_phys
   intent = out
-  optional = F
 [dusfci_diag]
   standard_name = instantaneous_surface_x_momentum_flux_for_diag
   long_name = instantaneous sfc x momentum flux multiplied by timestep
@@ -539,7 +480,6 @@
   type = real
   kind = kind_phys
   intent = out
-  optional = F
 [dvsfci_diag]
   standard_name = instantaneous_surface_y_momentum_flux_for_diag
   long_name = instantaneous sfc y momentum flux multiplied by timestep
@@ -548,7 +488,6 @@
   type = real
   kind = kind_phys
   intent = out
-  optional = F
 [dtsfci_diag]
   standard_name = instantaneous_surface_upward_sensible_heat_flux_for_diag
   long_name = instantaneous sfc sensible heat flux multiplied by timestep
@@ -557,7 +496,6 @@
   type = real
   kind = kind_phys
   intent = out
-  optional = F
 [dqsfci_diag]
   standard_name = instantaneous_surface_upward_latent_heat_flux_for_diag
   long_name = instantaneous sfc latent heat flux multiplied by timestep
@@ -566,7 +504,6 @@
   type = real
   kind = kind_phys
   intent = out
-  optional = F
 [dusfc_diag]
   standard_name = cumulative_surface_x_momentum_flux_for_diag_multiplied_by_timestep
   long_name = cumulative sfc x momentum flux multiplied by timestep
@@ -575,7 +512,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [dvsfc_diag]
   standard_name = cumulative_surface_y_momentum_flux_for_diag_multiplied_by_timestep
   long_name = cumulative sfc y momentum flux multiplied by timestep
@@ -584,7 +520,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [dtsfc_diag]
   standard_name = cumulative_surface_upward_sensible_heat_flux_for_diag_multiplied_by_timestep
   long_name = cumulative sfc sensible heat flux multiplied by timestep
@@ -593,7 +528,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [dqsfc_diag]
   standard_name = cumulative_surface_upward_latent_heat_flux_for_diag_multiplied_by_timestep
   long_name = cumulative sfc latent heat flux multiplied by timestep
@@ -602,7 +536,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [dusfc_cice]
   standard_name = surface_x_momentum_flux_from_coupled_process
   long_name = sfc x momentum flux for coupling
@@ -611,7 +544,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [dvsfc_cice]
   standard_name = surface_y_momentum_flux_from_coupled_process
   long_name = sfc y momentum flux for coupling
@@ -620,7 +552,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [dtsfc_cice]
   standard_name = surface_upward_sensible_heat_flux_from_coupled_process
   long_name = sfc sensible heat flux for coupling
@@ -629,7 +560,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [dqsfc_cice]
   standard_name = surface_upward_latent_heat_flux_from_coupled_process
   long_name = sfc latent heat flux for coupling
@@ -638,7 +568,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [hflx_wat]
   standard_name = kinematic_surface_upward_sensible_heat_flux_over_water
   long_name = kinematic surface upward sensible heat flux over water
@@ -647,7 +576,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [qflx_wat]
   standard_name = kinematic_surface_upward_latent_heat_flux_over_water
   long_name = kinematic surface upward latent heat flux over water
@@ -656,7 +584,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [stress_wat]
   standard_name = surface_wind_stress_over_water
   long_name = surface wind stress over water
@@ -665,7 +592,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [oceanfrac]
   standard_name = sea_area_fraction
   long_name = fraction of horizontal grid area occupied by ocean
@@ -674,7 +600,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [fice]
   standard_name = sea_ice_area_fraction_of_sea_area_fraction
   long_name = ice fraction over open water
@@ -683,7 +608,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [wet]
   standard_name = flag_nonzero_wet_surface_fraction
   long_name = flag indicating presence of some ocean or lake surface area fraction
@@ -691,7 +615,6 @@
   dimensions = (horizontal_loop_extent)
   type = logical
   intent = in
-  optional = F
 [icy]
   standard_name = flag_nonzero_sea_ice_surface_fraction
   long_name = flag indicating presence of some sea ice surface area fraction
@@ -699,7 +622,6 @@
   dimensions = (horizontal_loop_extent)
   type = logical
   intent = in
-  optional = F
 [dry]
   standard_name = flag_nonzero_land_surface_fraction
   long_name = flag indicating presence of some land surface area fraction
@@ -707,7 +629,6 @@
   dimensions = (horizontal_loop_extent)
   type = logical
   intent = in
-  optional = F
 [dusfci_cpl]
   standard_name = surface_x_momentum_flux_for_coupling
   long_name = instantaneous sfc u momentum flux
@@ -716,7 +637,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [dvsfci_cpl]
   standard_name = surface_y_momentum_flux_for_coupling
   long_name = instantaneous sfc v momentum flux
@@ -725,7 +645,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [dtsfci_cpl]
   standard_name = surface_upward_sensible_heat_flux_for_coupling
   long_name = instantaneous sfc sensible heat flux
@@ -734,7 +653,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [dqsfci_cpl]
   standard_name = surface_upward_latent_heat_flux_for_coupling
   long_name = instantaneous sfc latent heat flux
@@ -743,7 +661,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [dusfc_cpl]
   standard_name = cumulative_surface_x_momentum_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative sfc u momentum flux multiplied by timestep
@@ -752,7 +669,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [dvsfc_cpl]
   standard_name = cumulative_surface_y_momentum_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative sfc v momentum flux multiplied by timestep
@@ -761,7 +677,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [dtsfc_cpl]
   standard_name = cumulative_surface_upward_sensible_heat_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative sfc sensible heat flux multiplied by timestep
@@ -770,7 +685,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [dqsfc_cpl]
   standard_name = cumulative_surface_upward_latent_heat_flux_for_coupling_multiplied_by_timestep
   long_name = cumulative sfc latent heat flux multiplied by timestep
@@ -779,7 +693,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [recmol]
   standard_name = reciprocal_of_obukhov_length
   long_name = one over obukhov length
@@ -788,7 +701,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [qke]
   standard_name = nonadvected_turbulent_kinetic_energy_multiplied_by_2
   long_name = 2 x tke at mass points
@@ -797,7 +709,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [qke_adv]
   standard_name = turbulent_kinetic_energy
   long_name = turbulent kinetic energy
@@ -806,7 +717,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [tsq]
   standard_name = variance_of_air_temperature
   long_name = temperature fluctuation squared
@@ -815,7 +725,6 @@
   type = real
   kind = kind_phys
   intent = out
-  optional = F
 [qsq]
   standard_name = variance_of_specific_humidity
   long_name = water vapor fluctuation squared
@@ -824,7 +733,6 @@
   type = real
   kind = kind_phys
   intent = out
-  optional = F
 [cov]
   standard_name = covariance_of_air_temperature_and_specific_humidity
   long_name = covariance of temperature and moisture
@@ -833,7 +741,6 @@
   type = real
   kind = kind_phys
   intent = out
-  optional = F
 [el_pbl]
   standard_name = turbulent_mixing_length
   long_name = mixing length in meters
@@ -842,7 +749,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [Sh3D]
   standard_name = stability_function_for_heat
   long_name = stability function for heat
@@ -851,7 +757,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [exch_h]
   standard_name = atmosphere_heat_diffusivity_for_mynnpbl
   long_name = diffusivity for heat for MYNN PBL (defined for all mass levels)
@@ -860,7 +765,6 @@
   type = real
   kind = kind_phys
   intent = out
-  optional = F
 [exch_m]
   standard_name = atmosphere_momentum_diffusivity_for_mynnpbl
   long_name = diffusivity for momentum for MYNN PBL (defined for all mass levels)
@@ -869,7 +773,6 @@
   type = real
   kind = kind_phys
   intent = out
-  optional = F
 [PBLH]
   standard_name = atmosphere_boundary_layer_thickness
   long_name = PBL thickness
@@ -878,7 +781,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [kpbl]
   standard_name = vertical_index_at_top_of_atmosphere_boundary_layer
   long_name = PBL top model level index
@@ -886,7 +788,6 @@
   dimensions = (horizontal_loop_extent)
   type = integer
   intent = inout
-  optional = F
 [QC_BL]
   standard_name = subgrid_scale_cloud_liquid_water_mixing_ratio
   long_name = subgrid cloud water mixing ratio from PBL scheme
@@ -895,7 +796,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [QI_BL]
   standard_name = subgrid_scale_cloud_ice_mixing_ratio
   long_name = subgrid cloud ice mixing ratio from PBL scheme
@@ -904,7 +804,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [CLDFRA_BL]
   standard_name = subgrid_scale_cloud_area_fraction_in_atmosphere_layer
   long_name = subgrid cloud fraction from PBL scheme
@@ -913,7 +812,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [edmf_a]
   standard_name = emdf_updraft_area
   long_name = updraft area from mass flux scheme
@@ -922,7 +820,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [edmf_w]
   standard_name = emdf_updraft_vertical_velocity
   long_name = updraft vertical velocity from mass flux scheme
@@ -931,7 +828,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [edmf_qt]
   standard_name = emdf_updraft_total_water
   long_name = updraft total water from mass flux scheme
@@ -940,7 +836,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [edmf_thl]
   standard_name = emdf_updraft_theta_l
   long_name = updraft theta-l from mass flux scheme
@@ -949,7 +844,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [edmf_ent]
   standard_name = emdf_updraft_entrainment_rate
   long_name = updraft entrainment rate from mass flux scheme
@@ -958,7 +852,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [edmf_qc]
   standard_name = emdf_updraft_cloud_water
   long_name = updraft cloud water from mass flux scheme
@@ -967,7 +860,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [sub_thl]
   standard_name = theta_subsidence_tendency
   long_name = updraft theta subsidence tendency
@@ -976,7 +868,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [sub_sqv]
   standard_name = water_vapor_subsidence_tendency
   long_name = updraft water vapor subsidence tendency
@@ -985,7 +876,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [det_thl]
   standard_name = theta_detrainment_tendency
   long_name = updraft theta detrainment tendency
@@ -994,7 +884,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [det_sqv]
   standard_name = water_vapor_detrainment_tendency
   long_name = updraft water vapor detrainment tendency
@@ -1003,7 +892,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [nupdraft]
   standard_name = number_of_plumes
   long_name = number of plumes per grid column
@@ -1011,7 +899,6 @@
   dimensions = (horizontal_loop_extent)
   type = integer
   intent = inout
-  optional = F
 [maxMF]
   standard_name = maximum_mass_flux
   long_name = maximum mass flux within a column
@@ -1020,7 +907,6 @@
   type = real
   kind = kind_phys
   intent = out
-  optional = F
 [ktop_plume]
   standard_name = k_level_of_highest_plume
   long_name = k-level of highest plume
@@ -1028,7 +914,6 @@
   dimensions = (horizontal_loop_extent)
   type = integer
   intent = inout
-  optional = F
 [dudt]
   standard_name = process_split_cumulative_tendency_of_x_wind
   long_name = updated tendency of the x wind
@@ -1037,7 +922,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [dvdt]
   standard_name = process_split_cumulative_tendency_of_y_wind
   long_name = updated tendency of the y wind
@@ -1046,7 +930,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [dtdt]
   standard_name = process_split_cumulative_tendency_of_air_temperature
   long_name = updated tendency of the temperature
@@ -1055,7 +938,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [dqdt_water_vapor]
   standard_name = process_split_cumulative_tendency_of_specific_humidity
   long_name = water vapor specific humidity tendency due to model physics
@@ -1064,7 +946,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [dqdt_liquid_cloud]
   standard_name = process_split_cumulative_tendency_of_cloud_liquid_water_mixing_ratio
   long_name = cloud condensed water mixing ratio tendency due to model physics
@@ -1073,7 +954,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [dqdt_ice_cloud]
   standard_name = process_split_cumulative_tendency_of_cloud_ice_mixing_ratio
   long_name = cloud condensed water mixing ratio tendency due to model physics
@@ -1082,7 +962,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [dqdt_ozone]
   standard_name = process_split_cumulative_tendency_of_ozone_mixing_ratio
   long_name = ozone mixing ratio tendency due to model physics
@@ -1091,7 +970,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [dqdt_cloud_droplet_num_conc]
   standard_name = process_split_cumulative_tendency_of_mass_number_concentration_of_cloud_liquid_water_particles_in_air
   long_name = number conc. of cloud droplets (liquid) tendency due to model physics
@@ -1100,7 +978,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [dqdt_ice_num_conc]
   standard_name = process_split_cumulative_tendency_of_mass_number_concentration_of_cloud_ice_water_crystals_in_air
   long_name = number conc. of ice tendency due to model physics
@@ -1109,7 +986,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [dqdt_water_aer_num_conc]
   standard_name = process_split_cumulative_tendency_of_mass_number_concentration_of_hygroscopic_aerosols
   long_name = number conc. of water-friendly aerosols tendency due to model physics
@@ -1118,7 +994,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [dqdt_ice_aer_num_conc]
   standard_name = process_split_cumulative_tendency_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols
   long_name = number conc. of ice-friendly aerosols tendency due to model physics
@@ -1127,7 +1002,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [flag_for_pbl_generic_tend]
   standard_name = flag_for_generic_tendency_due_to_planetary_boundary_layer
   long_name = true if GFS_PBL_generic should calculate tendencies
@@ -1135,7 +1009,6 @@
   dimensions = ()
   type = logical
   intent = in
-  optional = F
 [dtend]
   standard_name = cumulative_change_of_state_variables
   long_name = diagnostic tendencies for state variables
@@ -1144,7 +1017,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = F
 [dtidx]
   standard_name = cumulative_change_of_state_variables_outer_index
   long_name = index of state-variable and process in last dimension of diagnostic tendencies array AKA cumulative_change_index
@@ -1152,7 +1024,6 @@
   dimensions = (number_of_tracers_plus_one_hundred,number_of_cumulative_change_processes)
   type = integer
   intent = in
-  optional = F
 [index_of_temperature]
   standard_name = index_of_temperature_in_cumulative_change_index
   long_name = index of temperature in first dimension of array cumulative change index
@@ -1160,7 +1031,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [index_of_x_wind]
   standard_name = index_of_x_wind_in_cumulative_change_index
   long_name = index of x-wind in first dimension of array cumulative change index
@@ -1168,7 +1038,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [index_of_y_wind]
   standard_name = index_of_y_wind_in_cumulative_change_index
   long_name = index of x-wind in first dimension of array cumulative change index
@@ -1176,7 +1045,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [ntke]
   standard_name = index_of_turbulent_kinetic_energy_in_tracer_concentration_array
   long_name = tracer index for turbulent kinetic energy
@@ -1184,7 +1052,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [ntoz]
   standard_name = index_of_ozone_mixing_ratio_in_tracer_concentration_array
   long_name = tracer index for ozone mixing ratio
@@ -1192,7 +1059,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [ntqv]
   standard_name = index_of_specific_humidity_in_tracer_concentration_array
   long_name = tracer index for water vapor (specific humidity)
@@ -1200,7 +1066,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [ntcw]
   standard_name = index_of_cloud_liquid_water_mixing_ratio_in_tracer_concentration_array
   long_name = tracer index for cloud condensate (or liquid water)
@@ -1208,7 +1073,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [ntiw]
   standard_name = index_of_cloud_ice_mixing_ratio_in_tracer_concentration_array
   long_name = tracer index for  ice water
@@ -1216,7 +1080,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [ntlnc]
   standard_name = index_of_mass_number_concentration_of_cloud_droplets_in_tracer_concentration_array
   long_name = tracer index for liquid number concentration
@@ -1224,7 +1087,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [ntinc]
   standard_name = index_of_mass_number_concentration_of_cloud_ice_in_tracer_concentration_array
   long_name = tracer index for ice    number concentration
@@ -1232,7 +1094,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [ntwa]
   standard_name = index_of_mass_number_concentration_of_hygroscopic_aerosols_in_tracer_concentration_array
   long_name = tracer index for water friendly aerosol
@@ -1240,7 +1101,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [ntia]
   standard_name = index_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_in_tracer_concentration_array
   long_name = tracer index for ice friendly aerosol
@@ -1248,7 +1108,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [index_of_process_pbl]
   standard_name = index_of_subgrid_scale_vertical_mixing_process_in_cumulative_change_index
   long_name = index of subgrid scale vertical mixing process in second dimension of array cumulative change index
@@ -1256,7 +1115,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [htrsw]
   standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_timestep
   long_name = total sky sw heating rate
@@ -1265,7 +1123,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [htrlw]
   standard_name = tendency_of_air_temperature_due_to_longwave_heating_on_radiation_timestep
   long_name = total sky lw heating rate
@@ -1274,7 +1131,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [xmu]
   standard_name = zenith_angle_temporal_adjustment_factor_for_shortwave_fluxes
   long_name = zenith angle temporal adjustment factor for shortwave
@@ -1283,7 +1139,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = F
 [grav_settling]
   standard_name = control_for_gravitational_settling_of_cloud_droplets
   long_name = flag to activate gravitational setting of fog
@@ -1291,7 +1146,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [bl_mynn_tkebudget]
   standard_name = control_for_tke_budget_output
   long_name = flag for activating TKE budget
@@ -1299,7 +1153,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [bl_mynn_tkeadvect]
   standard_name = flag_for_tke_advection
   long_name = flag for activating TKE advect
@@ -1307,7 +1160,6 @@
   dimensions = ()
   type = logical
   intent = in
-  optional = F
 [bl_mynn_cloudpdf]
   standard_name = control_for_cloud_pdf_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to determine which cloud PDF to use
@@ -1315,7 +1167,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [bl_mynn_mixlength]
   standard_name = control_for_mixing_length_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to determine which mixing length form to use
@@ -1323,7 +1174,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [bl_mynn_edmf]
   standard_name = control_for_edmf_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to activate the mass-flux scheme
@@ -1331,7 +1181,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [bl_mynn_edmf_mom]
   standard_name = control_for_edmf_momentum_transport_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to activate the transport of momentum
@@ -1339,7 +1188,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [bl_mynn_edmf_tke]
   standard_name = control_for_edmf_tke_transport_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to activate the transport of TKE
@@ -1347,7 +1195,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [bl_mynn_edmf_part]
   standard_name = control_for_edmf_partitioning_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to partitioning of the MF and ED areas
@@ -1355,7 +1202,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [bl_mynn_cloudmix]
   standard_name = control_for_cloud_species_mixing_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to activate mixing of cloud species
@@ -1363,7 +1209,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [bl_mynn_mixqt]
   standard_name = control_for_total_water_mixing_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to mix total water or individual species
@@ -1371,7 +1216,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [bl_mynn_output]
   standard_name = control_for_additional_diagnostics_in_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag initialize and output extra 3D variables
@@ -1379,7 +1223,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [icloud_bl]
   standard_name = control_for_sgs_cloud_radiation_coupling_in_mellor_yamamda_nakanishi_niino_pbl_scheme
   long_name = flag for coupling sgs clouds to radiation
@@ -1387,7 +1230,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [do_mynnsfclay]
   standard_name = flag_for_mellor_yamada_nakanishi_niino_surface_layer_scheme
   long_name = flag to activate MYNN surface layer
@@ -1395,7 +1237,6 @@
   dimensions = ()
   type = logical
   intent = in
-  optional = F
 [imp_physics]
   standard_name = control_for_microphysics_scheme
   long_name = choice of microphysics scheme
@@ -1403,7 +1244,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [imp_physics_gfdl]
   standard_name = identifier_for_gfdl_microphysics_scheme
   long_name = choice of GFDL microphysics scheme
@@ -1411,7 +1251,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [imp_physics_thompson]
   standard_name = identifier_for_thompson_microphysics_scheme
   long_name = choice of Thompson microphysics scheme
@@ -1419,7 +1258,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [imp_physics_wsm6]
   standard_name = identifier_for_wsm6_microphysics_scheme
   long_name = choice of WSM6 microphysics scheme
@@ -1427,7 +1265,6 @@
   dimensions = ()
   type = integer
   intent = in
-  optional = F
 [ltaerosol]
   standard_name = flag_for_aerosol_physics
   long_name = flag for aerosol physics
@@ -1435,7 +1272,6 @@
   dimensions = ()
   type = logical
   intent = in
-  optional = F
 [lprnt]
   standard_name = flag_print
   long_name = control flag for diagnostic print out
@@ -1443,7 +1279,6 @@
   dimensions = ()
   type = logical
   intent = in
-  optional = F
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP
@@ -1452,7 +1287,6 @@
   type = character
   kind = len=*
   intent = out
-  optional = F
 [errflg]
   standard_name = ccpp_error_flag
   long_name = error flag for error handling in CCPP
@@ -1460,4 +1294,3 @@
   dimensions = ()
   type = integer
   intent = out
-  optional = F

--- a/physics/module_bl_mynn.F90
+++ b/physics/module_bl_mynn.F90
@@ -2,20 +2,18 @@
 !! This file contains the entity of MYNN-EDMF PBL scheme.
 !WRF:MODEL_LAYER:PHYSICS
 !
-! Translated from NN f77 to F90 and put into WRF by Mariusz Pagowski
+! translated from NN f77 to F90 and put into WRF by Mariusz Pagowski
 ! NOAA/GSD & CIRA/CSU, Feb 2008
 ! changes to original code:
 ! 1. code is 1D (in z)
-! 2. option to advect TKE, but not the covariances and variances
+! 2. no advection of TKE, covariances and variances 
 ! 3. Cranck-Nicholson replaced with the implicit scheme
-! 4. removed terrain-dependent grid since input in WRF in actual
+! 4. removed terrain dependent grid since input in WRF in actual
 !    distances in z[m]
-! 5. cosmetic changes to adhere to WRF standard (remove common blocks,
+! 5. cosmetic changes to adhere to WRF standard (remove common blocks, 
 !            intent etc)
 !-------------------------------------------------------------------
-!Modifications implemented by Joseph Olson and Jaymes Kenyon (NOAA/GSL),
-!Wayne Angevine (NOAA/CSL), Kay Suselj (NASA/JPL), Franciano Puhales (UFSM),
-!Laura Fowler (NCAR), and Elynn Wu (UCSD) 
+!Modifications implemented by Joseph Olson and Jaymes Kenyon NOAA/GSD/MDB - CU/CIRES
 !
 ! Departures from original MYNN (Nakanish & Niino 2009)
 ! 1. Addition of BouLac mixing length in the free atmosphere.
@@ -121,30 +119,11 @@
 !            Misc small-impact bugfixes:
 !                1) dz was incorrectly indexed in mym_condensation
 !                2) configurations with icloud_bl = 0 were using uninitialized arrays
-! v4.3 / CCPP
-!            This version includes many modifications that proved valuable in the global
-!            framework and removes some key lingering bugs in the mixing of chemical species.
-!            TKE Budget output fixed (Puhales, 2020-12)
-!            New option for stability function: (Puhales, 2020-12)
-!                bl_mynn_stfunc = 0 (original, Kansas-type function, Paulson, 1970 )
-!                bl_mynn_stfunc = 1 (new (for test), same used for Jimenez et al (MWR)
-!                see the Technical Note for this implementation).
-!            Improved conservation of momentum and higher-order moments.
-!            Important bug fixes for mixing of chemical species.
-!            Addition of pressure-gradient effects on updraft momentum transport.
-!            Addition of bl_mynn_closure option = 2.5, 2.6, or 3.0
-!            Addition of sig_order to regulate the use of higher-order moments
-!                for sigma when using bl_mynn_cloudpdf = 2 (Chab-Becht). This
-!                new option is set in the subroutine mym_condensation.
-!            Many miscellaneous tweaks.
 !
-! Many of these changes are now documented in:
-!   Olson, J. B., J. S. Kenyon, W. M. Angevine, J. M. Brown, M. Pagowski, and K. Suselj, 2019: 
-!        A description of the MYNN-EDMF scheme and coupling to other components in WRF-ARW. 
-!        NOAA Tech. Memo. OAR GSD, 61, 37 pp., https://doi.org/10.25923/n9wm-be49.
-!   Puhales, Franciano S., Joseph B. Olson, Jimy Dudhia, Douglas Lima de Bem, Rafael Maroneze, 
-!        Otavio C. Acevedo, Felipe D. Costa, and Vagner Anabor, 2020: Turbulent Kinetic Energy 
-!        Budget for MYNN-EDMF PBL Scheme in WRF model. Universidade Federal de Santa Maria Technical Note. 9 pp.
+!            Many of these changes are now documented in Olson et al. (2019,
+!                NOAA Technical Memorandum)
+!
+! For more explanation of some configuration options, see "JOE's mods" below:
 !-------------------------------------------------------------------
 
 MODULE module_bl_mynn
@@ -242,7 +221,7 @@ MODULE module_bl_mynn
 ! and factor for eddy viscosity for TKE (Kq = Sqfac*Km):
   REAL, PARAMETER :: qmin=0.0, zmax=1.0, Sqfac=3.0
 ! Note that the following mixing-length constants are now specified in mym_length
-!      &cns=3.5, alp1=0.23, alp2=0.3, alp3=3.0, alp4=10.0, alp5=0.2
+!      &cns=3.5, alp1=0.23, alp2=0.3, alp3=3.0, alp4=10.0, alp5=0.4
 
 ! Constants for gravitational settling
 !  REAL, PARAMETER :: gno=1.e6/(1.e8)**(2./3.), gpw=5./3., qcgmin=1.e-8
@@ -271,24 +250,17 @@ MODULE module_bl_mynn
   !!for TKE in the upper PBL/cloud layer.
   REAL, PARAMETER :: scaleaware=1.
 
-  !>Temporary switch to deactivate the mixing of chemical species (if WRF_CHEM = 1)
-  LOGICAL, PARAMETER :: mynn_chem_vertmx = .false.
-  LOGICAL, PARAMETER :: enh_vermix = .false.
+  !>Temporary switch to deactivate the mixing of chemical species (already done when WRF_CHEM = 1)
+  INTEGER, PARAMETER :: bl_mynn_mixchem = 0
 
-  !>Of the following the options, use one OR the other, not both.
   !>Adding top-down diffusion driven by cloud-top radiative cooling
-  INTEGER, PARAMETER :: bl_mynn_topdown = 0
-  !>Option to activate downdrafts, from Elynn Wu (0: deactive, 1: active)
-  INTEGER, PARAMETER :: bl_mynn_edmf_dd = 0
+  INTEGER, PARAMETER :: bl_mynn_topdown = 1
 
   !>Option to activate heating due to dissipation of TKE (to activate, set to 1.0)
   REAL, PARAMETER :: dheat_opt = 1.
 
   !Option to activate environmental subsidence in mass-flux scheme
   LOGICAL, PARAMETER :: env_subs = .true.
-
-  !Option to switch flux-profile relationship for surface (from Puhales et al. 2020)
-  INTEGER, PARAMETER :: bl_mynn_stfunc = 1
 
   !option to print out more stuff for debugging purposes
   LOGICAL, PARAMETER :: debug_code = .false.
@@ -489,9 +461,8 @@ CONTAINS
        &            kts,kte,                                  &
        &            dz, dx, zw,                               &
        &            u, v, thl, qw,                            &
-       &            thlsg, qwsg,                              &
 !       &            ust, rmo, pmz, phh, flt, flq,             &
-       &            zi, theta, thetav, sh, sm,                &
+       &            zi, theta, sh,                            &
        &            ust, rmo, el,                             &
        &            Qke, Tsq, Qsq, Cov, Psig_bl, cldfra_bl1D, &
        &            bl_mynn_mixlength,                        &
@@ -519,7 +490,7 @@ CONTAINS
     INTEGER :: k,l,lmax
     REAL :: phm,vkz,elq,elv,b1l,b2l,pmz=1.,phh=1.,flt=0.,flq=0.,tmpq
     REAL :: zi
-    REAL, DIMENSION(kts:kte) :: theta,thetav,thlsg,qwsg
+    REAL, DIMENSION(kts:kte) :: theta
 
     REAL, DIMENSION(kts:kte) :: rstoch_col
     INTEGER ::spp_pbl
@@ -532,11 +503,10 @@ CONTAINS
     END DO
 !
 !> - Call mym_level2() to calculate the stability functions at level 2.
-    CALL mym_level2 ( kts,kte,                      &
-         &            dz,                           &
-         &            u, v, thl, thetav, qw,        &
-         &            thlsg, qwsg,                  &
-         &            ql, vt, vq,                   &
+    CALL mym_level2 ( kts,kte,&
+         &            dz,  &
+         &            u, v, thl, qw, &
+         &            ql, vt, vq, &
          &            dtl, dqw, dtv, gm, gh, sm, sh )
 !
 !   **  Preliminary setting  **
@@ -691,11 +661,10 @@ CONTAINS
 !!\param sh      stability function for heat, at Level 2
 !!\section gen_mym_level2 GSD MYNN-EDMF mym_level2 General Algorithm
 !! @ {
-  SUBROUTINE  mym_level2 (kts,kte,                &
-       &            dz,                           &
-       &            u, v, thl, thetav, qw,        &
-       &            thlsg, qwsg,                  &
-       &            ql, vt, vq,                   &
+  SUBROUTINE  mym_level2 (kts,kte,&
+       &            dz, &
+       &            u, v, thl, qw, &
+       &            ql, vt, vq, &
        &            dtl, dqw, dtv, gm, gh, sm, sh )
 !
 !-------------------------------------------------------------------
@@ -708,8 +677,8 @@ CONTAINS
 #endif
 
     REAL, DIMENSION(kts:kte), INTENT(in) :: dz
-    REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,thl,qw,ql,vt,vq,&
-                                            thetav,thlsg,qwsg
+    REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,thl,qw,ql,vt,vq
+
     REAL, DIMENSION(kts:kte), INTENT(out) :: &
          &dtl,dqw,dtv,gm,gh,sm,sh
 
@@ -718,7 +687,7 @@ CONTAINS
     REAL :: rfc,f1,f2,rf1,rf2,smc,shc,&
          &ri1,ri2,ri3,ri4,duz,dtz,dqz,vtt,vqq,dtq,dzk,afk,abk,ri,rf
 
-    REAL ::   a2fac
+    REAL ::   a2den
 
 !    ev  = 2.5e6
 !    tv0 = 0.61*tref
@@ -746,17 +715,11 @@ CONTAINS
        duz = ( u(k)-u(k-1) )**2 +( v(k)-v(k-1) )**2
        duz =   duz                    /dzk**2
        dtz = ( thl(k)-thl(k-1) )/( dzk )
-       !Alternatively, use SGS clouds for thl
-       !dtz = ( thlsg(k)-thlsg(k-1) )/( dzk )
        dqz = ( qw(k)-qw(k-1) )/( dzk )
-       !Alternatively, use SGS clouds for qw
-       !dqz = ( qwsg(k)-qwsg(k-1) )/( dzk )
 !
        vtt =  1.0 +vt(k)*abk +vt(k-1)*afk  ! Beta-theta in NN09, Eq. 39
        vqq =  tv0 +vq(k)*abk +vq(k-1)*afk  ! Beta-q
        dtq =  vtt*dtz +vqq*dqz
-       !Alternatively, use theta-v without the SGS clouds
-       !dtq = ( thetav(k)-thetav(k-1) )/( dzk )
 !
        dtl(k) =  dtz
        dqw(k) =  dqz
@@ -771,21 +734,21 @@ CONTAINS
 !   **  Gradient Richardson number  **
        ri = -gh(k)/MAX( duz, 1.0e-10 )
 
-    !a2fac is needed for the Canuto/Kitamura mod
+    !a2den is needed for the Canuto/Kitamura mod
     IF (CKmod .eq. 1) THEN
-       a2fac = 1./(1. + MAX(ri,0.0))
+       a2den = 1. + MAX(ri,0.0)
     ELSE
-       a2fac = 1.
+       a2den = 1. + 0.0
     ENDIF
 
        rfc = g1/( g1+g2 )
-       f1  = b1*( g1-c1 ) +3.0*a2*a2fac *( 1.0    -c2 )*( 1.0-c5 ) &
+       f1  = b1*( g1-c1 ) +3.0*(a2/a2den)*( 1.0    -c2 )*( 1.0-c5 ) &
     &                     +2.0*a1*( 3.0-2.0*c2 )
        f2  = b1*( g1+g2 ) -3.0*a1*( 1.0    -c2 )
        rf1 = b1*( g1-c1 )/f1
        rf2 = b1*  g1     /f2
-       smc = a1 /(a2*a2fac)*  f1/f2
-       shc = 3.0*(a2*a2fac)*( g1+g2 )
+       smc = a1 /(a2/a2den)*  f1/f2
+       shc = 3.0*(a2/a2den)*( g1+g2 )
 
        ri1 = 0.5/smc
        ri2 = rf1*smc
@@ -793,7 +756,7 @@ CONTAINS
        ri4 = ri2**2
 
 !   **  Flux Richardson number  **
-       rf = MIN( ri1*( ri + ri2-SQRT(ri**2 - ri3*ri + ri4) ), rfc )
+       rf = MIN( ri1*( ri+ri2-SQRT(ri**2-ri3*ri+ri4) ), rfc )
 !
        sh (k) = shc*( rfc-rf )/( 1.0-rf )
        sm (k) = smc*( rf1-rf )/( rf2-rf ) * sh(k)
@@ -889,24 +852,23 @@ CONTAINS
 
 
     INTEGER :: i,j,k
-    REAL :: afk,abk,zwk,zwk1,dzk,qdz,vflx,bv,tau_cloud,wstar,elb,els, &
-            & els1,elf,el_stab,el_unstab,el_mf,el_stab_mf,elb_mf,     &
-            & PBLH_PLUS_ENT,Uonset,Ugrid,el_les
-    REAL, PARAMETER :: ctau = 1000. !constant for tau_cloud
+    REAL :: afk,abk,zwk,zwk1,dzk,qdz,vflx,bv,tau_cloud,elb,els,els1,elf, &
+            & el_stab,el_unstab,el_mf,el_stab_mf,elb_mf,PBLH_PLUS_ENT,   &
+            & Uonset,Ugrid,el_les
 
 !    tv0 = 0.61*tref
 !    gtr = 9.81/tref
 
     SELECT CASE(bl_mynn_mixlength)
 
-      CASE (0) ! ORIGINAL MYNN MIXING LENGTH + BouLac
+      CASE (0) ! ORIGINAL MYNN MIXING LENGTH
 
         cns  = 2.7
         alp1 = 0.23
         alp2 = 1.0
         alp3 = 5.0
         alp4 = 100.
-        alp5 = 0.2
+        alp5 = 0.4
 
         ! Impose limits on the height integration for elt and the transition layer depth
         zi2  = MIN(10000.,zw(kte-2))  !originally integrated to model top, not just 10 km.
@@ -940,7 +902,7 @@ CONTAINS
         vflx = ( vt(kts)+1.0 )*flt +( vq(kts)+tv0 )*flq
         vsc = ( gtr*elt*MAX( vflx, 0.0 ) )**(1.0/3.0)
 
-        !   **  Strictly, el(i,k=1) is not zero.  **
+        !   **  Strictly, el(i,j,1) is not zero.  **
         el(kts) = 0.0
         zwk1    = zw(kts+1)
 
@@ -981,31 +943,30 @@ CONTAINS
 
         END DO
 
-      CASE (1, 2) !NONLOCAL (using BouLac) FORM OF MIXING LENGTH
+      CASE (1) !OPERATIONAL FORM OF MIXING LENGTH
 
-        cns  = 3.5
-        alp1 = 0.21
-        alp2 = 0.3
-        alp3 = 1.5
-        alp4 = 5.0
-        alp5 = 0.2
-        alp6 = 50.
+        cns  = 2.3
+        alp1 = 0.23
+        alp2 = 0.65
+        alp3 = 3.0
+        alp4 = 20.
+        alp5 = 0.4
 
         ! Impose limits on the height integration for elt and the transition layer depth
-        zi2=MAX(zi,200.) !minzi)
-        h1=MAX(0.3*zi2,200.)
-        h1=MIN(h1,500.)          ! 1/2 transition layer depth
+        zi2=MAX(zi,minzi)
+        h1=MAX(0.3*zi2,mindz)
+        h1=MIN(h1,maxdz)         ! 1/2 transition layer depth
         h2=h1/2.0                ! 1/4 transition layer depth
 
-        qtke(kts)=MAX(0.5*qke(kts), 0.01) !tke at full sigma levels
-        thetaw(kts)=theta(kts)            !theta at full-sigma levels
+        qtke(kts)=MAX(qke(kts)/2.,0.01) !tke at full sigma levels
+        thetaw(kts)=theta(kts)          !theta at full-sigma levels
         qkw(kts) = SQRT(MAX(qke(kts),1.0e-10))
 
         DO k = kts+1,kte
            afk = dz(k)/( dz(k)+dz(k-1) )
            abk = 1.0 -afk
            qkw(k) = SQRT(MAX(qke(k)*abk+qke(k-1)*afk,1.0e-3))
-           qtke(k) = 0.5*(qkw(k)**2)     ! q -> TKE
+           qtke(k) = (qkw(k)**2.)/2.    ! q -> TKE
            thetaw(k)= theta(k)*abk + theta(k-1)*afk
         END DO
 
@@ -1024,9 +985,9 @@ CONTAINS
            zwk = zw(k)
         END DO
 
-        elt = MIN( MAX( alp1*elt/vsc, 10.), 400.)
+        elt =  alp1*elt/vsc
         vflx = ( vt(kts)+1.0 )*flt +( vq(kts)+tv0 )*flq
-        vsc = ( gtr*elt*MAX( vflx, 0.0 ) )**onethird
+        vsc = ( gtr*elt*MAX( vflx, 0.0 ) )**(1.0/3.0)
 
         !   **  Strictly, el(i,j,1) is not zero.  **
         el(kts) = 0.0
@@ -1041,14 +1002,11 @@ CONTAINS
            !   **  Length scale limited by the buoyancy effect  **
            IF ( dtv(k) .GT. 0.0 ) THEN
               bv  = SQRT( gtr*dtv(k) ) 
-              !elb = alp2*qkw(k) / bv &               ! formulation,
-              !    &       *( 1.0 + alp3/alp2*&       ! except keep
-              !    &SQRT( vsc/( bv*elt ) ) )          ! elb bounded by zwk
-              elb = MAX(alp2*qkw(k),                      &
-                  &    alp6*edmf_a1(k)*edmf_w1(k)) / bv   &
-                  &  *( 1.0 + alp3*SQRT( vsc/(bv*elt) ) )
-              elb = MIN(elb, zwk)
-              elf = 0.65 * qkw(k)/bv
+              elb = alp2*qkw(k) / bv &                ! formulation,
+                  &       *( 1.0 + alp3/alp2*&       ! except keep
+                  &SQRT( vsc/( bv*elt ) ) )          ! elb bounded by
+              elb = MIN(elb, zwk)                     ! zwk
+              elf = alp2 * qkw(k)/bv
            ELSE
               elb = 1.0e10
               elf = elb
@@ -1070,47 +1028,41 @@ CONTAINS
 
            !add blending to use BouLac mixing length in free atmos;
            !defined relative to the PBLH (zi) + transition layer (h1)
-           !el(k) = MIN(elb/( elb/elt+elb/els+1.0 ),elf)
-           !try squared-blending
-           !el_unstab = SQRT( els**2/(1. + (els1**2/elt**2) ))
-           el(k) = SQRT( els**2/(1. + (els1**2/elt**2) +(els1**2/elb**2)))  
-           el(k) = MIN (el(k), elf)
-           el(k) = el(k)*(1.-wt) + alp5*elBLavg(k)*wt
+           el(k) = MIN(elb/( elb/elt+elb/els+1.0 ),elf)
+           el(k) = el(k)*(1.-wt) + alp5*elBLmin(k)*wt
 
            ! include scale-awareness, except for original MYNN
            el(k) = el(k)*Psig_bl
 
          END DO
 
-      CASE (3) !Local (mostly) mixing length formulation
+      CASE (2) !Experimental mixing length formulation
 
-        Uonset = 3.5 + dz(kts)*0.1
+        Uonset = 2.5 + dz(kts)*0.1
         Ugrid  = sqrt(u1(kts)**2 + v1(kts)**2)
-        cns  = 3.5 !JOE-test  * (1.0 - MIN(MAX(Ugrid - Uonset, 0.0)/10.0, 1.0))
-        alp1 = 0.21
-        alp2 = 0.30
-        alp3 = 1.5
-        alp4 = 5.0
+        cns  = 3.5 * (1.0 - MIN(MAX(Ugrid - Uonset, 0.0)/10.0, 1.0))
+        alp1 = 0.23
+        alp2 = 0.30 + 0.3*MIN(MAX((dx - 3000.)/10000., 0.0), 1.0)
+        alp3 = 2.0
+        alp4 = 20.  !10.
         alp5 = alp2 !like alp2, but for free atmosphere
         alp6 = 50.0 !used for MF mixing length
 
         ! Impose limits on the height integration for elt and the transition layer depth
         !zi2=MAX(zi,minzi)
-        zi2=MAX(zi,    200.)
-        !h1=MAX(0.3*zi2,mindz)
-        !h1=MIN(h1,maxdz)         ! 1/2 transition layer depth
-        h1=MAX(0.3*zi2,200.)
-        h1=MIN(h1,500.)
+        zi2=MAX(zi,    100.)
+        h1=MAX(0.3*zi2,mindz)
+        h1=MIN(h1,maxdz)         ! 1/2 transition layer depth
         h2=h1*0.5                ! 1/4 transition layer depth
 
         qtke(kts)=MAX(0.5*qke(kts),0.01) !tke at full sigma levels
-        qkw(kts) = SQRT(MAX(qke(kts),1.0e-4))
+        qkw(kts) = SQRT(MAX(qke(kts),1.0e-10))
 
         DO k = kts+1,kte
            afk = dz(k)/( dz(k)+dz(k-1) )
            abk = 1.0 -afk
            qkw(k) = SQRT(MAX(qke(k)*abk+qke(k-1)*afk,1.0e-3))
-           qtke(k) = 0.5*qkw(k)**2  ! qkw -> TKE
+           qtke(k) = 0.5*qkw(k)  ! qkw -> TKE
         END DO
 
         elt = 1.0e-5
@@ -1122,14 +1074,14 @@ CONTAINS
         zwk = zw(k)
         DO WHILE (zwk .LE. PBLH_PLUS_ENT)
            dzk = 0.5*( dz(k)+dz(k-1) )
-           qdz = MAX( qkw(k)-qmin, 0.03 )*dzk
+           qdz = MAX( qkw(k)-qmin, 0.03 )*dzk  !consider reducing 0.3
            elt = elt +qdz*zwk
            vsc = vsc +qdz
            k   = k+1
            zwk = zw(k)
         END DO
 
-        elt = MIN( MAX(alp1*elt/vsc, 10.), 400.)
+        elt =  MAX(alp1*elt/vsc, 10.)
         vflx = ( vt(kts)+1.0 )*flt +( vq(kts)+tv0 )*flq
         vsc = ( gtr*elt*MAX( vflx, 0.0 ) )**onethird
 
@@ -1139,28 +1091,18 @@ CONTAINS
 
         DO k = kts+1,kte
            zwk = zw(k)              !full-sigma levels
-           dzk = 0.5*( dz(k)+dz(k-1) )
            cldavg = 0.5*(cldfra_bl1D(k-1)+cldfra_bl1D(k))
 
            !   **  Length scale limited by the buoyancy effect  **
            IF ( dtv(k) .GT. 0.0 ) THEN
-              !impose min value on bv
-              bv  = MAX( SQRT( gtr*dtv(k) ), 0.001)  
+              bv  = SQRT( gtr*dtv(k) )
               !elb_mf = alp2*qkw(k) / bv  &
-              elb_mf = MAX(alp2*qkw(k),                    &
-                  &    alp6*edmf_a1(k)*edmf_w1(k)) / bv    &
+              elb_mf = MAX(alp2*qkw(k),  &
+!                  &MAX(1.-0.5*cldavg,0.0)**0.5 * alp6*edmf_a1(k)*edmf_w1(k)) / bv  &
+                  & alp6*edmf_a1(k)*edmf_w1(k)) / bv  &
                   &  *( 1.0 + alp3*SQRT( vsc/( bv*elt ) ) )
-              elb = MIN(MAX(alp5*qkw(k), alp6*edmf_a1(k)*edmf_w1(k))/bv, zwk)
-
-              !tau_cloud = MIN(MAX(0.5*zi/((gtr*zi*MAX(vflx,1.0e-4))**onethird),30.),150.)
-              wstar = 1.25*(gtr*zi*MAX(vflx,1.0e-4))**onethird
-              tau_cloud = MIN(MAX(ctau * wstar/g, 30.), 150.)
-              !minimize influence of surface heat flux on tau far away from the PBLH.
-              wt=.5*TANH((zwk - (zi2+h1))/h2) + .5
-              tau_cloud = tau_cloud*(1.-wt) + 50.*wt
-              elf = MIN(MAX(tau_cloud*SQRT(MIN(qtke(k),40.)), &
-                  &         alp6*edmf_a1(k)*edmf_w1(k)/bv), zwk)
-
+              elb = MIN(alp5*qkw(k)/bv, zwk)
+              elf = elb/(1. + (elb/600.))  !bound free-atmos mixing length to < 600 m.
               !IF (zwk > zi .AND. elf > 400.) THEN
               !   ! COMPUTE BouLac mixing length
               !   !CALL boulac_length0(k,kts,kte,zw,dz,qtke,thetaw,elBLmin0,elBLavg0)
@@ -1179,22 +1121,15 @@ CONTAINS
               ! velocity scale), except that elt is relpaced
               ! by zi, and zero is replaced by 1.0e-4 to
               ! prevent division by zero.
-              !tau_cloud = MIN(MAX(0.5*zi/((gtr*zi*MAX(vflx,1.0e-4))**onethird),50.),150.)
-              wstar = 1.25*(gtr*zi*MAX(vflx,1.0e-4))**onethird
-              tau_cloud = MIN(MAX(ctau * wstar/g, 50.), 200.)
+              tau_cloud = MIN(MAX(0.5*zi/((gtr*zi*MAX(flt,1.0e-4))**onethird),50.),150.)
               !minimize influence of surface heat flux on tau far away from the PBLH.
               wt=.5*TANH((zwk - (zi2+h1))/h2) + .5
-              !tau_cloud = tau_cloud*(1.-wt) + 50.*wt
-              tau_cloud = tau_cloud*(1.-wt) + MAX(100.,dzk*0.25)*wt
+              tau_cloud = tau_cloud*(1.-wt) + 50.*wt
 
-              elb = MIN(tau_cloud*SQRT(MIN(qtke(k),40.)), zwk)
-              !elf = elb
-              elf = elb !/(1. + (elb/800.))  !bound free-atmos mixing length to < 800 m.
+              elb = MIN(tau_cloud*SQRT(MIN(qtke(k),30.)), zwk)
+              elf = elb
               elb_mf = elb
          END IF
-         elf    = elf/(1. + (elf/800.))  !bound free-atmos mixing length to < 800 m.
-!         elb_mf = elb_mf/(1. + (elb_mf/800.))  !bound buoyancy mixing length to < 800 m.
-         elb_mf = MAX(elb_mf, 0.01) !to avoid divide-by-zero below
 
          z_m = MAX(0.,zwk - 4.)
 
@@ -1211,11 +1146,8 @@ CONTAINS
          wt=.5*TANH((zwk - (zi2+h1))/h2) + .5
 
          ! "el_unstab" = blended els-elt
-         !el_unstab = els/(1. + (els1/elt))
-         !try squared-blending
-         !el(k) = SQRT( els**2/(1. + (els1**2/elt**2) ))
-         el(k) = SQRT( els**2/(1. + (els1**2/elt**2) +(els1**2/elb_mf**2)))
-         !el(k) = MIN(el_unstab, elb_mf)
+         el_unstab = els/(1. + (els1/elt))
+         el(k) = MIN(el_unstab, elb_mf)
          el(k) = el(k)*(1.-wt) + elf*wt
 
          ! include scale-awareness. For now, use simple asymptotic kz -> 12 m.
@@ -1562,7 +1494,8 @@ CONTAINS
 !     SUBROUTINE  mym_turbulence:
 !
 !     Input variables:    see subroutine mym_initialize
-!       closure        : closure level (2.5, 2.6, or 3.0)
+!       levflag         : <>3;  Level 2.5
+!                         = 3;  Level 3
 !
 !     # ql, vt, vq, qke, tsq, qsq and cov are changed to input variables.
 !
@@ -1609,15 +1542,14 @@ CONTAINS
 !! is set to True)
   SUBROUTINE  mym_turbulence (                                &
     &            kts,kte,                                     &
-    &            closure,                                     &
+    &            levflag,                                     &
     &            dz, dx, zw,                                  &
-    &            u, v, thl, thetav, ql, qw,                   &
-    &            thlsg, qwsg,                                 &
+    &            u, v, thl, ql, qw,                           &
     &            qke, tsq, qsq, cov,                          &
     &            vt, vq,                                      &
     &            rmo, flt, flq,                               &
     &            zi,theta,                                    &
-    &            sh, sm,                                      &
+    &            sh,                                          &
     &            El,                                          &
     &            Dfm, Dfh, Dfq, Tcd, Qcd, Pdk, Pdt, Pdq, Pdc, &
     &		 qWT1D,qSHEAR1D,qBUOY1D,qDISS1D,              &
@@ -1636,14 +1568,13 @@ CONTAINS
 # define kte HARDCODE_VERTICAL
 #endif
 
-    INTEGER, INTENT(IN)   :: bl_mynn_mixlength,bl_mynn_edmf
-    REAL, INTENT(IN)      :: closure
+    INTEGER, INTENT(IN)   :: levflag,bl_mynn_mixlength,bl_mynn_edmf
     REAL, DIMENSION(kts:kte), INTENT(in) :: dz
     REAL, DIMENSION(kts:kte+1), INTENT(in) :: zw
     REAL, INTENT(in) :: rmo,flt,flq,Psig_bl,Psig_shcu,dx
-    REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,thl,thetav,qw,& 
+    REAL, DIMENSION(kts:kte), INTENT(in) :: u,v,thl,qw,& 
          &ql,vt,vq,qke,tsq,qsq,cov,cldfra_bl1D,edmf_w1,edmf_a1,edmf_qc1,&
-         &TKEprodTD,thlsg,qwsg
+         &TKEprodTD
 
     REAL, DIMENSION(kts:kte), INTENT(out) :: dfm,dfh,dfq,&
          &pdk,pdt,pdq,pdc,tcd,qcd,el
@@ -1665,10 +1596,10 @@ CONTAINS
     REAL :: zi, cldavg
     REAL, DIMENSION(kts:kte), INTENT(in) :: theta
 
-    REAL ::  a2fac, duz, ri !JOE-Canuto/Kitamura mod
-
-    REAL:: auh,aum,adh,adm,aeh,aem,Req,Rsl,Rsl2,&
-           gmelq,sm20,sh20,sm25max,sh25max,sm25min,sh25min
+    REAL ::  a2den, duz, ri, HLmod  !JOE-Canuto/Kitamura mod
+!JOE-stability criteria for cw
+    REAL:: auh,aum,adh,adm,aeh,aem,Req,Rsl,Rsl2
+!JOE-end
 
     DOUBLE PRECISION  q2sq, t2sq, r2sq, c2sq, elsq, gmel, ghel
     DOUBLE PRECISION  q3sq, t3sq, r3sq, c3sq, dlsq, qdiv
@@ -1677,8 +1608,7 @@ CONTAINS
 !   Stochastic
     INTEGER,  INTENT(IN)                          ::    spp_pbl
     REAL, DIMENSION(KTS:KTE)                      ::    rstoch_col
-    REAL :: Prnum
-    REAL, PARAMETER :: Prlimit = 10.0
+    REAL :: prlimit
 
 
 !
@@ -1694,12 +1624,11 @@ CONTAINS
 !    e5c =  6.0*a1*a1
 !
 
-    CALL mym_level2 (kts,kte,                   &
-    &            dz,                            &
-    &            u, v, thl, thetav, qw,         &
-    &            thlsg, qwsg,                   &
-    &            ql, vt, vq,                    &
-    &            dtl, dqw, dtv, gm, gh, sm, sh  )
+    CALL mym_level2 (kts,kte,&
+    &            dz, &
+    &            u, v, thl, qw, &
+    &            ql, vt, vq, &
+    &            dtl, dqw, dtv, gm, gh, sm, sh )
 !
     CALL mym_length (                           &
     &            kts,kte,                       &
@@ -1719,32 +1648,20 @@ CONTAINS
        afk = dz(k)/( dz(k)+dz(k-1) )
        abk = 1.0 -afk
        elsq = el (k)**2
-       q3sq = qkw(k)**2
        q2sq = b1*elsq*( sm(k)*gm(k)+sh(k)*gh(k) )
+       q3sq = qkw(k)**2
 
-       sh20 = MAX(sh(k), 1e-5)
-       sm20 = MAX(sm(k), 1e-5)
-       sh(k)= MAX(sh(k), 1e-5)
-
-       !Canuto/Kitamura mod
+!JOE-Canuto/Kitamura mod
        duz = ( u(k)-u(k-1) )**2 +( v(k)-v(k-1) )**2
        duz =   duz                    /dzk**2
        !   **  Gradient Richardson number  **
        ri = -gh(k)/MAX( duz, 1.0e-10 )
        IF (CKmod .eq. 1) THEN
-          a2fac = 1./(1. + MAX(ri,0.0))
+          a2den = 1. + MAX(ri,0.0)
        ELSE
-          a2fac = 1.
+          a2den = 1. + 0.0
        ENDIF
-       !end Canuto/Kitamura mod
-
-       !level 2.0 Prandtl number
-       !Prnum = MIN(sm20/sh20, 4.0)
-       !The form of Zilitinkevich et al. (2006) but modified
-       !half-way towards Esau and Grachev (2007, Wind Eng)
-       !Prnum = MIN(0.76 + 3.0*MAX(ri,0.0), Prlimit)
-       Prnum = MIN(0.76 + 4.0*MAX(ri,0.0), Prlimit)
-       !Prnum = MIN(0.76 + 5.0*MAX(ri,0.0), Prlimit)
+!JOE-end
 !
 !  Modified: Dec/22/2005, from here, (dlsq -> elsq)
        gmel = gm (k)*elsq
@@ -1754,12 +1671,20 @@ CONTAINS
        ! Level 2.0 debug prints
        IF ( debug_code ) THEN
          IF (sh(k)<0.0 .OR. sm(k)<0.0) THEN
-           print*,"MYNN; mym_turbulence 2.0; sh=",sh(k)," k=",k
+           print*,"MYNN; mym_turbulence2.0; sh=",sh(k)," k=",k
            print*," gm=",gm(k)," gh=",gh(k)," sm=",sm(k)
            print*," q2sq=",q2sq," q3sq=",q3sq," q3/q2=",q3sq/q2sq
            print*," qke=",qke(k)," el=",el(k)," ri=",ri
            print*," PBLH=",zi," u=",u(k)," v=",v(k)
          ENDIF
+       ENDIF
+
+!JOE-Apply Helfand & Labraga stability check for all Ric
+!      when CKmod == 1. (currently not forced below)
+       IF (CKmod .eq. 1) THEN
+          HLmod = q2sq -1.
+       ELSE
+          HLmod = q3sq
        ENDIF
 
 !     **  Since qkw is set to more than 0.0, q3sq > 0.0.  **
@@ -1771,102 +1696,58 @@ CONTAINS
 !JOE-end
 
        IF ( q3sq .LT. q2sq ) THEN
+       !IF ( HLmod .LT. q2sq ) THEN
           !Apply Helfand & Labraga mod
           qdiv = SQRT( q3sq/q2sq )   !HL89: (1-alfa)
-!
-          !Use level 2.5 stability functions
-          !e1   = q3sq - e1c*ghel*a2fac
-          !e2   = q3sq - e2c*ghel*a2fac
-          !e3   = e1   + e3c*ghel*a2fac**2
-          !e4   = e1   - e4c*ghel*a2fac
-          !eden = e2*e4 + e3*e5c*gmel
-          !eden = MAX( eden, 1.0d-20 )
-          !sm(k) = q3sq*a1*( e3-3.0*c1*e4       )/eden
-          !!JOE-Canuto/Kitamura mod
-          !!sh(k) = q3sq*a2*( e2+3.0*c1*e5c*gmel )/eden
-          !sh(k) = q3sq*(a2*a2fac)*( e2+3.0*c1*e5c*gmel )/eden
-          !sm(k) = Prnum*sh(k)
-          !sm(k) = sm(k) * qdiv
-
-          !Use level 2.0 functions as in original MYNN
-          sh(k) = sh(k) * qdiv
           sm(k) = sm(k) * qdiv
-          !Or, use the simple Pr relationship
-          !sm(k) = Prnum*sh(k)
-
-          !Recalculate terms for later use
+          sh(k) = sh(k) * qdiv
+!
           !JOE-Canuto/Kitamura mod
           !e1   = q3sq - e1c*ghel * qdiv**2
           !e2   = q3sq - e2c*ghel * qdiv**2
           !e3   = e1   + e3c*ghel * qdiv**2
           !e4   = e1   - e4c*ghel * qdiv**2
-          e1   = q3sq - e1c*ghel*a2fac * qdiv**2
-          e2   = q3sq - e2c*ghel*a2fac * qdiv**2
-          e3   = e1   + e3c*ghel*a2fac**2 * qdiv**2
-          e4   = e1   - e4c*ghel*a2fac * qdiv**2
+          e1   = q3sq - e1c*ghel/a2den * qdiv**2
+          e2   = q3sq - e2c*ghel/a2den * qdiv**2
+          e3   = e1   + e3c*ghel/(a2den**2) * qdiv**2
+          e4   = e1   - e4c*ghel/a2den * qdiv**2
           eden = e2*e4 + e3*e5c*gmel * qdiv**2
           eden = MAX( eden, 1.0d-20 )
-          !!JOE-Canuto/Kitamura mod
-          !!sh(k) = q3sq*a2*( e2+3.0*c1*e5c*gmel )/eden  - retro 5
-          !sh(k) = q3sq*(a2*a2fac)*( e2+3.0*c1*e5c*gmel )/eden
-          !sm(k) = Prnum*sh(k)
        ELSE
           !JOE-Canuto/Kitamura mod
           !e1   = q3sq - e1c*ghel
           !e2   = q3sq - e2c*ghel
           !e3   = e1   + e3c*ghel
           !e4   = e1   - e4c*ghel
-          e1   = q3sq - e1c*ghel*a2fac
-          e2   = q3sq - e2c*ghel*a2fac
-          e3   = e1   + e3c*ghel*a2fac**2
-          e4   = e1   - e4c*ghel*a2fac
+          e1   = q3sq - e1c*ghel/a2den
+          e2   = q3sq - e2c*ghel/a2den
+          e3   = e1   + e3c*ghel/(a2den**2)
+          e4   = e1   - e4c*ghel/a2den
           eden = e2*e4 + e3*e5c*gmel
           eden = MAX( eden, 1.0d-20 )
 
           qdiv = 1.0
-          !Use level 2.5 stability functions
           sm(k) = q3sq*a1*( e3-3.0*c1*e4       )/eden
-          !!JOE-Canuto/Kitamura mod
-          !!sh(k) = q3sq*a2*( e2+3.0*c1*e5c*gmel )/eden
-          sh(k) = q3sq*(a2*a2fac)*( e2+3.0*c1*e5c*gmel )/eden
-          !sm(k) = Prnum*sh(k)
+          !JOE-Canuto/Kitamura mod
+          !sh(k) = q3sq*a2*( e2+3.0*c1*e5c*gmel )/eden
+          sh(k) = q3sq*(a2/a2den)*( e2+3.0*c1*e5c*gmel )/eden
        END IF !end Helfand & Labraga check
-
-       !Impose broad limits on Sh and Sm:
-       gmelq    = MAX(gmel/q3sq, 1e-8)
-       sm25max  = 10. !MIN(sm20*3.0, SQRT(.1936/gmelq))
-       sh25max  = 10. !MIN(sh20*3.0, 0.76*b2)
-       sm25min  = 0.0 !MAX(sm20*0.1, 1e-6)
-       sh25min  = 0.0 !MAX(sh20*0.1, 1e-6)
 
        !JOE: Level 2.5 debug prints
        ! HL88 , lev2.5 criteria from eqs. 3.17, 3.19, & 3.20
        IF ( debug_code ) THEN
-         IF ((sh(k)<sh25min .OR. sm(k)<sm25min .OR. &
-              sh(k)>sh25max .OR. sm(k)>sm25max) ) THEN
-           print*,"In mym_turbulence 2.5: k=",k
-           print*," sm=",sm(k)," sh=",sh(k)
-           print*," ri=",ri," Pr=",sm(k)/MAX(sh(k),1e-8)
-           print*," gm=",gm(k)," gh=",gh(k)
-           print*," q2sq=",q2sq," q3sq=",q3sq, q3sq/q2sq
-           print*," qke=",qke(k)," el=",el(k)
+         IF (sh(k)<0.0 .OR. sm(k)<0.0 .OR. &
+           sh(k) > 0.76*b2 .or. (sm(k)**2*gm(k) .gt. .44**2)) THEN
+           print*,"MYNN; mym_turbulence2.5; sh=",sh(k)," k=",k
+           print*," gm=",gm(k)," gh=",gh(k)," sm=",sm(k)
+           print*," q2sq=",q2sq," q3sq=",q3sq," q3/q2=",q3sq/q2sq
+           print*," qke=",qke(k)," el=",el(k)," ri=",ri
            print*," PBLH=",zi," u=",u(k)," v=",v(k)
-           print*," SMnum=",q3sq*a1*( e3-3.0*c1*e4)," SMdenom=",eden
-           print*," SHnum=",q3sq*(a2*a2fac)*( e2+3.0*c1*e5c*gmel ),&
-                  " SHdenom=",eden
          ENDIF
        ENDIF
 
-       !Enforce constraints for level 2.5 functions
-       IF ( sh(k) > sh25max ) sh(k) = sh25max
-       IF ( sh(k) < sh25min ) sh(k) = sh25min
-       !IF ( sm(k) > sm25max ) sm(k) = sm25max
-       !IF ( sm(k) < sm25min ) sm(k) = sm25min
-       !sm(k) = Prnum*sh(k)
-       sm(k) = MIN(sm(k), Prlimit*Sh(k))
-
 !   **  Level 3 : start  **
-       IF ( closure .GE. 3.0 ) THEN
+       IF ( levflag .EQ. 3 ) THEN
           t2sq = qdiv*b2*elsq*sh(k)*dtl(k)**2
           r2sq = qdiv*b2*elsq*sh(k)*dqw(k)**2
           c2sq = qdiv*b2*elsq*sh(k)*dtl(k)*dqw(k)
@@ -1879,7 +1760,6 @@ CONTAINS
 !
           vtt  = 1.0 +vt(k)*abk +vt(k-1)*afk
           vqq  = tv0 +vq(k)*abk +vq(k-1)*afk
-
           t2sq = vtt*t2sq +vqq*c2sq
           r2sq = vtt*c2sq +vqq*r2sq
           c2sq = MAX( vtt*t2sq+vqq*r2sq, 0.0d0 )
@@ -1894,18 +1774,18 @@ CONTAINS
           IF ( q3sq/dlsq .LT. -gh(k) ) q3sq = -dlsq*gh(k)
 !
 !     **  Limitation on c3sq (0.12 =< cw =< 0.76) **
-          ! Use Janjic's (2001; p 13-17) methodology (eqs 4.11-414 and 5.7-5.10)
+          !JOE: use Janjic's (2001; p 13-17) methodology (eqs 4.11-414 and 5.7-5.10)
           ! to calculate an exact limit for c3sq:
-          auh = 27.*a1*((a2*a2fac)**2)*b2*(g/tref)**2
-          aum = 54.*(a1**2)*(a2*a2fac)*b2*c1*(g/tref)
-          adh = 9.*a1*((a2*a2fac)**2)*(12.*a1 + 3.*b2)*(g/tref)**2
-          adm = 18.*(a1**2)*(a2*a2fac)*(b2 - 3.*(a2*a2fac))*(g/tref)
+          auh = 27.*a1*((a2/a2den)**2)*b2*(g/tref)**2
+          aum = 54.*(a1**2)*(a2/a2den)*b2*c1*(g/tref)
+          adh = 9.*a1*((a2/a2den)**2)*(12.*a1 + 3.*b2)*(g/tref)**2
+          adm = 18.*(a1**2)*(a2/a2den)*(b2 - 3.*(a2/a2den))*(g/tref)
 
-          aeh = (9.*a1*((a2*a2fac)**2)*b1 +9.*a1*((a2*a2fac)**2)* &
+          aeh = (9.*a1*((a2/a2den)**2)*b1 +9.*a1*((a2/a2den)**2)* &
                 (12.*a1 + 3.*b2))*(g/tref)
-          aem = 3.*a1*(a2*a2fac)*b1*(3.*(a2*a2fac) + 3.*b2*c1 + &
+          aem = 3.*a1*(a2/a2den)*b1*(3.*(a2/a2den) + 3.*b2*c1 + &
                 (18.*a1*c1 - b2)) + &
-                (18.)*(a1**2)*(a2*a2fac)*(b2 - 3.*(a2*a2fac))
+                (18.)*(a1**2)*(a2/a2den)*(b2 - 3.*(a2/a2den))
 
           Req = -aeh/aem
           Rsl = (auh + aum*Req)/(3.*adh + 3.*adm*Req)
@@ -1923,23 +1803,23 @@ CONTAINS
           !e2   = q3sq - e2c*ghel * qdiv**2
           !e3   = q3sq + e3c*ghel * qdiv**2
           !e4   = q3sq - e4c*ghel * qdiv**2
-          e2   = q3sq - e2c*ghel*a2fac * qdiv**2
-          e3   = q3sq + e3c*ghel*a2fac**2 * qdiv**2
-          e4   = q3sq - e4c*ghel*a2fac * qdiv**2
+          e2   = q3sq - e2c*ghel/a2den * qdiv**2
+          e3   = q3sq + e3c*ghel/(a2den**2) * qdiv**2
+          e4   = q3sq - e4c*ghel/a2den * qdiv**2
           eden = e2*e4  + e3 *e5c*gmel * qdiv**2
 
           !JOE-Canuto/Kitamura mod
           !wden = cc3*gtr**2 * dlsq**2/elsq * qdiv**2 &
           !     &        *( e2*e4c - e3c*e5c*gmel * qdiv**2 )
           wden = cc3*gtr**2 * dlsq**2/elsq * qdiv**2 &
-               &        *( e2*e4c*a2fac - e3c*e5c*gmel*a2fac**2 * qdiv**2 )
+               &        *( e2*e4c/a2den - e3c*e5c*gmel/(a2den**2) * qdiv**2 )
 
           IF ( wden .NE. 0.0 ) THEN
              !JOE: test dynamic limits
-             clow = q3sq*( 0.12-cw25 )*eden/wden
-             cupp = q3sq*( 0.76-cw25 )*eden/wden
-             !clow = q3sq*( Rsl -cw25 )*eden/wden
-             !cupp = q3sq*( Rsl2-cw25 )*eden/wden
+             !clow = q3sq*( 0.12-cw25 )*eden/wden
+             !cupp = q3sq*( 0.76-cw25 )*eden/wden
+             clow = q3sq*( Rsl -cw25 )*eden/wden
+             cupp = q3sq*( Rsl2-cw25 )*eden/wden
 !
              IF ( wden .GT. 0.0 ) THEN
                 c3sq  = MIN( MAX( c3sq, c2sq+clow ), c2sq+cupp )
@@ -1954,7 +1834,7 @@ CONTAINS
 
           !JOE-Canuto/Kitamura mod
           !e6c  = 3.0*a2*cc3*gtr * dlsq/elsq
-          e6c  = 3.0*(a2*a2fac)*cc3*gtr * dlsq/elsq
+          e6c  = 3.0*(a2/a2den)*cc3*gtr * dlsq/elsq
 
           !============================
           !     **  for Gamma_theta  **
@@ -1983,8 +1863,8 @@ CONTAINS
 
           !JOE-Canuto/Kitamura mod
           !smd  = dlsq*enum*gtr/eden * qdiv**2 * (e3c+e4c)*a1/a2
-          smd  = dlsq*enum*gtr/eden * qdiv**2 * (e3c*a2fac**2 + &
-               & e4c*a2fac)*a1/(a2*a2fac)
+          smd  = dlsq*enum*gtr/eden * qdiv**2 * (e3c/(a2den**2) + &
+               & e4c/a2den)*a1/(a2/a2den)
 
           gamv = e1  *enum*gtr/eden
           sm(k) = sm(k) +smd
@@ -2019,9 +1899,9 @@ CONTAINS
        cldavg = 0.5*(cldfra_bl1D(k-1) + cldfra_bl1D(k))
        IF (edmf_a1(k) > 0.001 .OR. cldavg > 0.02) THEN
            cldavg = 0.5*(cldfra_bl1D(k-1) + cldfra_bl1D(k))
-           !sm(k) = MAX(sm(k), MAX(1.0 - 2.0*cldavg, 0.0)**0.33 * 0.03 * &
+           !sm(k) = MAX(sm(k), MAX(1.0 - 2.0*cldavg, 0.0)**0.33 * 0.03 * &                           
            !  &     MIN(10.*edmf_a1(k)*edmf_w1(k),1.0) )
-           !sh(k) = MAX(sh(k), MAX(1.0 - 2.0*cldavg, 0.0)**0.33 * 0.03 * &
+           !sh(k) = MAX(sh(k), MAX(1.0 - 2.0*cldavg, 0.0)**0.33 * 0.03 * &                           
            !  &     MIN(10.*edmf_a1(k)*edmf_w1(k),1.0) )
 
            ! for mass-flux columns
@@ -2030,6 +1910,7 @@ CONTAINS
            ! for clouds
            sm(k) = MAX(sm(k), 0.03*MIN(cldavg,1.0) )
            sh(k) = MAX(sh(k), 0.03*MIN(cldavg,1.0) )
+
        ENDIF
 !
        elq = el(k)*qkw(k)
@@ -2038,8 +1919,8 @@ CONTAINS
        ! Production of TKE (pdk), T-variance (pdt),
        ! q-variance (pdq), and covariance (pdc)
        pdk(k) = elq*( sm(k)*gm(k) &
-            &                    +sh(k)*gh(k)+gamv ) + &
-            &   TKEprodTD(k)
+            &                    +sh(k)*gh(k)+gamv ) + & ! JAYMES TKE
+            &   TKEprodTD(k)                             ! JOE-top-down
        pdt(k) = elh*( sh(k)*dtl(k)+gamt )*dtl(k)
        pdq(k) = elh*( sh(k)*dqw(k)+gamq )*dqw(k)
        pdc(k) = elh*( sh(k)*dtl(k)+gamt )&
@@ -2061,34 +1942,41 @@ CONTAINS
 
    IF ( bl_mynn_tkebudget == 1) THEN
        !TKE BUDGET
-!       dudz = ( u(k)-u(k-1) )/dzk
-!       dvdz = ( v(k)-v(k-1) )/dzk
-!       dTdz = ( thl(k)-thl(k-1) )/dzk
+       dudz = ( u(k)-u(k-1) )/dzk
+       dvdz = ( v(k)-v(k-1) )/dzk
+       dTdz = ( thl(k)-thl(k-1) )/dzk
 
-!       upwp = -elq*sm(k)*dudz
-!       vpwp = -elq*sm(k)*dvdz
-!       Tpwp = -elq*sh(k)*dTdz
-!       Tpwp = SIGN(MAX(ABS(Tpwp),1.E-6),Tpwp)
+       upwp = -elq*sm(k)*dudz
+       vpwp = -elq*sm(k)*dvdz
+       Tpwp = -elq*sh(k)*dTdz
+       Tpwp = SIGN(MAX(ABS(Tpwp),1.E-6),Tpwp)
 
-       
-!!  TKE budget  (Puhales, 2020, WRF 4.2.1)  << EOB   
+       IF ( k .EQ. kts+1 ) THEN
+          qWT1D(kts)=0.
+          q3sq_old =0.
+          qWTP_old =0.
+          !**  Limitation on q, instead of L/q  **
+          dlsq1 = MAX(el(kts)**2,1.0)
+          IF ( q3sq_old/dlsq1 .LT. -gh(k) ) q3sq_old = -dlsq1*gh(k)
+       ENDIF
+
+       !!!Vertical Transport Term
+       qWTP_new = elq*Sqfac*sm(k)*(q3sq - q3sq_old)/dzk
+       qWT1D(k) = 0.5*(qWTP_new - qWTP_old)/dzk
+       qWTP_old = elq*Sqfac*sm(k)*(q3sq - q3sq_old)/dzk
+       q3sq_old = q3sq
 
        !!!Shear Term
        !!!qSHEAR1D(k)=-(upwp*dudz + vpwp*dvdz)
-       qSHEAR1D(k) = elq*sm(k)*gm(k) !staggered
+       qSHEAR1D(k) = elq*sm(k)*gm(k)
 
        !!!Buoyancy Term    
        !!!qBUOY1D(k)=g*Tpwp/thl(k)
        !qBUOY1D(k)= elq*(sh(k)*gh(k) + gamv)
-       !qBUOY1D(k) = elq*(sh(k)*(-dTdz*g/thl(k)) + gamv) !! ORIGINAL CODE
-       
-       !! Buoyncy term takes the TKEprodTD(k) production now
-       qBUOY1D(k) = elq*(sh(k)*gh(k)+gamv)+TKEprodTD(k) !staggered
+       qBUOY1D(k) = elq*(sh(k)*(-dTdz*g/thl(k)) + gamv)
 
-       !!!Dissipation Term (now it evaluated on mym_predict)
-       !qDISS1D(k) = (q3sq**(3./2.))/(b1*MAX(el(k),1.)) !! ORIGINAL CODE
-       
-       !! >> EOB  
+       !!!Dissipation Term
+       qDISS1D(k) = (q3sq**(3./2.))/(b1*MAX(el(k),1.))
     ENDIF
 
     END DO
@@ -2111,6 +1999,13 @@ CONTAINS
     END DO
 !
 
+   IF ( bl_mynn_tkebudget == 1) THEN
+      !JOE-TKE BUDGET
+      qWT1D(kts)=0.
+      qSHEAR1D(kts)=qSHEAR1D(kts+1)
+      qBUOY1D(kts)=qBUOY1D(kts+1)
+      qDISS1D(kts)=qDISS1D(kts+1)
+   ENDIF
 
     if (spp_pbl==1) then
        DO k = kts,kte
@@ -2174,15 +2069,15 @@ CONTAINS
 !>\ingroup gsd_mynn_edmf
 !! This subroutine predicts the turbulent quantities at the next step.
   SUBROUTINE  mym_predict (kts,kte,                                     &
-       &            closure,                                            &
+       &            levflag,                                            &
        &            delt,                                               &
        &            dz,                                                 &
        &            ust, flt, flq, pmz, phh,                            &
-       &            el, dfq, rho,                                       &
+       &            el, dfq,                                            &
        &            pdk, pdt, pdq, pdc,                                 &
        &            qke, tsq, qsq, cov,                                 &
-       &            s_aw,s_awqke,bl_mynn_edmf_tke,                      &
-       &            qWT1D, qDISS1D,bl_mynn_tkebudget)  !! TKE budget  (Puhales, 2020)
+       &            s_aw,s_awqke,bl_mynn_edmf_tke                       &
+       &)
 
 !-------------------------------------------------------------------
     INTEGER, INTENT(IN) :: kts,kte    
@@ -2192,30 +2087,22 @@ CONTAINS
 # define kte HARDCODE_VERTICAL
 #endif
 
-    REAL, INTENT(IN)    :: closure
+    INTEGER, INTENT(IN) :: levflag
     INTEGER, INTENT(IN) :: bl_mynn_edmf_tke
     REAL, INTENT(IN)    :: delt
-    REAL, DIMENSION(kts:kte), INTENT(IN) :: dz, dfq, el, rho
+    REAL, DIMENSION(kts:kte), INTENT(IN) :: dz, dfq,el
     REAL, DIMENSION(kts:kte), INTENT(INOUT) :: pdk, pdt, pdq, pdc
     REAL, INTENT(IN)    ::  flt, flq, ust, pmz, phh
     REAL, DIMENSION(kts:kte), INTENT(INOUT) :: qke,tsq, qsq, cov
 ! WA 8/3/15
     REAL, DIMENSION(kts:kte+1), INTENT(INOUT) :: s_awqke,s_aw
-    
-    !!  TKE budget  (Puhales, 2020, WRF 4.2.1)  << EOB 
-    REAL, DIMENSION(kts:kte), INTENT(OUT) :: qWT1D, qDISS1D  
-    INTEGER, INTENT(IN) :: bl_mynn_tkebudget  
-    REAL, DIMENSION(kts:kte) :: tke_up,dzinv  
-    !! >> EOB
-    
+
     INTEGER :: k
     REAL, DIMENSION(kts:kte) :: qkw, bp, rp, df3q
     REAL :: vkz,pdk1,phm,pdt1,pdq1,pdc1,b1l,b2l,onoff
     REAL, DIMENSION(kts:kte) :: dtz
     REAL, DIMENSION(kts:kte) :: a,b,c,d,x
 
-    REAL, DIMENSION(kts:kte) :: rhoinv
-    REAL, DIMENSION(kts:kte+1) :: rhoz,kqdz,kmdz
 
     ! REGULATE THE MOMENTUM MIXING FROM THE MASS-FLUX SCHEME (on or off)
     IF (bl_mynn_edmf_tke == 0) THEN
@@ -2236,33 +2123,6 @@ CONTAINS
        dtz(k)=delt/dz(k)
     END DO
 !
-!JOE-add conservation + stability criteria
-    !Prepare "constants" for diffusion equation.
-    !khdz = rho*Kh/dz = rho*dfh
-    rhoz(kts)  =rho(kts)
-    rhoinv(kts)=1./rho(kts)
-    kqdz(kts)  =rhoz(kts)*df3q(kts)
-    kmdz(kts)  =rhoz(kts)*dfq(kts)
-    DO k=kts+1,kte
-       rhoz(k)  =(rho(k)*dz(k-1) + rho(k-1)*dz(k))/(dz(k-1)+dz(k))
-       rhoz(k)  =  MAX(rhoz(k),1E-4)
-       rhoinv(k)=1./MAX(rho(k),1E-4)
-       kqdz(k)  = rhoz(k)*df3q(k) ! for TKE
-       kmdz(k)  = rhoz(k)*dfq(k)  ! for T'2, q'2, and T'q'
-    ENDDO
-    rhoz(kte+1)=rhoz(kte)
-    kqdz(kte+1)=rhoz(kte+1)*df3q(kte)
-    kmdz(kte+1)=rhoz(kte+1)*dfq(kte)
-
-    !stability criteria for mf
-    DO k=kts+1,kte-1
-       kqdz(k) = MAX(kqdz(k),  0.5* s_aw(k))
-       kqdz(k) = MAX(kqdz(k), -0.5*(s_aw(k)-s_aw(k+1)))
-       kmdz(k) = MAX(kmdz(k),  0.5* s_aw(k))
-       kmdz(k) = MAX(kmdz(k), -0.5*(s_aw(k)-s_aw(k+1)))
-    ENDDO
-!JOE-end conservation mods
-
     pdk1 = 2.0*ust**3*pmz/( vkz )
     phm  = 2.0/ust   *phh/( vkz )
     pdt1 = phm*flt**2
@@ -2299,21 +2159,11 @@ CONTAINS
 !       c(k-kts+1)=-dtz(k)*df3q(k+1)
 !       d(k-kts+1)=rp(k)*delt + qke(k)
 ! WA 8/3/15 add EDMF contribution
-!       a(k)=   - dtz(k)*df3q(k) + 0.5*dtz(k)*s_aw(k)*onoff
-!       b(k)=1. + dtz(k)*(df3q(k)+df3q(k+1)) &
-!               + 0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*onoff + bp(k)*delt
-!       c(k)=   - dtz(k)*df3q(k+1) - 0.5*dtz(k)*s_aw(k+1)*onoff
-!       d(k)=rp(k)*delt + qke(k) + dtz(k)*(s_awqke(k)-s_awqke(k+1))*onoff
-!JOE 8/22/20 improve conservation
-       a(k)=   - dtz(k)*kqdz(k)*rhoinv(k)                       &
-           &   + 0.5*dtz(k)*rhoinv(k)*s_aw(k)*onoff
-       b(k)=1. + dtz(k)*(kqdz(k)+kqdz(k+1))*rhoinv(k)           &
-           &   + 0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))*onoff &
-           &   + bp(k)*delt
-       c(k)=   - dtz(k)*kqdz(k+1)*rhoinv(k)                     &
-           &   - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*onoff
-       d(k)=rp(k)*delt + qke(k)                                 &
-           &   + dtz(k)*rhoinv(k)*(s_awqke(k)-s_awqke(k+1))*onoff
+       a(k-kts+1)=-dtz(k)*df3q(k) + 0.5*dtz(k)*s_aw(k)*onoff
+       b(k-kts+1)=1. + dtz(k)*(df3q(k)+df3q(k+1)) &
+                     + 0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*onoff + bp(k)*delt
+       c(k-kts+1)=-dtz(k)*df3q(k+1) - 0.5*dtz(k)*s_aw(k+1)*onoff
+       d(k-kts+1)=rp(k)*delt + qke(k) + dtz(k)*(s_awqke(k)-s_awqke(k+1))*onoff
     ENDDO
 
 !!    DO k=kts+1,kte-1
@@ -2323,16 +2173,10 @@ CONTAINS
 !!       d(k-kts+1)=rp(k)*delt + qke(k) - qke(k)*bp(k)*delt
 !!    ENDDO
 
-!! "no flux at top"
-!    a(kte)=-1. !0.
-!    b(kte)=1.
-!    c(kte)=0.
-!    d(kte)=0.
-!! "prescribed value"
-    a(kte)=0.
+    a(kte)=-1. !0.
     b(kte)=1.
     c(kte)=0.
-    d(kte)=qke(kte)
+    d(kte)=0.
 
 !    CALL tridiag(kte,a,b,c,d)
     CALL tridiag2(kte,a,b,c,d,x)
@@ -2340,89 +2184,15 @@ CONTAINS
     DO k=kts,kte
 !       qke(k)=max(d(k-kts+1), 1.e-4)
        qke(k)=max(x(k), 1.e-4)
-       qke(k)=min(qke(k), 150.)
     ENDDO
       
-   
-!!  TKE budget  (Puhales, 2020, WRF 4.2.1)  << EOB 
-    IF (bl_mynn_tkebudget == 1) THEN
-       !! TKE Vertical transport << EOBvt
-        tke_up=0.5*qke
-        dzinv=1./dz
-        k=kts
-        qWT1D(k)=dzinv(k)*(                                    &
-            &  (kqdz(k+1)*(tke_up(k+1)-tke_up(k))-kqdz(k)*tke_up(k)) &
-            &  + 0.5*rhoinv(k)*(s_aw(k+1)*tke_up(k+1)          &
-            &  +      (s_aw(k+1)-s_aw(k))*tke_up(k)            &
-            &  +      (s_awqke(k)-s_awqke(k+1)))*onoff) !unstaggered
-        DO k=kts+1,kte-1
-            qWT1D(k)=dzinv(k)*(                                &
-            & (kqdz(k+1)*(tke_up(k+1)-tke_up(k))-kqdz(k)*(tke_up(k)-tke_up(k-1))) &
-            &  + 0.5*rhoinv(k)*(s_aw(k+1)*tke_up(k+1)          &
-            &  +      (s_aw(k+1)-s_aw(k))*tke_up(k)            &
-            &  -                  s_aw(k)*tke_up(k-1)          &
-            &  +      (s_awqke(k)-s_awqke(k+1)))*onoff) !unstaggered
-        ENDDO
-        k=kte
-        qWT1D(k)=dzinv(k)*(-kqdz(k)*(tke_up(k)-tke_up(k-1)) &
-            &  + 0.5*rhoinv(k)*(-s_aw(k)*tke_up(k)-s_aw(k)*tke_up(k-1)+s_awqke(k))*onoff) !unstaggared
-        !!  >> EOBvt
-        qDISS1D=bp*tke_up !! TKE dissipation rate !unstaggered
-    END IF
-!! >> EOB 
-   
-    IF ( closure > 2.5 ) THEN
 
-       !   **  Prediction of the moisture variance  **
-       DO k = kts,kte-1
-          b2l = b2*0.5*( el(k+1)+el(k) )
-          bp(k) = 2.*qkw(k) / b2l
-          rp(k) = pdq(k+1) +pdq(k)
-       END DO
-
-       !zero gradient for qsq at bottom and top
-       !a(1)=0.
-       !b(1)=1.
-       !c(1)=-1.
-       !d(1)=0.
-
-       ! Since dfq(kts)=0.0, a(1)=0.0 and b(1)=1.+dtz(k)*dfq(k+1)+bp(k)*delt.
-       DO k=kts,kte-1
-          a(k)=   - dtz(k)*kmdz(k)*rhoinv(k)
-          b(k)=1. + dtz(k)*(kmdz(k)+kmdz(k+1))*rhoinv(k) + bp(k)*delt
-          c(k)=   - dtz(k)*kmdz(k+1)*rhoinv(k)
-          d(k)=rp(k)*delt + qsq(k)
-       ENDDO
-
-       a(kte)=-1. !0.
-       b(kte)=1.
-       c(kte)=0.
-       d(kte)=0.
-
-!       CALL tridiag(kte,a,b,c,d)
-    CALL tridiag2(kte,a,b,c,d,x)
-       
-       DO k=kts,kte
-          !qsq(k)=d(k-kts+1)
-          qsq(k)=MAX(x(k),1e-12)
-       ENDDO
-    ELSE
-       !level 2.5 - use level 2 diagnostic
-       DO k = kts,kte-1
-          IF ( qkw(k) .LE. 0.0 ) THEN
-             b2l = 0.0
-          ELSE
-             b2l = b2*0.25*( el(k+1)+el(k) )/qkw(k)
-          END IF
-          qsq(k) = b2l*( pdq(k+1)+pdq(k) )
-       END DO
-       qsq(kte)=qsq(kte-1)
-    END IF
-!!!!!!!!!!!!!!!!!!!!!!end level 2.6   
-
-    IF ( closure .GE. 3.0 ) THEN
+    IF ( levflag .EQ. 3 ) THEN
 !
+!  Modified: Dec/22/2005, from here
 !   **  dfq for the scalar variance is 1.0*dfm.  **
+!       CALL coefvu ( dfq, 1.0 ) make change here 
+!  Modified: Dec/22/2005, up to here
 !
 !   **  Prediction of the temperature variance  **
 !!       DO k = kts+1,kte-1
@@ -2441,15 +2211,10 @@ CONTAINS
 
 ! Since dfq(kts)=0.0, a(1)=0.0 and b(1)=1.+dtz(k)*dfq(k+1)+bp(k)*delt.
        DO k=kts,kte-1
-          !a(k-kts+1)=-dtz(k)*dfq(k)
-          !b(k-kts+1)=1.+dtz(k)*(dfq(k)+dfq(k+1))+bp(k)*delt
-          !c(k-kts+1)=-dtz(k)*dfq(k+1)
-          !d(k-kts+1)=rp(k)*delt + tsq(k)
-!JOE 8/22/20 improve conservation
-          a(k)=   - dtz(k)*kmdz(k)*rhoinv(k)
-          b(k)=1. + dtz(k)*(kmdz(k)+kmdz(k+1))*rhoinv(k) + bp(k)*delt
-          c(k)=   - dtz(k)*kmdz(k+1)*rhoinv(k)
-          d(k)=rp(k)*delt + tsq(k)
+          a(k-kts+1)=-dtz(k)*dfq(k)
+          b(k-kts+1)=1.+dtz(k)*(dfq(k)+dfq(k+1))+bp(k)*delt
+          c(k-kts+1)=-dtz(k)*dfq(k+1)
+          d(k-kts+1)=rp(k)*delt + tsq(k)
        ENDDO
 
 !!       DO k=kts+1,kte-1
@@ -2463,15 +2228,58 @@ CONTAINS
        b(kte)=1.
        c(kte)=0.
        d(kte)=0.
+
+!       CALL tridiag(kte,a,b,c,d)
+    CALL tridiag2(kte,a,b,c,d,x)
+       
+       DO k=kts,kte
+!          tsq(k)=d(k-kts+1)
+           tsq(k)=x(k)
+       ENDDO
+       
+!   **  Prediction of the moisture variance  **
+!!       DO k = kts+1,kte-1
+       DO k = kts,kte-1
+          b2l = b2*0.5*( el(k+1)+el(k) )
+          bp(k) = 2.*qkw(k) / b2l
+          rp(k) = pdq(k+1) +pdq(k) 
+       END DO
+       
+!zero gradient for qsq at bottom and top
+       
+!!       a(1)=0.
+!!       b(1)=1.
+!!       c(1)=-1.
+!!       d(1)=0.
+
+! Since dfq(kts)=0.0, a(1)=0.0 and b(1)=1.+dtz(k)*dfq(k+1)+bp(k)*delt.
+       DO k=kts,kte-1
+          a(k-kts+1)=-dtz(k)*dfq(k)
+          b(k-kts+1)=1.+dtz(k)*(dfq(k)+dfq(k+1))+bp(k)*delt
+          c(k-kts+1)=-dtz(k)*dfq(k+1)
+          d(k-kts+1)=rp(k)*delt + qsq(k)
+       ENDDO
+
+!!       DO k=kts+1,kte-1
+!!          a(k-kts+1)=-dtz(k)*dfq(k)
+!!          b(k-kts+1)=1.+dtz(k)*(dfq(k)+dfq(k+1))
+!!          c(k-kts+1)=-dtz(k)*dfq(k+1)
+!!          d(k-kts+1)=rp(k)*delt + qsq(k) -qsq(k)*bp(k)*delt
+!!       ENDDO
+
+       a(kte)=-1. !0.
+       b(kte)=1.
+       c(kte)=0.
+       d(kte)=0.
        
 !       CALL tridiag(kte,a,b,c,d)
        CALL tridiag2(kte,a,b,c,d,x)
 
        DO k=kts,kte
-!          tsq(k)=d(k-kts+1)
-           tsq(k)=x(k)
+!          qsq(k)=d(k-kts+1)
+           qsq(k)=x(k)
        ENDDO
-
+       
 !   **  Prediction of the temperature-moisture covariance  **
 !!       DO k = kts+1,kte-1
        DO k = kts,kte-1
@@ -2489,15 +2297,10 @@ CONTAINS
 
 ! Since dfq(kts)=0.0, a(1)=0.0 and b(1)=1.+dtz(k)*dfq(k+1)+bp(k)*delt.
        DO k=kts,kte-1
-          !a(k-kts+1)=-dtz(k)*dfq(k)
-          !b(k-kts+1)=1.+dtz(k)*(dfq(k)+dfq(k+1))+bp(k)*delt
-          !c(k-kts+1)=-dtz(k)*dfq(k+1)
-          !d(k-kts+1)=rp(k)*delt + cov(k)
-!JOE 8/22/20 improve conservation
-          a(k)=   - dtz(k)*kmdz(k)*rhoinv(k)
-          b(k)=1. + dtz(k)*(kmdz(k)+kmdz(k+1))*rhoinv(k) + bp(k)*delt
-          c(k)=   - dtz(k)*kmdz(k+1)*rhoinv(k)
-          d(k)=rp(k)*delt + cov(k)
+          a(k-kts+1)=-dtz(k)*dfq(k)
+          b(k-kts+1)=1.+dtz(k)*(dfq(k)+dfq(k+1))+bp(k)*delt
+          c(k-kts+1)=-dtz(k)*dfq(k+1)
+          d(k-kts+1)=rp(k)*delt + cov(k)
        ENDDO
 
 !!       DO k=kts+1,kte-1
@@ -2521,8 +2324,7 @@ CONTAINS
        ENDDO
        
     ELSE
-
-       !Not level 3 - default to level 2 diagnostic
+!!       DO k = kts+1,kte-1
        DO k = kts,kte-1
           IF ( qkw(k) .LE. 0.0 ) THEN
              b2l = 0.0
@@ -2531,10 +2333,16 @@ CONTAINS
           END IF
 !
           tsq(k) = b2l*( pdt(k+1)+pdt(k) )
+          qsq(k) = b2l*( pdq(k+1)+pdq(k) )
           cov(k) = b2l*( pdc(k+1)+pdc(k) )
        END DO
        
+!!       tsq(kts)=tsq(kts+1)
+!!       qsq(kts)=qsq(kts+1)
+!!       cov(kts)=cov(kts+1)
+
        tsq(kte)=tsq(kte-1)
+       qsq(kte)=qsq(kte-1)
        cov(kte)=cov(kte-1)
       
     END IF
@@ -2582,8 +2390,8 @@ CONTAINS
 !! use of the namelist parameter \p bl_mynn_cloudpdf .
   SUBROUTINE  mym_condensation (kts,kte,  &
     &            dx, dz, zw,              &
-    &            thl, qw, qv, qc, qi,     &
-    &            p,exner,                 &
+    &            thl, qw, qv, qc, qi, qs, &     ! qs added by G. Thompson
+    &            p,exner, xland,          &     ! xland added by G. Thompson
     &            tsq, qsq, cov,           &
     &            Sh, el, bl_mynn_cloudpdf,&
     &            qc_bl1D, qi_bl1D,        &
@@ -2594,6 +2402,8 @@ CONTAINS
 
 !-------------------------------------------------------------------
 
+    use module_radiation_clouds, only: cal_cldfra3
+
     INTEGER, INTENT(IN)   :: kts,kte, bl_mynn_cloudpdf
 
 #ifdef HARDCODE_VERTICAL
@@ -2601,20 +2411,20 @@ CONTAINS
 # define kte HARDCODE_VERTICAL
 #endif
 
-    REAL, INTENT(IN)      :: dx,PBLH1,HFX1,rmo
+    REAL, INTENT(IN)      :: dx,PBLH1,HFX1,rmo,xland
     REAL, DIMENSION(kts:kte), INTENT(IN) :: dz
     REAL, DIMENSION(kts:kte+1), INTENT(IN) :: zw
-    REAL, DIMENSION(kts:kte), INTENT(IN) :: p,exner,thl,qw,qv,qc,qi, &
+    REAL, DIMENSION(kts:kte), INTENT(IN) :: p,exner,thl,qw,qv,qc,qi,qs, &
          &tsq, qsq, cov, th
 
     REAL, DIMENSION(kts:kte), INTENT(INOUT) :: vt,vq,sgm
 
-    REAL, DIMENSION(kts:kte) :: qmq,alp,a,bet,b,ql,q1,RH
+    REAL, DIMENSION(kts:kte) :: qmq,alp,a,bet,b,ql,q1,RH,cld,t_1d
     REAL, DIMENSION(kts:kte), INTENT(OUT) :: qc_bl1D,qi_bl1D, &
                                              cldfra_bl1D
     DOUBLE PRECISION :: t3sq, r3sq, c3sq
 
-    REAL :: qsl,esat,qsat,tlk,qsat_tl,dqsl,cld0,q1k,qlk,eq1,qll,&
+    REAL :: qsl,esat,qsat,tlk,qsat_tl,dqsl,cld0,q1k,eq1,qll,&
          &q2p,pt,rac,qt,t,xl,rsl,cpm,cdhdz,Fng,qww,alpha,beta,bb,&
          &ls_min,ls,wt,cld_factor,fac_damp,liq_frac,ql_ice,ql_water,&
          &low_weight
@@ -2622,41 +2432,59 @@ CONTAINS
 
     REAL :: erf
 
-    !VARIABLES FOR ALTERNATIVE SIGMA
+    !JOE: NEW VARIABLES FOR ALTERNATE SIGMA
     REAL::dth,dtl,dqw,dzk,els
     REAL, DIMENSION(kts:kte), INTENT(IN) :: Sh,el
 
-    !variables for SGS BL clouds
-    REAL            :: zagl,damp,PBLH2
+    !JOE: variables for BL clouds
+    REAL::zagl,damp,PBLH2,ql_limit
     REAL            :: lfac
-    INTEGER, PARAMETER :: sig_order = 2  !sigma form, 1: use state variables, 2: higher-order variables
+
+    !GREG: 1-D only variables for cal_cldfra3
+    REAL, DIMENSION(KTS:KTE) :: qv_1d, qc_1d, qi_1d
 
     !JAYMES:  variables for tropopause-height estimation
-    REAL            :: theta1, theta2, ht1, ht2
-    INTEGER         :: k_tropo
+    REAL            :: theta1, theta2, delz
+    INTEGER         :: k_tropo, k_p200
 
 !   Stochastic
     INTEGER,  INTENT(IN)                          ::    spp_pbl
     REAL, DIMENSION(KTS:KTE)                      ::    rstoch_col
     REAL :: qw_pert
 
-! First, obtain an estimate for the tropopause height (k), using the method employed in the
-! Thompson subgrid-cloud scheme.  This height will be a consideration later when determining 
-! the "final" subgrid-cloud properties.
-! JAYMES:  added 3 Nov 2016, adapted from G. Thompson
 
-    DO k = kte-3, kts, -1
-       theta1 = th(k)
-       theta2 = th(k+2)
-       ht1 = 44307.692 * (1.0 - (p(k)/101325.)**0.190)
-       ht2 = 44307.692 * (1.0 - (p(k+2)/101325.)**0.190)
-       if ( (((theta2-theta1)/(ht2-ht1)) .lt. 10./1500. ) .AND.       &
-     &                       (ht1.lt.19000.) .and. (ht1.gt.4000.) ) then 
-          goto 86
-       endif
-    ENDDO
- 86   continue
-    k_tropo = MAX(kts+2, k+2)
+!..Find tropopause height, best surrogate, because we would not really
+!.. wish to put fake clouds into the stratosphere.  The 10/1500 ratio
+!.. d(Theta)/d(Z) approximates a vertical line on typical SkewT chart
+!.. near typical (mid-latitude) tropopause height.  Since messy data
+!.. could give us a false signal of such a transition, do the check over 
+!.. three K-level change, not just a level-to-level check.  This method
+!.. has potential failure in arctic-like conditions with extremely low
+!.. tropopause height, as would any other diagnostic, so ensure resulting
+!.. k_tropo level is above 700hPa.
+
+      k_p200 = 0
+      DO k = kte, kts, -1
+         if (P(k).gt.19999.0 .and. k_p200.eq.0) k_p200 = k
+      ENDDO
+      if ( (kte-k_p200) .lt. 3) k_p200 = kte-3
+      DO k = k_p200-2, kts, -1
+         theta1 = th(k)
+         theta2 = th(k+2)
+         delz = 0.5*dz(k) + dz(k+1) + 0.5*dz(k+2)
+         if ( (((theta2-theta1)/delz).lt.10./1500.) .OR. P(k).gt.70000.) EXIT
+      ENDDO
+      k_tropo = MAX(kts+2, MIN(k+2, kte-1))
+
+      if (k_tropo .gt. k_p200) then
+         DO k = kte-3, k_p200-2, -1
+            theta1 = th(k)
+            theta2 = th(k+2)
+            delz = 0.5*dz(k) + dz(k+1) + 0.5*dz(k+2)
+            if ( (((theta2-theta1)/delz).lt.10./1500.) .AND. P(k).gt.9500.) EXIT
+         ENDDO
+         k_tropo = MAX(k_p200-1, MIN(k+2, kte-1))
+      endif
 
     zagl = 0.
 
@@ -2704,7 +2532,6 @@ CONTAINS
            !CLOUD FRACTION. rr2 = 1/SQRT(2) = 0.707
            cldfra_bl1D(k) = 0.5*( 1.0+erf( q1(k)*rr2 ) )
 
-           q1k  = q1(k)
            eq1  = rrp*EXP( -0.5*q1k*q1k )
            qll  = MAX( cldfra_bl1D(k)*q1k + eq1, 0.0 )
            !ESTIMATED LIQUID WATER CONTENT (UNNORMALIZED)
@@ -2717,7 +2544,7 @@ CONTAINS
            if(cldfra_bl1D(k)>0.01 .and. qc_bl1D(k)<1.E-6)qc_bl1D(k)=1.E-6
            if(cldfra_bl1D(k)>0.01 .and. qi_bl1D(k)<1.E-8)qi_bl1D(k)=1.E-8
 
-           !Now estimate the buoyancy flux functions
+           !Now estimate the buiyancy flux functions
            q2p = xlvcp/exner(k)
            pt = thl(k) +q2p*ql(k) ! potential temp
 
@@ -2777,7 +2604,7 @@ CONTAINS
            if(cldfra_bl1D(k)>0.01 .and. qc_bl1D(k)<1.E-6)qc_bl1D(k)=1.E-6
            if(cldfra_bl1D(k)>0.01 .and. qi_bl1D(k)<1.E-8)qi_bl1D(k)=1.E-8
 
-           !Now estimate the buoyancy flux functions
+           !Now estimate the buiyancy flux functions
            q2p = xlvcp/exner(k)
            pt = thl(k) +q2p*ql(k) ! potential temp
 
@@ -2794,147 +2621,84 @@ CONTAINS
         END DO
 
       CASE (2, -2)
+        !Diagnostic statistical scheme of Chaboureau and Bechtold (2002), JAS
+        !JAYMES- this added 27 Apr 2015
+        PBLH2=MAX(10.,PBLH1)
+        zagl = 0.
+        DO k = kts,kte-1
+           t  = th(k)*exner(k)
+           !SATURATED VAPOR PRESSURE
+           esat = esat_blend(t)
+           !SATURATED SPECIFIC HUMIDITY
+           !qsl=ep_2*esat/(p(k)-ep_3*esat)
+           qsl=ep_2*esat/max(1.e-4,(p(k)-ep_3*esat))
+           !dqw/dT: Clausius-Clapeyron
+           dqsl = qsl*ep_2*ev/( rd*t**2 )
+           !RH (0 to 1.0)
+           RH(k)=MAX(MIN(1.0,qw(k)/MAX(1.E-8,qsl)),0.001)
 
-        if (sig_order == 1) then
-          !Diagnostic statistical scheme of Chaboureau and Bechtold (2002), JAS
-          !using the first-order version of sigma (their eq. 5).
-          !JAYMES- this added 27 Apr 2015
-          PBLH2=MAX(10.,PBLH1)
-          zagl = 0.
-          DO k = kts,kte-1
-             t  = th(k)*exner(k)
-             !SATURATED VAPOR PRESSURE
-             esat = esat_blend(t)
-             !SATURATED SPECIFIC HUMIDITY
-             !qsl=ep_2*esat/(p(k)-ep_3*esat)
-             qsl=ep_2*esat/max(1.e-4,(p(k)-ep_3*esat))
-             !dqw/dT: Clausius-Clapeyron
-             dqsl = qsl*ep_2*ev/( rd*t**2 )
-             !RH (0 to 1.0)
-             RH(k)=MAX(MIN(1.0,qw(k)/MAX(1.E-8,qsl)),0.001)
+           alp(k) = 1.0/( 1.0+dqsl*xlvcp )
+           bet(k) = dqsl*exner(k)
 
-             alp(k) = 1.0/( 1.0+dqsl*xlvcp )
-             bet(k) = dqsl*exner(k)
-
-             xl = xl_blend(t)                    ! obtain latent heat
-             tlk = thl(k)*(p(k)/p1000mb)**rcp    ! recover liquid temp (tl) from thl
-             qsat_tl = qsat_blend(tlk,p(k))      ! get saturation water vapor mixing ratio
-                                                 !   at tl and p
-             rsl = xl*qsat_tl / (r_v*tlk**2)     ! slope of C-C curve at t = tl
-                                                 ! CB02, Eqn. 4
-             cpm = cp + qw(k)*cpv                ! CB02, sec. 2, para. 1
-             a(k) = 1./(1. + xl*rsl/cpm)         ! CB02 variable "a"
-             !SPP
-             qw_pert = qw(k) + qw(k)*0.5*rstoch_col(k)*real(spp_pbl)
-             !qmq(k) = a(k) * (qw(k) - qsat_tl) ! saturation deficit/excess;
+           xl = xl_blend(t)                    ! obtain latent heat
+           tlk = thl(k)*(p(k)/p1000mb)**rcp    ! recover liquid temp (tl) from thl
+           qsat_tl = qsat_blend(tlk,p(k))      ! get saturation water vapor mixing ratio
+                                               !   at tl and p
+           rsl = xl*qsat_tl / (r_v*tlk**2)     ! slope of C-C curve at t = tl
+                                               ! CB02, Eqn. 4
+           cpm = cp + qw(k)*cpv                ! CB02, sec. 2, para. 1
+           a(k) = 1./(1. + xl*rsl/cpm)         ! CB02 variable "a"
+           !SPP
+           qw_pert = qw(k) + qw(k)*0.5*rstoch_col(k)*real(spp_pbl)
+           !qmq(k) = a(k) * (qw(k) - qsat_tl) ! saturation deficit/excess;
                                                !   the numerator of Q1
-             qmq(k) = a(k) * (qw_pert - qsat_tl)
-             b(k) = a(k)*rsl                     ! CB02 variable "b"
- 
-             dtl =    0.5*(thl(k+1)*(p(k+1)/p1000mb)**rcp + tlk) &
+           qmq(k) = a(k) * (qw_pert - qsat_tl)
+           b(k) = a(k)*rsl                     ! CB02 variable "b"
+           dtl =    0.5*(thl(k+1)*(p(k+1)/p1000mb)**rcp + tlk) &
                & - 0.5*(tlk + thl(MAX(k-1,kts))*(p(MAX(k-1,kts))/p1000mb)**rcp)
-             dqw = 0.5*(qw(k+1) + qw(k)) - 0.5*(qw(k) + qw(MAX(k-1,kts)))
+           dqw = 0.5*(qw(k+1) + qw(k)) - 0.5*(qw(k) + qw(MAX(k-1,kts)))
 
-             if (k .eq. kts) then
-               dzk = 0.5*dz(k)
-             else
-               dzk = dz(k)
-             end if
+           if (k .eq. kts) then
+             dzk = 0.5*dz(k)
+           else
+             dzk = dz(k)
+           end if
 
-             cdhdz = dtl/dzk + (g/cpm)*(1.+qw(k))  ! expression below Eq. 9
+           cdhdz = dtl/dzk + (g/cpm)*(1.+qw(k))  ! expression below Eq. 9
                                                  ! in CB02
-             zagl = zagl + dz(k)
-             !Use analog to surface layer length scale to make the cloud mixing length scale
-             !become less than z in stable conditions.
-             els  = zagl !save for more testing:  /(1.0 + 1.0*MIN( 0.5*dz(1)*MAX(rmo,0.0), 1. ))
+           zagl = zagl + dz(k)
+           !Use analog to surface layer length scale to make the cloud mixing length scale
+           !become less than z in stable conditions.
+           els  = zagl !save for more testing:  /(1.0 + 1.0*MIN( 0.5*dz(1)*MAX(rmo,0.0), 1. ))
 
-             !ls_min = 300. + MIN(3.*MAX(HFX1,0.),300.)
-             ls_min = 300. + MIN(2.*MAX(HFX1,0.),150.)
-             ls_min = MIN(MAX(els,25.),ls_min) ! Let this be the minimum possible length scale:
-             if (zagl > PBLH1+2000.) ls_min = MAX(ls_min + 0.5*(PBLH1+2000.-zagl),300.)
-                                          !   25 m < ls_min(=zagl) < 300 m
-             lfac=MIN(4.25+dx/4000.,6.)   ! A dx-dependent multiplier for the master length scale:
-                                          !   lfac(750 m) = 4.4
-                                          !   lfac(3 km)  = 5.0
-                                          !   lfac(13 km) = 6.0
-             ls = MAX(MIN(lfac*el(k),600.),ls_min)  ! Bounded:  ls_min < ls < 600 m
-                     ! Note: CB02 use 900 m as a constant free-atmosphere length scale. 
+           !ls_min = 300. + MIN(3.*MAX(HFX1,0.),300.)
+           ls_min = 300. + MIN(2.*MAX(HFX1,0.),150.)
+           ls_min = MIN(MAX(els,25.),ls_min) ! Let this be the minimum possible length scale:
+           if (zagl > PBLH1+2000.) ls_min = MAX(ls_min + 0.5*(PBLH1+2000.-zagl),300.)
+                                        !   25 m < ls_min(=zagl) < 300 m
+           lfac=MIN(4.25+dx/4000.,6.)   ! A dx-dependent multiplier for the master length scale:
+                                        !   lfac(750 m) = 4.4
+                                        !   lfac(3 km)  = 5.0
+                                        !   lfac(13 km) = 6.0
+           ls = MAX(MIN(lfac*el(k),600.),ls_min)  ! Bounded:  ls_min < ls < 600 m
+                   ! Note: CB02 use 900 m as a constant free-atmosphere length scale. 
 
-                     ! Above 300 m AGL, ls_min remains 300 m.  For dx = 3 km, the 
-                     ! MYNN master length scale (el) must exceed 60 m before ls
-                     ! becomes responsive to el, otherwise ls = ls_min = 300 m.
+                   ! Above 300 m AGL, ls_min remains 300 m.  For dx = 3 km, the 
+                   ! MYNN master length scale (el) must exceed 60 m before ls
+                   ! becomes responsive to el, otherwise ls = ls_min = 300 m.
 
-             sgm(k) = MAX(1.e-10, 0.225*ls*SQRT(MAX(0., & ! Eq. 9 in CB02:
-                     & (a(k)*dqw/dzk)**2              & ! < 1st term in brackets,
-                     & -2*a(k)*b(k)*cdhdz*dqw/dzk     & ! < 2nd term,
-                     & +b(k)**2 * cdhdz**2)))            ! < 3rd term
-                     ! CB02 use a multiplier of 0.2, but 0.225 is chosen
-                     ! based on tests
+           sgm(k) = MAX(1.e-10, 0.225*ls*SQRT(MAX(0., & ! Eq. 9 in CB02:
+                   & (a(k)*dqw/dzk)**2              & ! < 1st term in brackets,
+                   & -2*a(k)*b(k)*cdhdz*dqw/dzk     & ! < 2nd term,
+                   & +b(k)**2 * cdhdz**2)))           ! < 3rd term
+                   ! CB02 use a multiplier of 0.2, but 0.225 is chosen
+                   ! based on tests
 
-             q1(k) = qmq(k) / sgm(k)  ! Q1, the normalized saturation
-             cldfra_bl1D(K) = MAX(0., MIN(1., 0.5+0.36*ATAN(1.55*q1(k)))) ! Eq. 7 in CB02
-          END DO
+           q1(k) = qmq(k) / sgm(k)  ! Q1, the normalized saturation
+           cldfra_bl1D(K) = MAX(0., MIN(1., 0.5+0.36*ATAN(1.55*q1(k)))) ! Eq. 7 in CB02
 
-        else
+        END DO
 
-          !Diagnostic statistical scheme of Chaboureau and Bechtold (2002), JAS
-          !but with use of higher-order moments to estimate sigma
-          PBLH2=MAX(10.,PBLH1)
-          zagl = 0.
-          DO k = kts,kte-1
-             t  = th(k)*exner(k)
-             !SATURATED VAPOR PRESSURE
-             esat = esat_blend(t)
-             !SATURATED SPECIFIC HUMIDITY
-             !qsl=ep_2*esat/(p(k)-ep_3*esat)
-             qsl=ep_2*esat/max(1.e-4,(p(k)-ep_3*esat))
-             !dqw/dT: Clausius-Clapeyron
-             dqsl = qsl*ep_2*ev/( rd*t**2 )
-             !RH (0 to 1.0)
-             RH(k)=MAX(MIN(1.0,qw(k)/MAX(1.E-8,qsl)),0.001)
-
-             alp(k) = 1.0/( 1.0+dqsl*xlvcp )
-             bet(k) = dqsl*exner(k)
-
-             xl = xl_blend(t)                    ! obtain latent heat
-             tlk = thl(k)*(p(k)/p1000mb)**rcp    ! recover liquid temp (tl) from thl
-             qsat_tl = qsat_blend(tlk,p(k))      ! get saturation water vapor mixing ratio
-                                                 !   at tl and p
-             rsl = xl*qsat_tl / (r_v*tlk**2)     ! slope of C-C curve at t = tl
-                                                 ! CB02, Eqn. 4
-             cpm = cp + qw(k)*cpv                ! CB02, sec. 2, para. 1
-             a(k) = 1./(1. + xl*rsl/cpm)         ! CB02 variable "a"
-             b(k) = a(k)*rsl                     ! CB02 variable "b"
-
-             !SPP
-             qw_pert = qw(k) + qw(k)*0.5*rstoch_col(k)*real(spp_pbl)
-
-             !This form of qmq (the numerator of Q1) no longer uses the a(k) factor
-             qmq(k) = qw_pert - qsat_tl          ! saturation deficit/excess;
-
-             !Use the form of Eq. (6) in Chaboureau and Bechtold (2002)
-             !except neglect all but the first term for sig_r
-             r3sq = MAX( qsq(k), 0.0 )
-             !Calculate sigma using higher-order moments:
-             sgm(k) = SQRT( r3sq )
-             !Set limits on sigma relative to saturation water vapor
-             sgm(k) = MIN( sgm(k), qsat_tl*0.666 ) !500 )
-             sgm(k) = MAX( sgm(k), qsat_tl*0.050 ) !Note: 0.02 results in SWDOWN similar
-                                                   !to the first-order version of sigma
-             q1(k) = qmq(k) / sgm(k)  ! Q1, the normalized saturation
-
-             !Original C-B cloud fraction, allows cloud fractions out to q1 = -3.5
-             cldfra_bl1D(K) = MAX(0., MIN(1., 0.5+0.36*ATAN(1.55*q1(k)))) ! Eq. 7 in CB02
-             !This form only allows cloud fractions out to q1 = -1.8
-             !cldfra_bl1D(K) = MAX(0., MIN(1., 0.5+0.41*ATAN(1.55*q1(k))))
-             !This form only allows cloud fractions out to q1 = -1
-             !cldfra_bl1D(K) = MAX(0., MIN(1., 0.5+0.50*ATAN(1.55*q1(k))))
-
-          END DO
-
-        endif !end sig_order option
-
-        ! Specify hydrometeors
         ! JAYMES- this option added 8 May 2015
         ! The cloud water formulations are taken from CB02, Eq. 8.
         ! "fng" represents the non-Gaussian contribution to the liquid
@@ -2948,7 +2712,7 @@ CONTAINS
            zagl = zagl + dz(k)
 
            !CLOUD WATER AND ICE
-           IF (q1k < 0.) THEN        !unsaturated
+           IF (q1k < 0.) THEN        !unstaurated
               ql_water = sgm(k)*EXP(1.2*q1k-1)
               ql_ice   = sgm(k)*EXP(1.2*q1k-1.)
               !Reduce ice mixing ratios in the upper troposphere
@@ -2957,37 +2721,33 @@ CONTAINS
 !                  + (1.-low_weight) * sgm(k)*EXP(1.1*q1k-2.8)!upper-lev
            ELSE IF (q1k > 2.) THEN   !supersaturated
               ql_water = sgm(k)*q1k
-              ql_ice   = sgm(k)*q1k
-              !ql_ice = MIN(80.*qv(k),0.1)*sgm(k)*q1k
+              ql_ice = MIN(80.*qv(k),0.1)*sgm(k)*q1k
            ELSE                      !slightly saturated (0 > q1 < 2)
               ql_water = sgm(k)*(EXP(-1.) + 0.66*q1k + 0.086*q1k**2)
-              ql_ice   = sgm(k)*(EXP(-1.) + 0.66*q1k + 0.086*q1k**2)
-              !ql_ice = MIN(80.*qv(k),0.1)*sgm(k)*(EXP(-1.) + 0.66*q1k + 0.086*q1k**2)
+              ql_ice = MIN(80.*qv(k),0.1)*sgm(k)*(EXP(-1.) + 0.66*q1k + 0.086*q1k**2)
            ENDIF
 
            !In saturated grid cells, use average of current estimate and prev time step
            IF ( qc(k) > 1.e-7 ) ql_water = 0.5 * ( ql_water + qc(k) )
            IF ( qi(k) > 1.e-9 ) ql_ice = 0.5 * ( ql_ice + qi(k) )
 
-           IF (cldfra_bl1D(k) < 0.01) THEN
+           IF (cldfra_bl1D(K) < 0.005) THEN
               ql_ice   = 0.0
               ql_water = 0.0
-              cldfra_bl1D(k) = 0.0
            ENDIF
 
-           !PHASE PARTITIONING:  Make some inferences about the relative amounts of 
-           !subgrid cloud water vs. ice based on collocated explicit clouds.  Otherise, 
-           !use a simple temperature-dependent partitioning.
-           IF ( qc(k) + qi(k) > 0.0 ) THEN ! explicit condensate exists, retain its phase partitioning
+           !PHASE PARTITIONING:  Make some inferences about the relative amounts of subgrid cloud water vs. ice
+           !based on collocated explicit clouds.  Otherise, use a simple temperature-dependent partitioning.
+           IF ( qc(k) + qi(k) > 0.0 ) THEN ! explicit condensate exists, so attempt to retain its phase partitioning
               IF ( qi(k) == 0.0 ) THEN       ! explicit contains no ice; assume subgrid liquid
-                liq_frac = 1.0
+                liq_frac = 1.0  
               ELSE IF ( qc(k) == 0.0 ) THEN  ! explicit contains no liquid; assume subgrid ice
                 liq_frac = 0.0
               ELSE IF ( (qc(k) >= 1.E-10) .AND. (qi(k) >= 1.E-10) ) THEN  ! explicit contains mixed phase of workably 
                                                                           ! large amounts; assume subgrid follows 
                                                                           ! same partioning
                 liq_frac = qc(k) / ( qc(k) + qi(k) )
-              ELSE
+              ELSE 
                 liq_frac = MIN(1.0, MAX(0.0, (t-238.)/31.)) ! explicit contains mixed phase, but at least one 
                                                                    ! species is very small, so make a temperature-
                                                                    ! depedent guess
@@ -3005,12 +2765,8 @@ CONTAINS
               qc_bl1D(k)  = 0.
               qi_bl1D(k)  = 0.
            endif
-        ENDDO
-
-        !Buoyancy-flux-related calculations follow...
-        DO k = kts,kte-1
-           t    = th(k)*exner(k)
-
+       
+           !Buoyancy-flux-related calculations follow...
            ! "Fng" represents the non-Gaussian transport factor
            ! (non-dimensional) from Bechtold et al. 1995 
            ! (hereafter BCMT95), section 3(c).  Their suggested 
@@ -3022,16 +2778,17 @@ CONTAINS
            !ELSE
            !  Fng = 1.-1.5*q1k
            !ENDIF
-           !limiting to avoid mixing away stratus, was -5
-           q1k=MAX(Q1(k),-1.0)
-           IF (q1k .GE. 1.0) THEN
+           ! For purposes of the buoyancy flux in stratus, we will use Fng = 1
+           !Fng = 1.
+           Q1(k)=MAX(Q1(k),-5.0)
+           IF (Q1(k) .GE. 1.0) THEN
               Fng = 1.0
-           ELSEIF (q1k .GE. -1.7 .AND. q1k .LT. 1.0) THEN
-              Fng = EXP(-0.4*(q1k-1.0))
-           ELSEIF (q1k .GE. -2.5 .AND. q1k .LT. -1.7) THEN
-              Fng = 3.0 + EXP(-3.8*(q1k+1.7))
+           ELSEIF (Q1(k) .GE. -1.7 .AND. Q1(k) .LT. 1.0) THEN
+              Fng = EXP(-0.4*(Q1(k)-1.0))
+           ELSEIF (Q1(k) .GE. -2.5 .AND. Q1(k) .LT. -1.7) THEN
+              Fng = 3.0 + EXP(-3.8*(Q1(k)+1.7))
            ELSE
-              Fng = MIN(23.9 + EXP(-1.6*(q1k+2.5)), 60.)
+              Fng = MIN(23.9 + EXP(-1.6*(Q1(k)+2.5)), 60.)
            ENDIF
            Fng = MIN(Fng, 20.)
 
@@ -3060,7 +2817,99 @@ CONTAINS
            !cld_factor = 1.0 + fac_damp*MAX(0.0, ( RH(k) - 0.5 ) / 0.51 )**3.3
            cld_factor = 1.0 + fac_damp*MAX(0.0, ( RH(k) - 0.75 ) / 0.26 )**1.9
            cldfra_bl1D(K) = MIN( 1., cld_factor*cldfra_bl1D(K) )
-        ENDDO
+
+         END DO
+
+
+! Added by G. Thompson for cloudpdf=3 which is an updated version of icloud=3 WRF code.
+
+      CASE (3, -3)
+          !    This is a copy/call to cal_cldfra3 (icloud=3) coded by G. Thompson
+
+           DO k = kts,kte-1
+              t_1d(k) = th(k)*exner(k)
+              qv_1d(k) = qv(k)
+              qc_1d(k) = qc(k)
+              qi_1d(k) = qi(k)
+           ENDDO
+           t_1d(kte) = t_1d(kte-1)
+           qv_1d(kte) = qv(kte)
+           qc_1d(kte) = qc(kte)
+           qi_1d(kte) = qi(kte)
+
+           CALL cal_cldfra3 (cld, qv_1d, qc_1d, qi_1d, qs, dz,          &
+     &                          p, t_1d, xland, dx*0.001,               &
+     &                          .false., 1.5, kts, kte, .false.)
+
+           DO k = kts,kte-1
+              cldfra_bl1D(k) = cld(k)
+              qc_bl1D(k) = MAX(0.0, qc_1d(k) - qc(k))
+              qi_bl1D(k) = MAX(0.0, qi_1d(k) - qi(k))
+           ENDDO
+
+         !..Just copy the case2 calculations to fill vt and vq but my own sgm variable.
+
+         DO k = kte-1, kts, -1
+
+           t = t_1d(k)
+           xl = xl_blend(t)                    ! obtain latent heat
+           tlk = thl(k)*(p(k)/p1000mb)**rcp    ! recover liquid temp (tl) from thl
+           qsat_tl = qsat_blend(tlk,p(k))      ! get saturation water vapor mixing ratio
+                                               !   at tl and p
+           rsl = xl*qsat_tl / (r_v*tlk*tlk)    ! slope of C-C curve at t = tl
+                                               ! CB02, Eqn. 4
+           cpm = cp + qw(k)*cpv                ! CB02, sec. 2, para. 1
+           a(k) = 1./(1. + xl*rsl/cpm)         ! CB02 variable "a"
+           b(k) = a(k)*rsl                     ! CB02 variable "b"
+           bb = b(k)*t/th(k) ! bb is "b" in BCMT95.  Their "b" differs from 
+                             ! "b" in CB02 (i.e., b(k) above) by a factor 
+                             ! of T/theta.  Strictly, b(k) above is formulated in
+                             ! terms of sat. mixing ratio, but bb in BCMT95 is
+                             ! cast in terms of sat. specific humidity.  The
+                             ! conversion is neglected here.
+           qww   = 1.+0.61*qw(k)
+           alpha = 0.61*th(k)
+           beta  = (th(k)/t)*(xl/cp) - 1.61*th(k)
+
+           !..Sigma-s (CB02) is little more than a statistical weighting function
+           !.. for pseudo bias correction of insufficient clouds at different altitude.
+           !.. It is likely easier to make it based on Temperature since multiple
+           !.. studies (e.g. Cintineo et al. 2014; Eikenberg et al. 2015;
+           !.. Thompson et al. 2016) have found biggest deficit of clouds occur
+           !.. near 0 to -20C.  So the functions below account for weighting by
+           !.. temperature.
+
+           if (t_1d(k).gt.268.) then
+              sgm(k) = MAX(1.E-8, 0.5*exp((268.-t_1d(k))*0.1))
+           else
+              sgm(k) = MAX(1.E-8, 0.5*exp((t_1d(k)-268.)*0.05))
+           endif
+
+           qmq(k) = a(k) * (qw(k) - qsat_tl)      ! saturation deficit/excess
+           q1(k) = qmq(k) / sgm(k)                ! Q1, the normalized saturation
+
+           Q1(k)=MAX(Q1(k),-5.0)
+           IF (Q1(k) .GE. 1.0) THEN
+              Fng = 1.0
+           ELSEIF (Q1(k) .GE. -1.7 .AND. Q1(k) < 1.0) THEN
+              Fng = EXP(-0.4*(Q1(k)-1.0))
+           ELSEIF (Q1(k) .GE. -2.5 .AND. Q1(k) .LE. -1.7) THEN
+              Fng = 3.0 + EXP(-3.8*(Q1(k)+1.7))
+           ELSE
+              Fng = 20.
+!             Fng = MIN(23.9 + EXP(-1.6*(Q1(k)+2.5)), 60.)  ! Unnecessary since way higher than 20 anyway.
+           ENDIF
+           Fng = MIN(Fng, 20.)
+
+           vt(k) = qww   - MIN(cld(k),0.99)*beta*bb*Fng   - 1.
+           vq(k) = alpha + MIN(cld(k),0.99)*beta*a(k)*Fng - tv0
+           ! vtand vq correspond to beta-theta and beta-q, respectively,  
+           ! in NN09, Eq. B8.  They also correspond to the bracketed
+           ! expressions in BCMT95, Eq. 15, since (s*ql/sigma^2) = cldfra*Fng
+           ! The "-1" and "-tv0" terms are included for consistency with 
+           ! the legacy vt and vq formulations (above).
+
+         END DO
 
       END SELECT !end cloudPDF option
 
@@ -3079,6 +2928,7 @@ CONTAINS
       qc_bl1D(kte)=0.
       qi_bl1D(kte)=0.
       cldfra_bl1D(kte)=0.
+
     RETURN
 
 #ifdef HARDCODE_VERTICAL
@@ -3093,10 +2943,10 @@ CONTAINS
 !! This subroutine solves for tendencies of U, V, \f$\theta\f$, qv,
 !! qc, and qi
   SUBROUTINE mynn_tendencies(kts,kte,      &
-       &closure,grav_settling,             &
+       &levflag,grav_settling,             &
        &delt,dz,rho,                       &
        &u,v,th,tk,qv,qc,qi,qnc,qni,        &
-       &psfc,p,exner,                      &
+       &p,exner,                           &
        &thl,sqv,sqc,sqi,sqw,               &
        &qnwfa,qnifa,ozone,                 &
        &ust,flt,flq,flqv,flqc,wspd,qcg,    &
@@ -3111,8 +2961,6 @@ CONTAINS
        &s_awu,s_awv,                       &
        &s_awqnc,s_awqni,                   &
        &s_awqnwfa,s_awqnifa,               &
-       &sd_aw,sd_awthl,sd_awqt,sd_awqv,    &
-       &sd_awqc,sd_awu,sd_awv,             &
        &sub_thl,sub_sqv,                   &
        &sub_u,sub_v,                       &
        &det_thl,det_sqv,det_sqc,           &
@@ -3134,8 +2982,7 @@ CONTAINS
 # define kte HARDCODE_VERTICAL
 #endif
 
-    INTEGER, INTENT(in) :: grav_settling
-    REAL,    INTENT(in) :: closure
+    INTEGER, INTENT(in) :: grav_settling,levflag
     INTEGER, INTENT(in) :: bl_mynn_cloudmix,bl_mynn_mixqt,&
                            bl_mynn_edmf,bl_mynn_edmf_mom, &
                            bl_mynn_mixscalars
@@ -3152,9 +2999,7 @@ CONTAINS
 
 ! mass-flux plumes
     REAL, DIMENSION(kts:kte+1), INTENT(in) :: s_aw,s_awthl,s_awqt,&
-         &s_awqnc,s_awqni,s_awqv,s_awqc,s_awu,s_awv,              &
-         &s_awqnwfa,s_awqnifa,                                    &
-         &sd_aw,sd_awthl,sd_awqt,sd_awqv,sd_awqc,sd_awu,sd_awv
+         &s_awqnc,s_awqni,s_awqv,s_awqc,s_awu,s_awv,s_awqnwfa,s_awqnifa
 ! tendencies from mass-flux environmental subsidence and detrainment
     REAL, DIMENSION(kts:kte), INTENT(in) :: sub_thl,sub_sqv,  &
          &sub_u,sub_v,det_thl,det_sqv,det_sqc,det_u,det_v
@@ -3164,14 +3009,14 @@ CONTAINS
          &qnwfa,qnifa,ozone,dfm,dfh
     REAL, DIMENSION(kts:kte), INTENT(inout) :: du,dv,dth,dqv,dqc,dqi,&
          &dqni,dqnc,dqnwfa,dqnifa,dozone
-    REAL, INTENT(IN) :: delt,ust,flt,flq,flqv,flqc,wspd,uoce,voce,qcg,psfc
+    REAL, INTENT(IN) :: delt,ust,flt,flq,flqv,flqc,wspd,uoce,voce,qcg
 
 !    REAL, INTENT(IN) :: delt,ust,flt,flq,qcg,&
 !         &gradu_top,gradv_top,gradth_top,gradqv_top
 
 !local vars
 
-    REAL, DIMENSION(kts:kte) :: dtz,dfhc,dfmc,delp
+    REAL, DIMENSION(kts:kte) :: dtz,vt,vq,dfhc,dfmc !Kh for clouds (Pr < 2)
     REAL, DIMENSION(kts:kte) :: sqv2,sqc2,sqi2,sqw2,qni2,qnc2, & !AFTER MIXING
                                 qnwfa2,qnifa2,ozone2
     REAL, DIMENSION(kts:kte) :: zfac,plumeKh,rhoinv
@@ -3180,14 +3025,12 @@ CONTAINS
           &         khdz, kmdz
     REAL :: rhs,gfluxm,gfluxp,dztop,maxdfh,mindfh,maxcf,maxKh,zw
     REAL :: grav_settling2,vdfg1    !Katata-fogdes
-    REAL :: t,esat,qsl,onoff,kh,km,dzk,rhosfc
-    REAL :: ustdrag,ustdiff
-    REAL :: th_new,portion_qc,portion_qi,condensate,qsat
+    REAL :: t,esat,qsl,onoff,kh,km,dzk
     INTEGER :: k,kk
 
     !Activate nonlocal mixing from the mass-flux scheme for
-    !number concentrations and aerosols (0.0 = no; 1.0 = yes)
-    REAL, PARAMETER :: nonloc = 1.0
+    !scalars (0.0 = no; 1.0 = yes)
+    REAL, PARAMETER :: nonloc = 0.0
 
     dztop=.5*(dz(kte)+dz(kte-1))
 
@@ -3202,13 +3045,11 @@ CONTAINS
 
     !Prepare "constants" for diffusion equation.
     !khdz = rho*Kh/dz = rho*dfh
-    rhosfc     = psfc/(Rd*(Tk(kts)+0.608*qv(kts)))
     dtz(kts)   =delt/dz(kts)
     rhoz(kts)  =rho(kts)
     rhoinv(kts)=1./rho(kts)
     khdz(kts)  =rhoz(kts)*dfh(kts)
     kmdz(kts)  =rhoz(kts)*dfm(kts)
-    delp(kts)  = psfc - (p(kts+1)*dz(kts) + p(kts)*dz(kts+1))/(dz(kts)+dz(kts+1))
     DO k=kts+1,kte
        dtz(k)   =delt/dz(k)
        rhoz(k)  =(rho(k)*dz(k-1) + rho(k-1)*dz(k))/(dz(k-1)+dz(k))
@@ -3218,26 +3059,17 @@ CONTAINS
        khdz(k)  = rhoz(k)*dfh(k)
        kmdz(k)  = rhoz(k)*dfm(k)
     ENDDO
-    DO k=kts+1,kte-1
-       delp(k)  = (p(k)*dz(k-1) + p(k-1)*dz(k))/(dz(k)+dz(k-1)) - &
-                  (p(k+1)*dz(k) + p(k)*dz(k+1))/(dz(k)+dz(k+1))
-    ENDDO
-    delp(kte)  =delp(kte-1)
     rhoz(kte+1)=rhoz(kte)
     khdz(kte+1)=rhoz(kte+1)*dfh(kte)
     kmdz(kte+1)=rhoz(kte+1)*dfm(kte)
 
     !stability criteria for mf
     DO k=kts+1,kte-1
-       khdz(k) = MAX(khdz(k),  0.5*s_aw(k))
-       khdz(k) = MAX(khdz(k), -0.5*(s_aw(k)-s_aw(k+1)))
-       kmdz(k) = MAX(kmdz(k),  0.5*s_aw(k))
-       kmdz(k) = MAX(kmdz(k), -0.5*(s_aw(k)-s_aw(k+1)))
+       khdz(k) = MAX(khdz(k),  0.5*rho(k)* s_aw(k))
+       khdz(k) = MAX(khdz(k), -0.5*rho(k)*(s_aw(k)-s_aw(k+1)))
+       kmdz(k) = MAX(kmdz(k),  0.5*rho(k)* s_aw(k))
+       kmdz(k) = MAX(kmdz(k), -0.5*rho(k)*(s_aw(k)-s_aw(k+1)))
     ENDDO
-
-    ustdrag = MIN(ust*ust,0.99)/wspd  ! limit at ~ 20 m/s
-    ustdiff = MIN(ust*ust,0.01)/wspd  ! limit at ~ 2 m/s
-    dth(kts:kte) = 0.0  ! must initialize for moisture_check routine
 
 !!============================================
 !! u
@@ -3245,34 +3077,40 @@ CONTAINS
 
     k=kts
 
-!original approach
 !    a(1)=0.
 !    b(1)=1. + dtz(k)*(dfm(k+1)+ust**2/wspd) - 0.5*dtz(k)*s_aw(k+1)*onoff
 !    c(1)=-dtz(k)*dfm(k+1) - 0.5*dtz(k)*s_aw(k+1)*onoff
 !    d(1)=u(k) + dtz(k)*uoce*ust**2/wspd - dtz(k)*s_awu(k+1)*onoff + &
 !         sub_u(k)*delt + det_u(k)*delt
+!
+!    DO k=kts+1,kte-1
+!       a(k)=   - dtz(k)*dfm(k)            + 0.5*dtz(k)*s_aw(k)*onoff
+!       b(k)=1. + dtz(k)*(dfm(k)+dfm(k+1)) + 0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*onoff
+!       c(k)=   - dtz(k)*dfm(k+1)          - 0.5*dtz(k)*s_aw(k+1)*onoff
+!       d(k)=u(k) + dtz(k)*(s_awu(k)-s_awu(k+1))*onoff + &
+!            sub_u(k)*delt + det_u(k)*delt
+!    ENDDO
 
 !rho-weighted:
-!    a(k)=  -dtz(k)*kmdz(k)*rhoinv(k)
-!    b(k)=1.+dtz(k)*(kmdz(k+1)+ust**2/wspd)*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)*onoff
-!    c(k)=  -dtz(k)*kmdz(k+1)*rhoinv(k)               - 0.5*dtz(k)*s_aw(k+1)*onoff
-!    d(k)=u(k)  + dtz(k)*uoce*ust**2/wspd - dtz(k)*s_awu(k+1)*onoff + &
-!       & sub_u(k)*delt + det_u(k)*delt
-
-!rho-weighted with drag term moved out of b-array
     a(k)=  -dtz(k)*kmdz(k)*rhoinv(k)
-    b(k)=1.+dtz(k)*(kmdz(k+1))*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*onoff - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)*onoff
-    c(k)=  -dtz(k)*kmdz(k+1)*rhoinv(k)   - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*onoff - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)*onoff
-    d(k)=u(k)*(1.-ust**2/wspd*dtz(k)*rhosfc/rho(k)) + dtz(k)*uoce*ust**2/wspd - &
-    !d(k)=u(k)*(1.-ust**2/wspd*dtz(k)) + dtz(k)*uoce*ust**2/wspd - &
-      &  dtz(k)*rhoinv(k)*s_awu(k+1)*onoff - dtz(k)*rhoinv(k)*sd_awu(k+1)*onoff + sub_u(k)*delt + det_u(k)*delt
+    b(k)=1.+dtz(k)*(kmdz(k+1)+ust**2/wspd)*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)*onoff
+    c(k)=  -dtz(k)*kmdz(k+1)*rhoinv(k)           - 0.5*dtz(k)*s_aw(k+1)*onoff
+    d(k)=u(k)  + dtz(k)*uoce*ust**2/wspd - dtz(k)*s_awu(k+1)*onoff + &
+       & sub_u(k)*delt + det_u(k)*delt
+
+!!JOE - tend test
+!!    a(k)=0.
+!!    b(k)=1.+dtz(k)*kmdz(k+1)*rhoinv(k)    - 0.5*dtz(k)*s_aw(k+1)*onoff
+!!    c(k)  =-dtz(k)*kmdz(k+1)*rhoinv(k)    - 0.5*dtz(k)*s_aw(k+1)*onoff
+!!    d(k)=u(k)*(1.-ust**2/wspd*dtz(k)) + &
+!!         dtz(k)*uoce*ust**2/wspd - dtz(k)*s_awu(k+1)*onoff
 
     DO k=kts+1,kte-1
-       a(k)=  -dtz(k)*kmdz(k)*rhoinv(k)     + 0.5*dtz(k)*rhoinv(k)*s_aw(k)*onoff + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)*onoff 
+       a(k)=  -dtz(k)*kmdz(k)*rhoinv(k)     + 0.5*dtz(k)*s_aw(k)*onoff
        b(k)=1.+dtz(k)*(kmdz(k)+kmdz(k+1))*rhoinv(k) + &
-           &    0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))*onoff + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))*onoff
-       c(k)=  -dtz(k)*kmdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*onoff - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)*onoff
-       d(k)=u(k) + dtz(k)*rhoinv(k)*(s_awu(k)-s_awu(k+1))*onoff + dtz(k)*rhoinv(k)*(sd_awu(k)-sd_awu(k+1))*onoff + &
+           &    0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*onoff
+       c(k)=  -dtz(k)*kmdz(k+1)*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)*onoff
+       d(k)=u(k) + dtz(k)*(s_awu(k)-s_awu(k+1))*onoff + &
            &    sub_u(k)*delt + det_u(k)*delt
     ENDDO
 
@@ -3308,34 +3146,41 @@ CONTAINS
 
     k=kts
 
-!original approach
 !    a(1)=0.
 !    b(1)=1. + dtz(k)*(dfm(k+1)+ust**2/wspd) - 0.5*dtz(k)*s_aw(k+1)*onoff
 !    c(1)=   - dtz(k)*dfm(k+1)               - 0.5*dtz(k)*s_aw(k+1)*onoff
+!!    d(1)=v(k)
 !    d(1)=v(k) + dtz(k)*voce*ust**2/wspd - dtz(k)*s_awv(k+1)*onoff + &
 !          sub_v(k)*delt + det_v(k)*delt
+!
+!    DO k=kts+1,kte-1
+!       a(k)=   - dtz(k)*dfm(k)            + 0.5*dtz(k)*s_aw(k)*onoff
+!       b(k)=1. + dtz(k)*(dfm(k)+dfm(k+1)) + 0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*onoff
+!       c(k)=   - dtz(k)*dfm(k+1)          - 0.5*dtz(k)*s_aw(k+1)*onoff
+!       d(k)=v(k) + dtz(k)*(s_awv(k)-s_awv(k+1))*onoff + &
+!            sub_v(k)*delt + det_v(k)*delt
+!    ENDDO
 
 !rho-weighted:
-!    a(k)=  -dtz(k)*kmdz(k)*rhoinv(k)
-!    b(k)=1.+dtz(k)*(kmdz(k+1)+ust**2/wspd)*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)*onoff
-!    c(k)=  -dtz(k)*kmdz(k+1)*rhoinv(k)               - 0.5*dtz(k)*s_aw(k+1)*onoff
-!    d(k)=v(k)  + dtz(k)*voce*ust**2/wspd - dtz(k)*s_awv(k+1)*onoff + &
-!       & sub_v(k)*delt + det_v(k)*delt
-
-!rho-weighted with drag	term moved out of b-array
     a(k)=  -dtz(k)*kmdz(k)*rhoinv(k)
-    b(k)=1.+dtz(k)*(kmdz(k+1))*rhoinv(k)  - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*onoff - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)*onoff
-    c(k)=  -dtz(k)*kmdz(k+1)*rhoinv(k)    - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*onoff - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)*onoff
-    d(k)=v(k)*(1.-ust**2/wspd*dtz(k)*rhosfc/rho(k)) + dtz(k)*voce*ust**2/wspd - &
-    !d(k)=v(k)*(1.-ust**2/wspd*dtz(k)) + dtz(k)*voce*ust**2/wspd - &
-      &  dtz(k)*rhoinv(k)*s_awv(k+1)*onoff - dtz(k)*rhoinv(k)*sd_awv(k+1)*onoff + sub_v(k)*delt + det_v(k)*delt
+    b(k)=1.+dtz(k)*(kmdz(k+1)+ust**2/wspd)*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)*onoff
+    c(k)=  -dtz(k)*kmdz(k+1)*rhoinv(k)           - 0.5*dtz(k)*s_aw(k+1)*onoff
+    d(k)=v(k)  + dtz(k)*voce*ust**2/wspd - dtz(k)*s_awv(k+1)*onoff + &
+       & sub_v(k)*delt + det_v(k)*delt
+
+!!JOE - tend test
+!!    a(k)=0.
+!!    b(k)=1.+dtz(k)*kmdz(k+1)*rhoinv(k)  - 0.5*dtz(k)*s_aw(k+1)*onoff
+!!    c(k)=  -dtz(k)*kmdz(k+1)*rhoinv(k)  - 0.5*dtz(k)*s_aw(k+1)*onoff
+!!    d(k)=v(k)*(1.-ust**2/wspd*dtz(k)) + &
+!!         dtz(k)*voce*ust**2/wspd - dtz(k)*s_awv(k+1)*onoff
 
     DO k=kts+1,kte-1
-       a(k)=  -dtz(k)*kmdz(k)*rhoinv(k)   + 0.5*dtz(k)*rhoinv(k)*s_aw(k)*onoff + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)*onoff
+       a(k)=  -dtz(k)*kmdz(k)*rhoinv(k)     + 0.5*dtz(k)*s_aw(k)*onoff
        b(k)=1.+dtz(k)*(kmdz(k)+kmdz(k+1))*rhoinv(k) + &
-           &    0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))*onoff + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))*onoff
-       c(k)=  -dtz(k)*kmdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*onoff - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)*onoff 
-       d(k)=v(k) + dtz(k)*rhoinv(k)*(s_awv(k)-s_awv(k+1))*onoff + dtz(k)*rhoinv(k)*(sd_awv(k)-sd_awv(k+1))*onoff + &
+           &    0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*onoff
+       c(k)=  -dtz(k)*kmdz(k+1)*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)*onoff
+       d(k)=v(k) + dtz(k)*(s_awv(k)-s_awv(k+1))*onoff + &
            &    sub_v(k)*delt + det_v(k)*delt
     ENDDO
 
@@ -3387,22 +3232,21 @@ CONTAINS
 !           &         sub_thl(k)*delt + det_thl(k)*delt
 !    ENDDO
 
-!rho-weighted:
+!rho-weighted:                                                                                                           
     a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
-    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
-    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)           - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
-    d(k)=thl(k)  + dtz(k)*flt + tcd(k)*delt - dtz(k)*rhoinv(k)*s_awthl(k+1) -dtz(k)*rhoinv(k)*sd_awthl(k+1) + &
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)           - 0.5*dtz(k)*s_aw(k+1)
+    d(k)=thl(k)  + dtz(k)*flt + tcd(k)*delt - dtz(k)*s_awthl(k+1) + &
        & diss_heat(k)*delt*dheat_opt + sub_thl(k)*delt + det_thl(k)*delt
 
     DO k=kts+1,kte-1
-       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*rhoinv(k)*s_aw(k) + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*s_aw(k)
        b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k) + &
-           &   0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1)) + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))
-       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
-       d(k)=thl(k) + tcd(k)*delt + &
-          & dtz(k)*rhoinv(k)*(s_awthl(k)-s_awthl(k+1)) + dtz(k)*rhoinv(k)*(sd_awthl(k)-sd_awthl(k+1)) + &
-          &       diss_heat(k)*delt*dheat_opt + &
-          &       sub_thl(k)*delt + det_thl(k)*delt
+           &    0.5*dtz(k)*(s_aw(k)-s_aw(k+1))
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)
+       d(k)=thl(k) + tcd(k)*delt + dtz(k)*(s_awthl(k)-s_awthl(k+1)) + &
+          &         diss_heat(k)*delt*dheat_opt + &
+          &         sub_thl(k)*delt + det_thl(k)*delt
     ENDDO
 
 !! no flux at the top
@@ -3458,16 +3302,16 @@ IF (bl_mynn_mixqt > 0) THEN
 
 !rho-weighted:
     a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
-    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
-    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)           - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
-    d(k)=sqw(k)  + dtz(k)*flq + qcd(k)*delt - dtz(k)*rhoinv(k)*s_awqt(k+1) - dtz(k)*rhoinv(k)*sd_awqt(k+1)
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)           - 0.5*dtz(k)*s_aw(k+1)
+    d(k)=sqw(k)  + dtz(k)*flq + qcd(k)*delt - dtz(k)*s_awqt(k+1)
 
     DO k=kts+1,kte-1
-       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*rhoinv(k)*s_aw(k) + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*s_aw(k)
        b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k) + &
-           &    0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1)) + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))
-       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
-       d(k)=sqw(k) + qcd(k)*delt + dtz(k)*rhoinv(k)*(s_awqt(k)-s_awqt(k+1)) + dtz(k)*rhoinv(k)*(sd_awqt(k)-sd_awqt(k+1))
+           &    0.5*dtz(k)*(s_aw(k)-s_aw(k+1))
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)
+       d(k)=sqw(k) + qcd(k)*delt + dtz(k)*(s_awqt(k)-s_awqt(k+1))
     ENDDO
 
 !! no flux at the top
@@ -3523,17 +3367,17 @@ IF (bl_mynn_mixqt == 0) THEN
 
 !rho-weighted:
     a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
-    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
-    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)           - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
-    d(k)=sqc(k)  + dtz(k)*flqc + qcd(k)*delt - dtz(k)*rhoinv(k)*s_awqc(k+1) - dtz(k)*rhoinv(k)*sd_awqc(k+1) + &
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)           - 0.5*dtz(k)*s_aw(k+1)
+    d(k)=sqc(k)  + dtz(k)*flqc + qcd(k)*delt - dtz(k)*s_awqc(k+1) + &
        & det_sqc(k)*delt
 
     DO k=kts+1,kte-1
-       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*rhoinv(k)*s_aw(k) + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*s_aw(k)
        b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k) + &
-           &    0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1)) + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))
-       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
-       d(k)=sqc(k) + qcd(k)*delt + dtz(k)*rhoinv(k)*(s_awqc(k)-s_awqc(k+1)) + dtz(k)*rhoinv(k)*(sd_awqc(k)-sd_awqc(k+1)) + &
+           &    0.5*dtz(k)*(s_aw(k)-s_aw(k+1))
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)
+       d(k)=sqc(k) + qcd(k)*delt + dtz(k)*(s_awqc(k)-s_awqc(k+1)) + &
           & det_sqc(k)*delt
     ENDDO
 
@@ -3580,17 +3424,17 @@ IF (bl_mynn_mixqt == 0) THEN
 
 !rho-weighted:
     a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
-    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
-    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)           - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
-    d(k)=sqv(k)  + dtz(k)*flqv + qcd(k)*delt - dtz(k)*rhoinv(k)*s_awqv(k+1) - dtz(k)*rhoinv(k)*sd_awqv(k+1) + &
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)           - 0.5*dtz(k)*s_aw(k+1)
+    d(k)=sqv(k)  + dtz(k)*flqv + qcd(k)*delt - dtz(k)*s_awqv(k+1) + &
        & sub_sqv(k)*delt + det_sqv(k)*delt
 
     DO k=kts+1,kte-1
-       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*rhoinv(k)*s_aw(k) + 0.5*dtz(k)*rhoinv(k)*sd_aw(k)
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*s_aw(k)
        b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k) + &
-           &    0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1)) + 0.5*dtz(k)*rhoinv(k)*(sd_aw(k)-sd_aw(k+1))
-       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1) - 0.5*dtz(k)*rhoinv(k)*sd_aw(k+1)
-       d(k)=sqv(k) + qcd(k)*delt + dtz(k)*rhoinv(k)*(s_awqv(k)-s_awqv(k+1)) + dtz(k)*rhoinv(k)*(sd_awqv(k)-sd_awqv(k+1)) + &
+           &    0.5*dtz(k)*(s_aw(k)-s_aw(k+1))
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)
+       d(k)=sqv(k) + qcd(k)*delt + dtz(k)*(s_awqv(k)-s_awqv(k+1)) + &
           & sub_sqv(k)*delt + det_sqv(k)*delt
     ENDDO
 
@@ -3695,16 +3539,16 @@ IF (bl_mynn_cloudmix > 0 .AND. FLAG_QNI .AND. &
     k=kts
 
     a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
-    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
-    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
-    d(k)=qni(k)  - dtz(k)*rhoinv(k)*s_awqni(k+1)*nonloc
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)*nonloc
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)*nonloc
+    d(k)=qni(k)  - dtz(k)*s_awqni(k+1)*nonloc
 
     DO k=kts+1,kte-1
-       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*rhoinv(k)*s_aw(k)*nonloc
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*s_aw(k)*nonloc
        b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k) + &
-           &    0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))*nonloc
-       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
-       d(k)=qni(k) + dtz(k)*rhoinv(k)*(s_awqni(k)-s_awqni(k+1))*nonloc
+           &    0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*nonloc
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)*nonloc
+       d(k)=qni(k) + dtz(k)*(s_awqni(k)-s_awqni(k+1))*nonloc
     ENDDO
 
 !! prescribed value
@@ -3736,16 +3580,16 @@ ENDIF
     k=kts
 
     a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
-    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
-    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)           - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
-    d(k)=qnc(k)  - dtz(k)*rhoinv(k)*s_awqnc(k+1)*nonloc
+    b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)*nonloc
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)           - 0.5*dtz(k)*s_aw(k+1)*nonloc
+    d(k)=qnc(k)  - dtz(k)*s_awqnc(k+1)*nonloc
 
     DO k=kts+1,kte-1
-       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*rhoinv(k)*s_aw(k)*nonloc
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*s_aw(k)*nonloc
        b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k) + &
-           &    0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))*nonloc
-       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
-       d(k)=qnc(k) + dtz(k)*rhoinv(k)*(s_awqnc(k)-s_awqnc(k+1))*nonloc
+           &    0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*nonloc
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)*nonloc
+       d(k)=qnc(k) + dtz(k)*(s_awqnc(k)-s_awqnc(k+1))*nonloc
     ENDDO
 
 !! prescribed value
@@ -3777,16 +3621,16 @@ IF (bl_mynn_cloudmix > 0 .AND. FLAG_QNWFA .AND. &
 
     a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
     b(k)=1.+dtz(k)*(khdz(k) + khdz(k+1))*rhoinv(k) - &
-           &    0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
-    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
-    d(k)=qnwfa(k)  - dtz(k)*rhoinv(k)*s_awqnwfa(k+1)*nonloc
+           &    0.5*dtz(k)*s_aw(k+1)*nonloc
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)*nonloc
+    d(k)=qnwfa(k)  - dtz(k)*s_awqnwfa(k+1)*nonloc
 
     DO k=kts+1,kte-1
-       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*rhoinv(k)*s_aw(k)*nonloc
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*s_aw(k)*nonloc
        b(k)=1.+dtz(k)*(khdz(k) + khdz(k+1))*rhoinv(k) + &
-           &    0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))*nonloc
-       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
-       d(k)=qnwfa(k) + dtz(k)*rhoinv(k)*(s_awqnwfa(k)-s_awqnwfa(k+1))*nonloc
+           &    0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*nonloc
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)*nonloc
+       d(k)=qnwfa(k) + dtz(k)*(s_awqnwfa(k)-s_awqnwfa(k+1))*nonloc
     ENDDO
 
 ! prescribed value
@@ -3819,16 +3663,16 @@ IF (bl_mynn_cloudmix > 0 .AND. FLAG_QNIFA .AND. &
 
     a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
     b(k)=1.+dtz(k)*(khdz(k) + khdz(k+1))*rhoinv(k) - &
-           &    0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
-    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
-    d(k)=qnifa(k)  - dtz(k)*rhoinv(k)*s_awqnifa(k+1)*nonloc
+           &    0.5*dtz(k)*s_aw(k+1)*nonloc
+    c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)*nonloc
+    d(k)=qnifa(k)  - dtz(k)*s_awqnifa(k+1)*nonloc
 
     DO k=kts+1,kte-1
-       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*rhoinv(k)*s_aw(k)*nonloc
+       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*s_aw(k)*nonloc
        b(k)=1.+dtz(k)*(khdz(k) + khdz(k+1))*rhoinv(k) + &
-           &    0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))*nonloc
-       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)*nonloc
-       d(k)=qnifa(k) + dtz(k)*rhoinv(k)*(s_awqnifa(k)-s_awqnifa(k+1))*nonloc
+           &    0.5*dtz(k)*(s_aw(k)-s_aw(k+1))*nonloc
+       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*s_aw(k+1)*nonloc
+       d(k)=qnifa(k) + dtz(k)*(s_awqnifa(k)-s_awqnifa(k+1))*nonloc
     ENDDO
 
 ! prescribed value
@@ -3890,45 +3734,42 @@ ENDIF
 !! Note that the momentum tendencies are calculated above.
 !!============================================
 
-   IF (bl_mynn_mixqt > 0) THEN 
+    IF (bl_mynn_mixqt > 0) THEN 
       DO k=kts,kte
-         !compute updated theta using updated thl and old condensate
-         th_new = thl(k) + xlvcp/exner(k)*sqc(k) &
-           &             + xlscp/exner(k)*sqi(k)
-
-         t  = th_new*exner(k)
-         qsat = qsat_blend(t,p(k)) 
+         t  = th(k)*exner(k)
          !SATURATED VAPOR PRESSURE
-         !esat=esat_blend(t)
+         esat=esat_blend(t)
          !SATURATED SPECIFIC HUMIDITY
          !qsl=ep_2*esat/(p(k)-ep_3*esat)
-         !qsl=ep_2*esat/max(1.e-4,(p(k)-ep_3*esat))
+         qsl=ep_2*esat/max(1.e-4,(p(k)-ep_3*esat))
 
-         IF (sqc(k) > 0.0 .or. sqi(k) > 0.0) THEN !initially saturated
-            sqv2(k) = MIN(sqw2(k),qsat)
-            portion_qc = sqc(k)/(sqc(k) + sqi(k))
-            portion_qi = sqi(k)/(sqc(k) + sqi(k))
-            condensate = MAX(sqw2(k) - qsat, 0.0)
-            sqc2(k) = condensate*portion_qc
-            sqi2(k) = condensate*portion_qi
-         ELSE                     ! initially unsaturated -----
-            sqv2(k) = sqw2(k)     ! let microphys decide what to do
-            sqi2(k) = 0.0         ! if sqw2 > qsat 
-            sqc2(k) = 0.0
-         ENDIF
-         !dqv(k) = (sqv2(k) - sqv(k))/delt
-         !dqc(k) = (sqc2(k) - sqc(k))/delt
-         !dqi(k) = (sqi2(k) - sqi(k))/delt
+         !IF (qsl >= sqw2(k)) THEN !unsaturated
+         !   sqv2(k) = MAX(0.0,sqw2(k))
+         !   sqi2(k) = MAX(0.0,sqi2(k))
+         !   sqc2(k) = MAX(0.0,sqw2(k) - sqv2(k) - sqi2(k))
+         !ELSE                     !saturated
+            IF (FLAG_QI) THEN
+              !sqv2(k) = qsl
+              sqi2(k) = MAX(0., sqi2(k))
+              sqc2(k) = MAX(0., sqw2(k) - sqi2(k) - qsl)      !updated cloud water
+              sqv2(k) = MAX(0., sqw2(k) - sqc2(k) - sqi2(k))  !updated water vapor
+            ELSE
+              !sqv2(k) = qsl
+              sqi2(k) = 0.0
+              sqc2(k) = MAX(0., sqw2(k) - qsl)         !updated cloud water
+              sqv2(k) = MAX(0., sqw2(k) - sqc2(k))     ! updated water vapor
+            ENDIF
+         !ENDIF
       ENDDO
-   ENDIF
-
+    ENDIF
 
     !=====================
     ! WATER VAPOR TENDENCY
     !=====================
     DO k=kts,kte
-       Dqv(k)=(sqv2(k)/(1.-sqv2(k)) - qv(k))/delt
-       !if (sqv2(k) < 0.0)print*,"neg qv:",sqv2(k),k
+       !Dqv(k)=(sqv2(k)/(1.-sqv2(k)) - qv(k))/delt  !mixing ratio
+       Dqv(k)=(sqv2(k) - sqv(k))/delt              !spec humidity
+       !IF(-Dqv(k) > qv(k)) Dqv(k)=-qv(k)
     ENDDO
 
     IF (bl_mynn_cloudmix > 0) THEN
@@ -3940,8 +3781,12 @@ ENDIF
       !print*,"FLAG_QC:",FLAG_QC
       IF (FLAG_QC) THEN
          DO k=kts,kte
-            Dqc(k)=(sqc2(k)/(1.-sqv2(k)) - qc(k))/delt
-            !if (sqc2(k) < 0.0)print*,"neg qc:",sqc2(k),k
+            !Dqc(k)=(sqc2(k)/(1.-sqv2(k)) - qc(k))/delt !mixing ratio
+            Dqc(k)=(sqc2(k) - sqc(k))/delt             !spec humidity
+            IF(Dqc(k)*delt + sqc(k) < 0.) THEN
+              !print*,'  neg qc:',qsl,sqw2(k),sqi2(k),sqc2(k),qc(k),tk(k)
+              Dqc(k)=-sqc(k)/delt 
+            ENDIF
          ENDDO
       ELSE
          DO k=kts,kte
@@ -3954,6 +3799,7 @@ ENDIF
       !===================
       IF (FLAG_QNC .AND. bl_mynn_mixscalars > 0) THEN
          DO k=kts,kte
+           !IF(sqc2(k)>1.e-9)qnc2(k)=MAX(qnc2(k),1.e6)
            Dqnc(k) = (qnc2(k)-qnc(k))/delt
            !IF(Dqnc(k)*delt + qnc(k) < 0.)Dqnc(k)=-qnc(k)/delt
          ENDDO 
@@ -3968,8 +3814,12 @@ ENDIF
       !===================
       IF (FLAG_QI) THEN
          DO k=kts,kte
-           Dqi(k)=(sqi2(k)/(1.-sqv2(k)) - qi(k))/delt
-           !if (sqi2(k) < 0.0)print*,"neg qi:",sqi2(k),k
+           !Dqi(k)=(sqi2(k)/(1.-sqv2(k)) - qi(k))/delt !mixing ratio
+           Dqi(k)=(sqi2(k) - sqi(k))/delt             !spec humidity
+           IF(Dqi(k)*delt + sqi(k) < 0.) THEN
+           !   !print*,' neg qi;',qsl,sqw2(k),sqi2(k),sqc2(k),qi(k),tk(k)
+              Dqi(k)=-sqi(k)/delt
+           ENDIF
          ENDDO
       ELSE
          DO k=kts,kte
@@ -4000,27 +3850,13 @@ ENDIF
       ENDDO
     ENDIF
 
-    !ensure non-negative moist species
-    CALL moisture_check(kte, delt, delp, exner,  &
-                        sqv2, sqc2, sqi2, thl,   &
-                        dqv, dqc, dqi, dth )
-
-    !=====================
-    ! OZONE TENDENCY CHECK
-    !=====================
-    DO k=kts,kte
-       IF(Dozone(k)*delt + ozone(k) < 0.) THEN
-         Dozone(k)=-ozone(k)*0.99/delt
-       ENDIF
-    ENDDO
-
     !===================
     ! THETA TENDENCY
     !===================
     IF (FLAG_QI) THEN
       DO k=kts,kte
-         Dth(k)=(thl(k) + xlvcp/exner(k)*sqc2(k) &
-           &            + xlscp/exner(k)*sqi2(k) &
+         Dth(k)=(thl(k) + xlvcp/exner(k)*sqc(k) &
+           &            + xlscp/exner(k)*sqi(k) &
            &            - th(k))/delt
          !Use form from Tripoli and Cotton (1981) with their
          !suggested min temperature to improve accuracy:
@@ -4030,7 +3866,7 @@ ENDIF
       ENDDO
     ELSE
       DO k=kts,kte
-         Dth(k)=(thl(k)+xlvcp/exner(k)*sqc2(k) - th(k))/delt
+         Dth(k)=(thl(k)+xlvcp/exner(k)*sqc(k) - th(k))/delt
          !Use form from Tripoli and Cotton (1981) with their
          !suggested min temperature to improve accuracy.
          !Dth(k)=(thl(k)*(1.+ xlvcp/MAX(tk(k),TKmin)*sqc(k))  &
@@ -4060,13 +3896,6 @@ ENDIF
        ENDDO
     ENDIF
 
-    !ensure non-negative moist species
-    !note: if called down here, dth needs to be updated, but
-    !      if called before the theta-tendency calculation, do not compute dth
-    !CALL moisture_check(kte, delt, delp, exner,     &
-    !                    sqv, sqc, sqi, thl,         &
-    !                    dqv, dqc, dqi, dth )
-
 #ifdef HARDCODE_VERTICAL
 # undef kts
 # undef kte
@@ -4075,197 +3904,54 @@ ENDIF
   END SUBROUTINE mynn_tendencies
 
 ! ==================================================================
-  SUBROUTINE moisture_check(kte, delt, dp, exner, &
-                            qv, qc, qi, th,       &
-                            dqv, dqc, dqi, dth )
-
-  ! This subroutine was adopted from the CAM-UW ShCu scheme and 
-  ! adapted for use here.
-  !
-  ! If qc < qcmin, qi < qimin, or qv < qvmin happens in any layer,
-  ! force them to be larger than minimum value by (1) condensating 
-  ! water vapor into liquid or ice, and (2) by transporting water vapor 
-  ! from the very lower layer.
-  ! 
-  ! We then update the final state variables and tendencies associated
-  ! with this correction. If any condensation happens, update theta too.
-  ! Note that (qv,qc,qi,th) are the final state variables after
-  ! applying corresponding input tendencies and corrective tendencies.
-
-    implicit none
-    integer,  intent(in)     :: kte
-    real, intent(in)         :: delt
-    real, dimension(kte), intent(in)     :: dp, exner
-    real, dimension(kte), intent(inout)  :: qv, qc, qi, th
-    real, dimension(kte), intent(inout)  :: dqv, dqc, dqi, dth
-    integer   k
-    real ::  dqc2, dqi2, dqv2, sum, aa, dum
-    real, parameter :: qvmin = 1e-20,   &
-                       qcmin = 0.0,     &
-                       qimin = 0.0
-
-    do k = kte, 1, -1  ! From the top to the surface
-       dqc2 = max(0.0, qcmin-qc(k)) !qc deficit (>=0)
-       dqi2 = max(0.0, qimin-qi(k)) !qi deficit (>=0)
-
-       !fix tendencies
-       dqc(k) = dqc(k) +  dqc2/delt
-       dqi(k) = dqi(k) +  dqi2/delt
-       dqv(k) = dqv(k) - (dqc2+dqi2)/delt
-       dth(k) = dth(k) + xlvcp/exner(k)*(dqc2/delt) + &
-                         xlscp/exner(k)*(dqi2/delt)
-       !update species
-       qc(k)  = qc(k)  +  dqc2
-       qi(k)  = qi(k)  +  dqi2
-       qv(k)  = qv(k)  -  dqc2 - dqi2
-       th(k)  = th(k)  +  xlvcp/exner(k)*dqc2 + &
-                          xlscp/exner(k)*dqi2
-
-       !then fix qv
-       dqv2   = max(0.0, qvmin-qv(k)) !qv deficit (>=0)
-       dqv(k) = dqv(k) + dqv2/delt
-       qv(k)  = qv(k)  + dqv2
-       if( k .ne. 1 ) then
-           qv(k-1)   = qv(k-1)  - dqv2*dp(k)/dp(k-1)
-           dqv(k-1)  = dqv(k-1) - dqv2*dp(k)/dp(k-1)/delt
-       endif
-       qv(k) = max(qv(k),qvmin)
-       qc(k) = max(qc(k),qcmin)
-       qi(k) = max(qi(k),qimin)
-    end do
-    ! Extra moisture used to satisfy 'qv(1)>=qvmin' is proportionally
-    ! extracted from all the layers that has 'qv > 2*qvmin'. This fully
-    ! preserves column moisture.
-    if( dqv2 .gt. 1.e-20 ) then
-        sum = 0.0
-        do k = 1, kte
-           if( qv(k) .gt. 2.0*qvmin ) sum = sum + qv(k)*dp(k)
-        enddo
-        aa = dqv2*dp(1)/max(1.e-20,sum)
-        if( aa .lt. 0.5 ) then
-            do k = 1, kte
-               if( qv(k) .gt. 2.0*qvmin ) then
-                   dum    = aa*qv(k)
-                   qv(k)  = qv(k) - dum
-                   dqv(k) = dqv(k) - dum/delt
-               endif
-            enddo
-        else
-        ! For testing purposes only (not yet found in any output):
-        !    write(*,*) 'Full moisture conservation is impossible'
-        endif
-    endif
-
-    return
-
-  END SUBROUTINE moisture_check
-
-! ==================================================================
 #if (WRF_CHEM == 1)
-  SUBROUTINE mynn_mix_chem(kts,kte,i,     &
-       grav_settling,                     &
-       delt,dz,pblh,                      &
+!>\ingroup gsd_mynn_edmf
+  SUBROUTINE mynn_mix_chem(kts,kte,      &
+       levflag,grav_settling,             &
+       delt,dz,                           &
        nchem, kdvel, ndvel, num_vert_mix, &
        chem1, vd1,                        &
        qnc,qni,                           &
        p,exner,                           &
-       thl,sqv,sqc,sqi,sqw,rho,           &
+       thl,sqv,sqc,sqi,sqw,               &
        ust,flt,flq,flqv,flqc,wspd,qcg,    &
+       uoce,voce,                         &
+       tsq,qsq,cov,                       &
        tcd,qcd,                           &
        dfm,dfh,dfq,                       &
        s_aw,                              &
        s_awchem,                          &
-       bl_mynn_cloudmix,                  &
-       emis_ant_no,                       &
-       frp_mean,                          &
-       enh_vermix                         )
+       bl_mynn_cloudmix)
 
 !-------------------------------------------------------------------
-    INTEGER, INTENT(in) :: kts,kte,i
-    INTEGER, INTENT(in) :: grav_settling
+    INTEGER, INTENT(in) :: kts,kte
+    INTEGER, INTENT(in) :: grav_settling,levflag
     INTEGER, INTENT(in) :: bl_mynn_cloudmix
 
     REAL, DIMENSION(kts:kte), INTENT(IN) :: qni,qnc,&
-         &p,exner,dfm,dfh,dfq,dz,tcd,qcd
-    REAL, DIMENSION(kts:kte), INTENT(INOUT) :: thl,sqw,sqv,sqc,sqi,rho
-    REAL, INTENT(IN) :: delt,ust,flt,flq,flqv,flqc,qcg
+         &p,exner,dfm,dfh,dfq,dz,tsq,qsq,cov,tcd,qcd
+    REAL, DIMENSION(kts:kte), INTENT(INOUT) :: thl,sqw,sqv,sqc,sqi
+    REAL, INTENT(IN) :: delt,ust,flt,flq,flqv,flqc,wspd,uoce,voce,qcg
     INTEGER, INTENT(IN   )   ::   nchem, kdvel, ndvel, num_vert_mix
     REAL, DIMENSION( kts:kte+1), INTENT(IN) :: s_aw
     REAL, DIMENSION( kts:kte, nchem ), INTENT(INOUT) :: chem1
     REAL, DIMENSION( kts:kte+1,nchem), INTENT(IN) :: s_awchem
-    REAL, DIMENSION( ndvel ), INTENT(IN) :: vd1
-    REAL, INTENT(IN) :: emis_ant_no,frp_mean,pblh
-    LOGICAL, INTENT(IN) :: enh_vermix
+    REAL, DIMENSION( ndvel ), INTENT(INOUT) :: vd1
+
 !local vars
 
-    REAL, DIMENSION(kts:kte) :: dtz
-    REAL, DIMENSION(1:kte-kts+1) :: a,b,c,d,x
+    REAL, DIMENSION(kts:kte) :: dtz,vt,vq
+    REAL, DIMENSION(1:kte-kts+1) :: a,b,c,d
     REAL :: rhs,gfluxm,gfluxp,dztop
-    REAL :: t,esl,qsl,dzk
-    REAL :: hght 
-    REAL :: khdz_old, khdz_back
+    REAL :: t,esl,qsl
     INTEGER :: k,kk
     INTEGER :: ic  ! Chemical array loop index
-    
-    INTEGER, SAVE :: icall
-
-    REAL, DIMENSION(kts:kte) :: rhoinv
-    REAL, DIMENSION(kts:kte+1) :: rhoz,khdz
-    REAL, PARAMETER :: no_threshold    = 0.1
-    REAL, PARAMETER :: frp_threshold   = 0.0
-    REAL, PARAMETER :: pblh_threshold  = 250.0
+    REAL, DIMENSION( kts:kte, nchem ) :: chem_new
 
     dztop=.5*(dz(kte)+dz(kte-1))
 
     DO k=kts,kte
        dtz(k)=delt/dz(k)
-    ENDDO
-
-    !Prepare "constants" for diffusion equation.
-    !khdz = rho*Kh/dz = rho*dfh
-    rhoz(kts)  =rho(kts)
-    rhoinv(kts)=1./rho(kts)
-    khdz(kts)  =rhoz(kts)*dfh(kts)
-! JLS
-    khdz_old  = khdz(kts)
-    khdz_back = pblh * 0.15 / dz(kts)
-    IF ( enh_vermix ) THEN
-    IF ( pblh < pblh_threshold ) THEN
-       IF ( emis_ant_no > no_threshold ) THEN
-          khdz(k) = MAX(khdz(k),khdz_back)
-       ENDIF
-       IF ( frp_mean > frp_threshold ) THEN
-          khdz(k) = MAX(khdz(k),khdz_back)
-       ENDIF
-    ENDIF
-    ENDIF
-    DO k=kts+1,kte
-       rhoz(k)  =(rho(k)*dz(k-1) + rho(k-1)*dz(k))/(dz(k-1)+dz(k))
-       rhoz(k)  =  MAX(rhoz(k),1E-4)
-       rhoinv(k)=1./MAX(rho(k),1E-4)
-       dzk      = 0.5  *( dz(k)+dz(k-1) )
-       khdz(k)  = rhoz(k)*dfh(k)
-    ENDDO
-    khdz(kte+1)=rhoz(kte+1)*dfh(kte)
-
-    !stability criteria for mf
-    DO k=kts+1,kte-1
-       khdz(k) = MAX(khdz(k),  0.5*s_aw(k))
-       khdz(k) = MAX(khdz(k), -0.5*(s_aw(k)-s_aw(k+1)))
-
-          khdz_old  = khdz(k)
-          khdz_back = pblh * 0.15 / dz(k)
-       IF ( enh_vermix ) THEN
-       !Modify based on anthropogenic emissions of NO and FRP
-       IF ( pblh < pblh_threshold ) THEN
-          IF ( emis_ant_no > no_threshold ) THEN
-             khdz(k) = MAX(khdz(k),khdz_back)
-          ENDIF
-          IF ( frp_mean > frp_threshold ) THEN
-             khdz(k) = MAX(khdz(k),khdz_back)
-          ENDIF
-       ENDIF
-       ENDIF
     ENDDO
 
   !============================================
@@ -4275,19 +3961,17 @@ ENDIF
     DO ic = 1,nchem
        k=kts
 
-       a(k)=  -dtz(k)*khdz(k)*rhoinv(k)
-       b(k)=1.+dtz(k)*(khdz(k+1)+khdz(k))*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)
-       c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k)           - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)
-       d(k)=chem1(k,ic) & !dtz(k)*flt  !neglecting surface sources 
-            & + dtz(k) * -vd1(ic)*chem1(1,ic) &
-            & - dtz(k)*rhoinv(k)*s_awchem(k+1,ic)
+       a(1)=0.
+       b(1)=1.+dtz(k)*dfh(k+1)  - 0.5*dtz(k)*s_aw(k+1)
+       c(1)=-dtz(k)*dfh(k+1)    - 0.5*dtz(k)*s_aw(k+1)
+       d(1)=chem1(k,ic) + dtz(k) * -vd1(ic)*chem1(1,ic) - dtz(k)*s_awchem(k+1,ic)
 
        DO k=kts+1,kte-1
-          a(k)=  -dtz(k)*khdz(k)*rhoinv(k)     + 0.5*dtz(k)*rhoinv(k)*s_aw(k)
-          b(k)=1.+dtz(k)*(khdz(k)+khdz(k+1))*rhoinv(k) + &
-             &    0.5*dtz(k)*rhoinv(k)*(s_aw(k)-s_aw(k+1))
-          c(k)=  -dtz(k)*khdz(k+1)*rhoinv(k) - 0.5*dtz(k)*rhoinv(k)*s_aw(k+1)
-          d(k)=chem1(k,ic) + dtz(k)*rhoinv(k)*(s_awchem(k,ic)-s_awchem(k+1,ic))
+          a(k)=-dtz(k)*dfh(k)      + 0.5*dtz(k)*s_aw(k)
+          b(k)=1.+dtz(k)*(dfh(k)+dfh(k+1)) +  0.5*dtz(k)*(s_aw(k)-s_aw(k+1))
+          c(k)=-dtz(k)*dfh(k+1)    - 0.5*dtz(k)*s_aw(k+1)
+          ! d(kk)=chem1(k,ic) + qcd(k)*delt
+          d(k)=chem1(k,ic) + rhs*delt + dtz(k)*(s_awchem(k,ic)-s_awchem(k+1,ic))
        ENDDO
 
       ! prescribed value at top
@@ -4296,12 +3980,10 @@ ENDIF
        c(kte)=0.
        d(kte)=chem1(kte,ic)
 
-       !CALL tridiag(kte,a,b,c,d)
-       CALL tridiag3(kte,a,b,c,d,x)
+       CALL tridiag(kte,a,b,c,d)
 
        DO k=kts,kte
-          !chem_new(k,ic)=d(k)
-          chem1(k,ic)=x(k)
+          chem_new(k,ic)=d(k-kts+1)
        ENDDO
     ENDDO
 
@@ -4461,7 +4143,7 @@ ENDIF
        &grav_settling,                  &
        &delt,dz,dx,znt,                 &
        &u,v,w,th,sqv3D,sqc3D,sqi3D,     &
-       &qnc,qni,                        &
+       &sqs3D,qnc,qni,                  &
        &qnwfa,qnifa,ozone,              &
        &p,exner,rho,T3D,                &
        &xland,ts,qsfc,qcg,ps,           &
@@ -4473,9 +4155,6 @@ ENDIF
 #if (WRF_CHEM == 1)
        chem3d, vd3d, nchem,             & ! WA 7/29/15 For WRF-Chem
        kdvel, ndvel, num_vert_mix,      &
-       FRP_MEAN,EMIS_ANT_NO,            & ! JLS/RAR to adjust exchange coeffs
-       mynn_chem_vertmx,                & ! JLS/RAR
-       enh_vermix,                      & ! JLS/RAR
 #endif
        &Tsq,Qsq,Cov,                    &
        &RUBLTEN,RVBLTEN,RTHBLTEN,       &
@@ -4491,12 +4170,11 @@ ENDIF
        &bl_mynn_cloudpdf,Sh3D,          &
        &bl_mynn_mixlength,              &
        &icloud_bl,qc_bl,qi_bl,cldfra_bl,&
-       &bl_mynn_edmf,                   &
+       &levflag,bl_mynn_edmf,           &
        &bl_mynn_edmf_mom,bl_mynn_edmf_tke, &
        &bl_mynn_mixscalars,             &
        &bl_mynn_output,                 &
        &bl_mynn_cloudmix,bl_mynn_mixqt, &
-       &closure,                        &
        &edmf_a,edmf_w,edmf_qt,          &
        &edmf_thl,edmf_ent,edmf_qc,      &
        &sub_thl3D,sub_sqv3D,            &
@@ -4504,7 +4182,7 @@ ENDIF
        &nupdraft,maxMF,ktop_plume,      &
        &spp_pbl,pattern_spp_pbl,        &
        &RTHRATEN,                       &
-       &FLAG_QC,FLAG_QI,FLAG_QNC,       &
+       &FLAG_QC,FLAG_QI,FLAG_QS,FLAG_QNC, &
        &FLAG_QNI,FLAG_QNWFA,FLAG_QNIFA  &
        &,IDS,IDE,JDS,JDE,KDS,KDE        &
        &,IMS,IME,JMS,JME,KMS,KME        &
@@ -4514,7 +4192,8 @@ ENDIF
 
     INTEGER, INTENT(in) :: initflag
     !INPUT NAMELIST OPTIONS:
-    LOGICAL, INTENT(IN) :: restart,cycling
+    LOGICAL, INTENT(in) :: restart,cycling
+    INTEGER, INTENT(in) :: levflag
     INTEGER, INTENT(in) :: grav_settling
     INTEGER, INTENT(in) :: bl_mynn_tkebudget
     INTEGER, INTENT(in) :: bl_mynn_cloudpdf
@@ -4528,14 +4207,10 @@ ENDIF
     INTEGER, INTENT(in) :: bl_mynn_cloudmix
     INTEGER, INTENT(in) :: bl_mynn_mixqt
     INTEGER, INTENT(in) :: icloud_bl
-    REAL,    INTENT(in) :: closure
 
-    LOGICAL, INTENT(in) :: FLAG_QI,FLAG_QNI,FLAG_QC,FLAG_QNC,&
+    LOGICAL, INTENT(in) :: FLAG_QI,FLAG_QS,FLAG_QNI,FLAG_QC,FLAG_QNC,&
                            FLAG_QNWFA,FLAG_QNIFA
-#if (WRF_CHEM == 1)
-    LOGICAL, INTENT(IN) :: mynn_chem_vertmx,enh_vermix
-#endif
-
+    
     INTEGER,INTENT(in) :: &
          & IDS,IDE,JDS,JDE,KDS,KDE &
          &,IMS,IME,JMS,JME,KMS,KME &
@@ -4548,9 +4223,8 @@ ENDIF
 
 ! initflag > 0  for TRUE
 ! else        for FALSE
-!       closure       : <= 2.5;  Level 2.5
-!                  2.5< and <3;  Level 2.6
-!                        =   3;  Level 3
+!       levflag         : <>3;  Level 2.5
+!                         = 3;  Level 3
 ! grav_settling = 1 when gravitational settling accounted for
 ! grav_settling = 0 when gravitational settling NOT accounted for
     
@@ -4559,30 +4233,31 @@ ENDIF
 !    REAL, INTENT(in) :: dx
 !END WRF
 !FV3
-    REAL, DIMENSION(IMS:IME), INTENT(in) :: dx
+    REAL, DIMENSION(IMS:IME,JMS:JME), INTENT(in) :: dx
 !END FV3
-    REAL, DIMENSION(IMS:IME,KMS:KME), INTENT(in) :: dz,&
+    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(in) :: dz,&
          &u,v,w,th,sqv3D,p,exner,rho,T3D
-    REAL, DIMENSION(IMS:IME,KMS:KME), OPTIONAL, INTENT(in)::&
-         &sqc3D,sqi3D,qni,qnc,qnwfa,qnifa
+    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), OPTIONAL, INTENT(in)::&
+         &sqc3D,sqi3D,sqs3D,qni,qnc,qnwfa,qnifa
     REAL, DIMENSION(IMS:IME,KMS:KME), OPTIONAL, INTENT(in):: ozone
-    REAL, DIMENSION(IMS:IME), INTENT(in) :: xland,ust,&
-         &ch,ts,qsfc,qcg,ps,hfx,qfx,wspd,uoce,voce,vdfg,znt
+    REAL, DIMENSION(IMS:IME,JMS:JME), INTENT(in) :: xland,ust,&
+         &ch,rmol,ts,qsfc,qcg,ps,hfx,qfx,wspd,uoce,voce,vdfg,znt
 
-    REAL, DIMENSION(IMS:IME,KMS:KME), INTENT(inout) :: &
+    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(inout) :: &
          &Qke,Tsq,Qsq,Cov, &
          !&tke_pbl, & !JOE-added for coupling (TKE_PBL = QKE/2)
-         &qke_adv     !ACF for QKE advection
+         &qke_adv    !ACF for QKE advection
 
-    REAL, DIMENSION(IMS:IME,KMS:KME), INTENT(inout) :: &
+    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(inout) :: &
          &RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,RQCBLTEN,&
          &RQIBLTEN,RQNIBLTEN,RQNCBLTEN, &
          &RQNWFABLTEN,RQNIFABLTEN
     REAL, DIMENSION(IMS:IME,KMS:KME), INTENT(inout) :: DOZONE
 
-    REAL, DIMENSION(IMS:IME,KMS:KME), INTENT(in) :: RTHRATEN
+    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(in) :: &
+         &RTHRATEN
 
-    REAL, DIMENSION(IMS:IME,KMS:KME), INTENT(out) :: &
+    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(out) :: &
          &exch_h,exch_m
 
    !These 10 arrays are only allocated when bl_mynn_output > 0
@@ -4590,31 +4265,30 @@ ENDIF
          & edmf_a,edmf_w,edmf_qt,edmf_thl,edmf_ent,edmf_qc, &
          & sub_thl3D,sub_sqv3D,det_thl3D,det_sqv3D
 
-!   REAL, DIMENSION(IMS:IME,KMS:KME)   :: &
-!         & edmf_a_dd,edmf_w_dd,edmf_qt_dd,edmf_thl_dd,edmf_ent_dd,edmf_qc_dd
+    REAL, DIMENSION(IMS:IME,JMS:JME), INTENT(inout) :: &
+         &Pblh,wstar,delta  !JOE-added for GRIMS
 
-    REAL, DIMENSION(IMS:IME), INTENT(inout) :: Pblh,wstar,delta,rmol
+    REAL, DIMENSION(IMS:IME,JMS:JME) :: &
+         &Psig_bl,Psig_shcu
 
-    REAL, DIMENSION(IMS:IME) :: Psig_bl,Psig_shcu
-
-    INTEGER,DIMENSION(IMS:IME),INTENT(INOUT) :: & 
+    INTEGER,DIMENSION(IMS:IME,JMS:JME),INTENT(INOUT) :: & 
          &KPBL,nupdraft,ktop_plume
 
-    REAL, DIMENSION(IMS:IME), INTENT(OUT) :: &
+    REAL, DIMENSION(IMS:IME,JMS:JME), INTENT(OUT) :: &
          &maxmf
 
-    REAL, DIMENSION(IMS:IME,KMS:KME), INTENT(inout) :: &
+    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(inout) :: &
          &el_pbl
 
-    REAL, DIMENSION(IMS:IME,KMS:KME), INTENT(out) :: &
+    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(out) :: &
          &qWT,qSHEAR,qBUOY,qDISS,dqke
     ! 3D budget arrays are not allocated when bl_mynn_tkebudget == 0.
     ! 1D (local) budget arrays are used for passing between subroutines.
     REAL, DIMENSION(KTS:KTE) :: qWT1,qSHEAR1,qBUOY1,qDISS1,dqke1,diss_heat
 
-    REAL, DIMENSION(IMS:IME,KMS:KME) :: Sh3D
+    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME) :: Sh3D
 
-    REAL, DIMENSION(IMS:IME,KMS:KME), INTENT(inout) :: &
+    REAL, DIMENSION(IMS:IME,KMS:KME,JMS:JME), INTENT(inout) :: &
          &qc_bl,qi_bl,cldfra_bl
     REAL, DIMENSION(KTS:KTE) :: qc_bl1D,qi_bl1D,cldfra_bl1D,&
                          qc_bl1D_old,qi_bl1D_old,cldfra_bl1D_old
@@ -4622,10 +4296,8 @@ ENDIF
 ! WA 7/29/15 Mix chemical arrays
 #if (WRF_CHEM == 1)
     INTEGER, INTENT(IN   ) ::   nchem, kdvel, ndvel, num_vert_mix
-    REAL,    DIMENSION( ims:ime, kms:kme, nchem ), INTENT(INOUT), OPTIONAL :: chem3d
-    REAL,    DIMENSION( ims:ime, kdvel, ndvel ), INTENT(IN), OPTIONAL :: vd3d
-    REAL,    DIMENSION(ims:ime), INTENT(IN), OPTIONAL ::FRP_MEAN,EMIS_ANT_NO
-    
+    REAL,    DIMENSION( ims:ime, kms:kme, jms:jme, nchem ), INTENT(INOUT), OPTIONAL :: chem3d
+    REAL,    DIMENSION( ims:ime, kdvel, jms:jme, ndvel ), INTENT(IN), OPTIONAL :: vd3d
     REAL,    DIMENSION( kts:kte, nchem ) :: chem1
     REAL,    DIMENSION( kts:kte+1, nchem ) :: s_awchem1
     REAL,    DIMENSION( ndvel ) :: vd1
@@ -4637,45 +4309,53 @@ ENDIF
     INTEGER :: i,j,k
     REAL, DIMENSION(KTS:KTE) :: thl,thvl,tl,qv1,qc1,qi1,sqw,&
          &El, Dfm, Dfh, Dfq, Tcd, Qcd, Pdk, Pdt, Pdq, Pdc, &
-         &Vt, Vq, sgm, thlsg, sqwsg
-    REAL, DIMENSION(KTS:KTE) :: thetav,sh,sm,u1,v1,w1,p1,ex1,dz1,th1,tk1,rho1,&
-           & qke1,tsq1,qsq1,cov1,sqv,sqi,sqc,du1,dv1,dth1,dqv1,dqc1,dqi1,ozone1, &
+         &Vt, Vq, sgm, thlsg
+
+    REAL, DIMENSION(KTS:KTE) :: thetav,sh,u1,v1,w1,p1,ex1,dz1,th1,tk1,rho1,&
+           & qke1,tsq1,qsq1,cov1,sqv,sqi,sqs,sqc,du1,dv1,dth1,dqv1,dqc1,dqi1,ozone1, &
            & k_m1,k_h1,qni1,dqni1,qnc1,dqnc1,qnwfa1,qnifa1,dqnwfa1,dqnifa1,dozone1
 
 !JOE: mass-flux variables
     REAL, DIMENSION(KTS:KTE) :: dth1mf,dqv1mf,dqc1mf,du1mf,dv1mf
     REAL, DIMENSION(KTS:KTE) :: edmf_a1,edmf_w1,edmf_qt1,edmf_thl1,&
                                 edmf_ent1,edmf_qc1
-    REAL, DIMENSION(KTS:KTE) :: edmf_a_dd1,edmf_w_dd1,edmf_qt_dd1,edmf_thl_dd1,&
-                                edmf_ent_dd1,edmf_qc_dd1
     REAL, DIMENSION(KTS:KTE) :: sub_thl,sub_sqv,sub_u,sub_v, &
                         det_thl,det_sqv,det_sqc,det_u,det_v
     REAL,DIMENSION(KTS:KTE+1) :: s_aw1,s_awthl1,s_awqt1,&
                   s_awqv1,s_awqc1,s_awu1,s_awv1,s_awqke1,&
                   s_awqnc1,s_awqni1,s_awqnwfa1,s_awqnifa1
-    REAL,DIMENSION(KTS:KTE+1) :: sd_aw1,sd_awthl1,sd_awqt1,&
-                  sd_awqv1,sd_awqc1,sd_awu1,sd_awv1,sd_awqke1
 
     REAL, DIMENSION(KTS:KTE+1) :: zw
-    REAL :: cpm,sqcg,flt,fltv,flq,flqv,flqc,pmz,phh,exnerg,zet,phi_m,&
-          & afk,abk,ts_decay, qc_bl2, qi_bl2,                        &
+    REAL :: cpm,sqcg,flt,flq,flqv,flqc,pmz,phh,exnerg,zet,&
+          & afk,abk,ts_decay, qc_bl2, qi_bl2,             &
           & th_sfc,ztop_plume,sqc9,sqi9
 
+!JOE-add GRIMS parameters & variables
+   real,parameter    ::  d1 = 0.02, d2 = 0.05, d3 = 0.001
+   real,parameter    ::  h1 = 0.33333335, h2 = 0.6666667
+   REAL :: govrth, sflux, bfx0, wstar3, wm2, wm3, delb
+!JOE-end GRIMS
 !JOE-top-down diffusion
-   REAL, DIMENSION(ITS:ITE) :: maxKHtopdown
-   REAL,DIMENSION(KTS:KTE) :: KHtopdown,TKEprodTD
+   REAL, DIMENSION(ITS:ITE,JTS:JTE) :: maxKHtopdown
+   REAL,DIMENSION(KTS:KTE) :: KHtopdown,zfac,wscalek2,&
+                             zfacent,TKEprodTD
+   REAL :: bfxpbl,dthvx,tmp1,temps,templ,zl1,wstar3_2
+   real :: ent_eff,radsum,radflux,we,rcldb,rvls,&
+           minrad,zminrad
+   real, parameter :: pfac =2.0, zfmin = 0.01, phifac=8.0
+   integer :: kk,kminrad
+   logical :: cloudflg
 !JOE-end top down
+
+!for WRF    INTEGER, SAVE :: levflag
 
     LOGICAL :: INITIALIZE_QKE
 
 ! Stochastic fields 
-     INTEGER,  INTENT(IN)                                     ::spp_pbl
-     REAL, DIMENSION( ims:ime, kms:kme), INTENT(IN),OPTIONAL  ::pattern_spp_pbl
+     INTEGER,  INTENT(IN)                                               ::spp_pbl
+     REAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN),OPTIONAL  ::pattern_spp_pbl
      REAL, DIMENSION(KTS:KTE)                         ::    rstoch_col
 
-! Substepping TKE
-     INTEGER :: nsub
-     real    :: delt2
 
     IF ( debug_code ) THEN
        print*,'in MYNN driver; at beginning'
@@ -4695,29 +4375,30 @@ ENDIF
     ITF=ITE
     KTF=KTE
 
-    IF (bl_mynn_output > 0) THEN !research mode
-       edmf_a(its:ite,kts:kte)=0.
-       edmf_w(its:ite,kts:kte)=0.
-       edmf_qt(its:ite,kts:kte)=0.
-       edmf_thl(its:ite,kts:kte)=0.
-       edmf_ent(its:ite,kts:kte)=0.
-       edmf_qc(its:ite,kts:kte)=0.
-       sub_thl3D(its:ite,kts:kte)=0.
-       sub_sqv3D(its:ite,kts:kte)=0.
-       det_thl3D(its:ite,kts:kte)=0.
-       det_sqv3D(its:ite,kts:kte)=0.
+!WRF
+!    levflag=mynn_level
 
-       !edmf_a_dd(its:ite,kts:kte)=0.
-       !edmf_w_dd(its:ite,kts:kte)=0.
-       !edmf_qt_dd(its:ite,kts:kte)=0.
-       !edmf_thl_dd(its:ite,kts:kte)=0.
-       !edmf_ent_dd(its:ite,kts:kte)=0.
-       !edmf_qc_dd(its:ite,kts:kte)=0.
+    IF (bl_mynn_edmf > 0) THEN
+      ! setup random seed
+      !call init_random_seed
+
+      IF (bl_mynn_output > 0) THEN !research mode
+         edmf_a(its:ite,kts:kte)=0.
+         edmf_w(its:ite,kts:kte)=0.
+         edmf_qt(its:ite,kts:kte)=0.
+         edmf_thl(its:ite,kts:kte)=0.
+         edmf_ent(its:ite,kts:kte)=0.
+         edmf_qc(its:ite,kts:kte)=0.
+         sub_thl3D(its:ite,kts:kte)=0.
+         sub_sqv3D(its:ite,kts:kte)=0.
+         det_thl3D(its:ite,kts:kte)=0.
+         det_sqv3D(its:ite,kts:kte)=0.
+      ENDIF
+      ktop_plume(its:ite,jts:jte)=0   !int
+      nupdraft(its:ite,jts:jte)=0     !int
+      maxmf(its:ite,jts:jte)=0.
     ENDIF
-    ktop_plume(its:ite)=0   !int
-    nupdraft(its:ite)=0     !int
-    maxmf(its:ite)=0.
-    maxKHtopdown(its:ite)=0.
+    maxKHtopdown(its:ite,jts:jte)=0.
 
     ! DH* CHECK HOW MUCH OF THIS INIT IF-BLOCK IS ACTUALLY NEEDED FOR RESTARTS
 !> - Within the MYNN-EDMF, there is a dependecy check for the first time step,
@@ -4728,7 +4409,7 @@ ENDIF
 
        !Test to see if we want to initialize qke
        IF ( (restart .or. cycling)) THEN
-          IF (MAXVAL(QKE(its:ite,kts)) < 0.0002) THEN
+          IF (MAXVAL(QKE(its:ite,kts,jts:jte)) < 0.0002) THEN
              INITIALIZE_QKE = .TRUE.
              !print*,"QKE is too small, must initialize"
           ELSE
@@ -4741,14 +4422,14 @@ ENDIF
        ENDIF
  
        if (.not.restart .or. .not.cycling) THEN
-         Sh3D(its:ite,kts:kte)=0.
-         el_pbl(its:ite,kts:kte)=0.
-         tsq(its:ite,kts:kte)=0.
-         qsq(its:ite,kts:kte)=0.
-         cov(its:ite,kts:kte)=0.
-         cldfra_bl(its:ite,kts:kte)=0.
-         qc_bl(its:ite,kts:kte)=0.
-         qke(its:ite,kts:kte)=0.
+         Sh3D(its:ite,kts:kte,jts:jte)=0.
+         el_pbl(its:ite,kts:kte,jts:jte)=0.
+         tsq(its:ite,kts:kte,jts:jte)=0.
+         qsq(its:ite,kts:kte,jts:jte)=0.
+         cov(its:ite,kts:kte,jts:jte)=0.
+         cldfra_bl(its:ite,kts:kte,jts:jte)=0.
+         qc_bl(its:ite,kts:kte,jts:jte)=0.
+         qke(its:ite,kts:kte,jts:jte)=0.
        else
          qc_bl1D(kts:kte)=0.0
          qi_bl1D(kts:kte)=0.0
@@ -4766,58 +4447,59 @@ ENDIF
        edmf_a1(kts:kte)=0.0
        edmf_w1(kts:kte)=0.0
        edmf_qc1(kts:kte)=0.0
-       edmf_a_dd1(kts:kte)=0.0
-       edmf_w_dd1(kts:kte)=0.0
-       edmf_qc_dd1(kts:kte)=0.0
        sgm(kts:kte)=0.0
        vt(kts:kte)=0.0
        vq(kts:kte)=0.0
 
-       DO k=KTS,KTE
-          DO i=ITS,ITF
-             exch_m(i,k)=0.
-             exch_h(i,k)=0.
-          ENDDO
+       DO j=JTS,JTF
+          DO k=KTS,KTE
+             DO i=ITS,ITF
+                exch_m(i,k,j)=0.
+                exch_h(i,k,j)=0.
+            ENDDO
+         ENDDO
        ENDDO
 
        IF ( bl_mynn_tkebudget == 1) THEN
-          DO k=KTS,KTE
-             DO i=ITS,ITF
-                qWT(i,k)=0.
-                qSHEAR(i,k)=0.
-                qBUOY(i,k)=0.
-                qDISS(i,k)=0.
-                dqke(i,k)=0.
-             ENDDO
-          ENDDO
+         DO j=JTS,JTF
+            DO k=KTS,KTE
+               DO i=ITS,ITF
+                  qWT(i,k,j)=0.
+                  qSHEAR(i,k,j)=0.
+                  qBUOY(i,k,j)=0.
+                  qDISS(i,k,j)=0.
+                  dqke(i,k,j)=0.
+               ENDDO
+            ENDDO
+         ENDDO
        ENDIF
 
-       DO i=ITS,ITF
-          DO k=KTS,KTE !KTF
-                dz1(k)=dz(i,k)
-                u1(k) = u(i,k)
-                v1(k) = v(i,k)
-                w1(k) = w(i,k)
-                th1(k)=th(i,k)
-                tk1(k)=T3D(i,k)
-                ex1(k)=exner(i,k)
-                rho1(k)=rho(i,k)
-                sqc(k)=sqc3D(i,k) !/(1.+qv(i,k))
-                sqv(k)=sqv3D(i,k) !/(1.+qv(i,k))
-                thetav(k)=th(i,k)*(1.+0.608*sqv(k))
+       DO j=JTS,JTF
+          DO i=ITS,ITF
+             DO k=KTS,KTE !KTF
+                dz1(k)=dz(i,k,j)
+                u1(k) = u(i,k,j)
+                v1(k) = v(i,k,j)
+                w1(k) = w(i,k,j)
+                th1(k)=th(i,k,j)
+                tk1(k)=T3D(i,k,j)
+                rho1(k)=rho(i,k,j)
+                sqc(k)=sqc3D(i,k,j) !/(1.+qv(i,k,j))
+                sqv(k)=sqv3D(i,k,j) !/(1.+qv(i,k,j))
+                thetav(k)=th(i,k,j)*(1.+0.61*sqv(k))
                 IF (icloud_bl > 0) THEN
-                   CLDFRA_BL1D(k)=CLDFRA_BL(i,k)
-                   QC_BL1D(k)=QC_BL(i,k)
-                   QI_BL1D(k)=QI_BL(i,k)
+                   CLDFRA_BL1D(k)=CLDFRA_BL(i,k,j)
+                   QC_BL1D(k)=QC_BL(i,k,j)
+                   QI_BL1D(k)=QI_BL(i,k,j)
                 ENDIF
                 IF (PRESENT(sqi3D) .AND. FLAG_QI ) THEN
-                   sqi(k)=sqi3D(i,k) !/(1.+qv(i,k))
+                   sqi(k)=sqi3D(i,k,j) !/(1.+qv(i,k,j))
                    sqw(k)=sqv(k)+sqc(k)+sqi(k)
-                   thl(k)=th1(k) - xlvcp/ex1(k)*sqc(k) &
-                       &         - xlscp/ex1(k)*sqi(k)
+                   thl(k)=th(i,k,j)- xlvcp/exner(i,k,j)*sqc(k) &
+                       &           - xlscp/exner(i,k,j)*sqi(k)
                    !Use form from Tripoli and Cotton (1981) with their
                    !suggested min temperature to improve accuracy.
-                   !thl(k)=th(i,k)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k) &
+                   !thl(k)=th(i,k,j)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k) &
                    !    &               - xlscp/MAX(tk1(k),TKmin)*sqi(k))
                    !COMPUTE THL USING SGS CLOUDS FOR PBLH DIAG
                    IF(sqc(k)<1e-6 .and. sqi(k)<1e-8 .and. CLDFRA_BL1D(k)>0.001)THEN
@@ -4827,16 +4509,15 @@ ENDIF
                       sqc9=sqc(k)
                       sqi9=sqi(k)
                    ENDIF
-                   thlsg(k)=th1(k) - xlvcp/ex1(k)*sqc9 &
-                         &         - xlscp/ex1(k)*sqi9
-                   sqwsg(k)=sqv(k)+sqc9+sqi9
+                   thlsg(k)=th(i,k,j)- xlvcp/exner(i,k,j)*sqc9 &
+                         &           - xlscp/exner(i,k,j)*sqi9
                 ELSE
                    sqi(k)=0.0
                    sqw(k)=sqv(k)+sqc(k)
-                   thl(k)=th1(k)-xlvcp/ex1(k)*sqc(k)
+                   thl(k)=th(i,k,j)-xlvcp/exner(i,k,j)*sqc(k)
                    !Use form from Tripoli and Cotton (1981) with their 
                    !suggested min temperature to improve accuracy.      
-                   !thl(k)=th(i,k)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k))
+                   !thl(k)=th(i,k,j)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k))
                    !COMPUTE THL USING SGS CLOUDS FOR PBLH DIAG
                    IF(sqc(k)<1e-6 .and. CLDFRA_BL1D(k)>0.001)THEN
 		      sqc9=QC_BL1D(k)*CLDFRA_BL1D(k)
@@ -4845,52 +4526,51 @@ ENDIF
                       sqc9=sqc(k)
                       sqi9=0.0
                    ENDIF
-                   thlsg(k)=th1(k) - xlvcp/ex1(k)*sqc9 &
-                         &         - xlscp/ex1(k)*sqi9
-                   sqwsg(k)=sqv(k)+sqc9+sqi9
+                   thlsg(k)=th(i,k,j)- xlvcp/exner(i,k,j)*sqc9 &
+                         &           - xlscp/exner(i,k,j)*sqi9
                 ENDIF
                 thvl(k)=thlsg(k)*(1.+0.61*sqv(k))
 
                 IF (k==kts) THEN
                    zw(k)=0.
                 ELSE
-                   zw(k)=zw(k-1)+dz(i,k-1)
+                   zw(k)=zw(k-1)+dz(i,k-1,j)
                 ENDIF
                 IF (INITIALIZE_QKE) THEN
                    !Initialize tke for initial PBLH calc only - using 
                    !simple PBLH form of Koracin and Berkowicz (1988, BLM)
                    !to linearly taper off tke towards top of PBL.
-                   qke1(k)=5.*ust(i) * MAX((ust(i)*700. - zw(k))/(MAX(ust(i),0.01)*700.), 0.01)
+                   qke1(k)=5.*ust(i,j) * MAX((ust(i,j)*700. - zw(k))/(MAX(ust(i,j),0.01)*700.), 0.01)
                 ELSE
-                   qke1(k)=qke(i,k)
+                   qke1(k)=qke(i,k,j)
                 ENDIF
-                el(k)=el_pbl(i,k)
-                sh(k)=Sh3D(i,k)
-                tsq1(k)=tsq(i,k)
-                qsq1(k)=qsq(i,k)
-                cov1(k)=cov(i,k)
+                el(k)=el_pbl(i,k,j)
+                sh(k)=Sh3D(i,k,j)
+                tsq1(k)=tsq(i,k,j)
+                qsq1(k)=qsq(i,k,j)
+                cov1(k)=cov(i,k,j)
                 if (spp_pbl==1) then
-                    rstoch_col(k)=pattern_spp_pbl(i,k)
+                    rstoch_col(k)=pattern_spp_pbl(i,k,j)
                 else
                     rstoch_col(k)=0.0
                 endif
 
              ENDDO
 
-             zw(kte+1)=zw(kte)+dz(i,kte)
+             zw(kte+1)=zw(kte)+dz(i,kte,j)
 
 !>  - Call get_pblh() to calculate hybrid (\f$\theta_{vli}-TKE\f$) PBL height.
-!             CALL GET_PBLH(KTS,KTE,PBLH(i),thetav,&
-             CALL GET_PBLH(KTS,KTE,PBLH(i),thvl,  &
-               &  Qke1,zw,dz1,xland(i),KPBL(i))
+!             CALL GET_PBLH(KTS,KTE,PBLH(i,j),thetav,&
+             CALL GET_PBLH(KTS,KTE,PBLH(i,j),thvl,&
+               &  Qke1,zw,dz1,xland(i,j),KPBL(i,j))
              
 !>  - Call scale_aware() to calculate similarity functions for scale-adaptive control
 !! (\f$P_{\sigma-PBL}\f$ and \f$P_{\sigma-shcu}\f$).
              IF (scaleaware > 0.) THEN
-                CALL SCALE_AWARE(dx(i),PBLH(i),Psig_bl(i),Psig_shcu(i))
+                CALL SCALE_AWARE(dx(i,j),PBLH(i,j),Psig_bl(i,j),Psig_shcu(i,j))
              ELSE
-                Psig_bl(i)=1.0
-                Psig_shcu(i)=1.0
+                Psig_bl(i,j)=1.0
+                Psig_shcu(i,j)=1.0
              ENDIF
 
              ! DH* CHECK IF WE CAN DO WITHOUT CALLING THIS ROUTINE FOR RESTARTS
@@ -4898,50 +4578,48 @@ ENDIF
 !! \f$q^{'2}\f$, and \f$\theta^{'}q^{'}\f$. These variables are calculated after 
 !! obtaining prerequisite variables by calling the following subroutines from 
 !! within mym_initialize(): mym_level2() and mym_length().
-             CALL mym_initialize (                & 
-                  &kts,kte,                       &
-                  &dz1, dx(i), zw,                &
-                  &u1, v1, thl, sqv,              &
-                  &thlsg, sqwsg,                  &
-                  &PBLH(i), th1, thetav, sh, sm,  &
-                  &ust(i), rmol(i),               &
-                  &el, Qke1, Tsq1, Qsq1, Cov1,    &
-                  &Psig_bl(i), cldfra_bl1D,       &
-                  &bl_mynn_mixlength,             &
+             CALL mym_initialize (             & 
+                  &kts,kte,                    &
+                  &dz1, dx(i,j), zw,           &
+                  &u1, v1, thl, sqv,           &
+                  &PBLH(i,j), th1, sh,         &
+                  &ust(i,j), rmol(i,j),        &
+                  &el, Qke1, Tsq1, Qsq1, Cov1, &
+                  &Psig_bl(i,j), cldfra_bl1D,  &
+                  &bl_mynn_mixlength,          &
                   &edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf,&
-                  &INITIALIZE_QKE,                &
+                  &INITIALIZE_QKE,             &
                   &spp_pbl,rstoch_col )
 
              IF (.not.restart) THEN
                 !UPDATE 3D VARIABLES
                 DO k=KTS,KTE !KTF
-                   el_pbl(i,k)=el(k)
-                   sh3d(i,k)=sh(k)
-                   qke(i,k)=qke1(k)
-                   tsq(i,k)=tsq1(k)
-                   qsq(i,k)=qsq1(k)
-                   cov(i,k)=cov1(k)
+                   el_pbl(i,k,j)=el(k)
+                   sh3d(i,k,j)=sh(k)
+                   qke(i,k,j)=qke1(k)
+                   tsq(i,k,j)=tsq1(k)
+                   qsq(i,k,j)=qsq1(k)
+                   cov(i,k,j)=cov1(k)
+                   !ACF,JOE- initialize qke_adv array if using advection
+                   IF (bl_mynn_tkeadvect) THEN
+                      qke_adv(i,k,j)=qke1(k)
+                   ENDIF
                 ENDDO
-                !initialize qke_adv array if using advection
-                IF (bl_mynn_tkeadvect) THEN
-                   DO k=KTS,KTE
-                      qke_adv(i,k)=qke1(k)
-                   ENDDO
-                ENDIF
              ENDIF
 
 !***  Begin debugging
 !             k=kdebug
 !             IF(I==IMD .AND. J==JMD)THEN
 !               PRINT*,"MYNN DRIVER INIT: k=",1," sh=",sh(k)
-!               PRINT*," sqw=",sqw(k)," thl=",thl(k)," k_m=",exch_m(i,k)
-!               PRINT*," xland=",xland(i)," rmol=",rmol(i)," ust=",ust(i)
-!               PRINT*," qke=",qke(i,k)," el=",el_pbl(i,k)," tsq=",Tsq(i,k)
-!               PRINT*," PBLH=",PBLH(i)," u=",u(i,k)," v=",v(i,k)
+!               PRINT*," sqw=",sqw(k)," thl=",thl(k)," k_m=",exch_m(i,k,j)
+!               PRINT*," xland=",xland(i,j)," rmol=",rmol(i,j)," ust=",ust(i,j)
+!               PRINT*," qke=",qke(i,k,j)," el=",el_pbl(i,k,j)," tsq=",Tsq(i,k,j)
+!               PRINT*," PBLH=",PBLH(i,j)," u=",u(i,k,j)," v=",v(i,k,j)
 !             ENDIF
 !***  End debugging
 
-       ENDDO !end i-loop
+          ENDDO
+       ENDDO
 
     ENDIF ! end initflag
 
@@ -4952,40 +4630,32 @@ ENDIF
        qke=qke_adv
     ENDIF
 
-    DO i=ITS,ITF
-       DO k=KTS,KTE !KTF
+    DO j=JTS,JTF
+       DO i=ITS,ITF
+          DO k=KTS,KTE !KTF
             !JOE-TKE BUDGET
              IF ( bl_mynn_tkebudget == 1) THEN
-                dqke(i,k)=qke(i,k)
+                dqke(i,k,j)=qke(i,k,j)
              END IF
              IF (icloud_bl > 0) THEN
-                CLDFRA_BL1D(k)=CLDFRA_BL(i,k)
-                QC_BL1D(k)=QC_BL(i,k)
-                QI_BL1D(k)=QI_BL(i,k)
-                cldfra_bl1D_old(k)=cldfra_bl(i,k)
-                qc_bl1D_old(k)=qc_bl(i,k)
-                qi_bl1D_old(k)=qi_bl(i,k)
-             else
-                CLDFRA_BL1D(k)=0.0
-                QC_BL1D(k)=0.0
-                QI_BL1D(k)=0.0
-                cldfra_bl1D_old(k)=0.0
-                qc_bl1D_old(k)=0.0
-                qi_bl1D_old(k)=0.0
+                CLDFRA_BL1D(k)=CLDFRA_BL(i,k,j)
+                QC_BL1D(k)=QC_BL(i,k,j)
+                QI_BL1D(k)=QI_BL(i,k,j)
+                cldfra_bl1D_old(k)=cldfra_bl(i,k,j)
+                qc_bl1D_old(k)=qc_bl(i,k,j)
+                qi_bl1D_old(k)=qi_bl(i,k,j)
              ENDIF
-             dz1(k)= dz(i,k)
-             u1(k) = u(i,k)
-             v1(k) = v(i,k)
-             w1(k) = w(i,k)
-             th1(k)= th(i,k)
-             tk1(k)=T3D(i,k)
-             p1(k) = p(i,k)
-             ex1(k)= exner(i,k)
-             rho1(k)=rho(i,k)
-             qv1(k)= sqv3D(i,k)/(1.-sqv3D(i,k))
-             qc1(k)= sqc3D(i,k)/(1.-sqv3D(i,k))
-             sqv(k)= sqv3D(i,k) !/(1.+qv(i,k))
-             sqc(k)= sqc3D(i,k) !/(1.+qv(i,k))
+             dz1(k)= dz(i,k,j)
+             u1(k) = u(i,k,j)
+             v1(k) = v(i,k,j)
+             w1(k) = w(i,k,j)
+             th1(k)= th(i,k,j)
+             tk1(k)=T3D(i,k,j)
+             rho1(k)=rho(i,k,j)
+             qv1(k)= sqv3D(i,k,j)/(1.-sqv3D(i,k,j))
+             qc1(k)= sqc3D(i,k,j)/(1.-sqv3D(i,k,j))
+             sqv(k)= sqv3D(i,k,j) !/(1.+qv(i,k,j))
+             sqc(k)= sqc3D(i,k,j) !/(1.+qv(i,k,j))
              dqc1(k)=0.0
              dqi1(k)=0.0
              dqni1(k)=0.0
@@ -4994,14 +4664,14 @@ ENDIF
              dqnifa1(k)=0.0
              dozone1(k)=0.0
              IF(PRESENT(sqi3D) .AND. FLAG_QI)THEN
-                qi1(k)= sqi3D(i,k)/(1.-sqv3D(i,k))
-                sqi(k)= sqi3D(i,k) !/(1.+qv(i,k))
+                qi1(k)= sqi3D(i,k,j)/(1.-sqv3D(i,k,j))
+                sqi(k)= sqi3D(i,k,j) !/(1.+qv(i,k,j))
                 sqw(k)= sqv(k)+sqc(k)+sqi(k)
-                thl(k)= th1(k) - xlvcp/ex1(k)*sqc(k) &
-                     &         - xlscp/ex1(k)*sqi(k)
+                thl(k)= th(i,k,j) - xlvcp/exner(i,k,j)*sqc(k) &
+                     &            - xlscp/exner(i,k,j)*sqi(k)
                 !Use form from Tripoli and Cotton (1981) with their
                 !suggested min temperature to improve accuracy.    
-                !thl(k)=th(i,k)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k) &
+                !thl(k)=th(i,k,j)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k) &
                 !    &               - xlscp/MAX(tk1(k),TKmin)*sqi(k))
                 !COMPUTE THL USING SGS CLOUDS FOR PBLH DIAG
                 IF(sqc(k)<1e-6 .and. sqi(k)<1e-8 .and. CLDFRA_BL1D(k)>0.001)THEN
@@ -5011,17 +4681,16 @@ ENDIF
                    sqc9=sqc(k)
                    sqi9=sqi(k)
                 ENDIF
-                thlsg(k)=th1(k) - xlvcp/ex1(k)*sqc9 &
-                      &         - xlscp/ex1(k)*sqi9
-                sqwsg(k)=sqv(k)+sqc9+sqi9
+                thlsg(k)=th(i,k,j)- xlvcp/exner(i,k,j)*sqc9 &
+                      &           - xlscp/exner(i,k,j)*sqi9
              ELSE
                 qi1(k)=0.0
                 sqi(k)=0.0
                 sqw(k)= sqv(k)+sqc(k)
-                thl(k)= th1(k)-xlvcp/ex1(k)*sqc(k)
+                thl(k)= th(i,k,j)-xlvcp/exner(i,k,j)*sqc(k)
                 !Use form from Tripoli and Cotton (1981) with their
                 !suggested min temperature to improve accuracy.    
-                !thl(k)=th(i,k)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k))
+                !thl(k)=th(i,k,j)*(1.- xlvcp/MAX(tk1(k),TKmin)*sqc(k))
                 !COMPUTE THL USING SGS CLOUDS FOR PBLH DIAG
                 IF(sqc(k)<1e-6 .and. CLDFRA_BL1D(k)>0.001)THEN
                    sqc9=QC_BL1D(k)*CLDFRA_BL1D(k)
@@ -5030,29 +4699,35 @@ ENDIF
                    sqc9=sqc(k)
                    sqi9=0.0
                 ENDIF
-                thlsg(k)=th1(k) - xlvcp/ex1(k)*sqc9 &
-                      &         - xlscp/ex1(k)*sqi9 
-            ENDIF
-            thetav(k)=th1(k)*(1.+0.608*sqv(k))
-            thvl(k)  =thlsg(k) *(1.+0.608*sqv(k))
+                thlsg(k)=th(i,k,j)- xlvcp/exner(i,k,j)*sqc9 &
+                      &           - xlscp/exner(i,k,j)*sqi9 
+             ENDIF
+             ! Need to add snow (G. Thompson)
+             IF(PRESENT(sqs3D) .AND. FLAG_QS)THEN
+                sqs(k)= sqs3D(i,k,j)
+             ELSE
+                sqs(k)=0.0
+             ENDIF
+            thetav(k)=th(i,k,j)*(1.+0.608*sqv(k))
+            thvl(k)=thlsg(k)*(1.+0.61*sqv(k))
 
              IF (PRESENT(qni) .AND. FLAG_QNI ) THEN
-                qni1(k)=qni(i,k)
+                qni1(k)=qni(i,k,j)
              ELSE
                 qni1(k)=0.0
              ENDIF
              IF (PRESENT(qnc) .AND. FLAG_QNC ) THEN
-                qnc1(k)=qnc(i,k)
+                qnc1(k)=qnc(i,k,j)
              ELSE
                 qnc1(k)=0.0
              ENDIF
              IF (PRESENT(qnwfa) .AND. FLAG_QNWFA ) THEN
-                qnwfa1(k)=qnwfa(i,k)
+                qnwfa1(k)=qnwfa(i,k,j)
              ELSE
                 qnwfa1(k)=0.0
              ENDIF
              IF (PRESENT(qnifa) .AND. FLAG_QNIFA ) THEN
-                qnifa1(k)=qnifa(i,k)
+                qnifa1(k)=qnifa(i,k,j)
              ELSE
                 qnifa1(k)=0.0
              ENDIF
@@ -5061,17 +4736,20 @@ ENDIF
              ELSE
                 ozone1(k)=0.0
              ENDIF
-             el(k) = el_pbl(i,k)
-             qke1(k)=qke(i,k)
-             sh(k) = sh3d(i,k)
-             tsq1(k)=tsq(i,k)
-             qsq1(k)=qsq(i,k)
-             cov1(k)=cov(i,k)
+             p1(k) = p(i,k,j)
+             ex1(k)= exner(i,k,j)
+             el(k) = el_pbl(i,k,j)
+             qke1(k)=qke(i,k,j)
+             sh(k) = sh3d(i,k,j)
+             tsq1(k)=tsq(i,k,j)
+             qsq1(k)=qsq(i,k,j)
+             cov1(k)=cov(i,k,j)
              if (spp_pbl==1) then
-                rstoch_col(k)=pattern_spp_pbl(i,k)
+                rstoch_col(k)=pattern_spp_pbl(i,k,j)
              else
                 rstoch_col(k)=0.0
              endif
+
 
              !edmf
              edmf_a1(k)=0.0
@@ -5089,18 +4767,6 @@ ENDIF
              s_awqni1(k)=0.
              s_awqnwfa1(k)=0.
              s_awqnifa1(k)=0.
-             ![EWDD]
-             edmf_a_dd1(k)=0.0
-             edmf_w_dd1(k)=0.0
-             edmf_qc_dd1(k)=0.0
-             sd_aw1(k)=0.
-             sd_awthl1(k)=0.
-             sd_awqt1(k)=0.
-             sd_awqv1(k)=0.
-             sd_awqc1(k)=0.
-             sd_awu1(k)=0.
-             sd_awv1(k)=0.
-             sd_awqke1(k)=0.
              sub_thl(k)=0.
              sub_sqv(k)=0.
              sub_u(k)=0.
@@ -5112,16 +4778,16 @@ ENDIF
              det_v(k)=0.
 
 #if (WRF_CHEM == 1)
-    IF ( mynn_chem_vertmx ) THEN
+    IF (bl_mynn_mixchem == 1) THEN
       IF (PRESENT(chem3d) .AND. PRESENT(vd3d)) THEN
              ! WA 7/29/15 Set up chemical arrays
              DO ic = 1,nchem
-                chem1(k,ic) = chem3d(i,k,ic)
+                chem1(k,ic) = chem3d(i,k,j,ic)
                 s_awchem1(k,ic)=0.
              ENDDO
              DO ic = 1,ndvel
                 IF (k == KTS) THEN
-                   vd1(ic) = vd3d(i,1,ic)
+                   vd1(ic) = vd3d(i,1,j,ic)
                 ENDIF
              ENDDO
       ELSE
@@ -5141,11 +4807,11 @@ ENDIF
              IF (k==kts) THEN
                 zw(k)=0.
              ELSE
-                zw(k)=zw(k-1)+dz(i,k-1)
+                zw(k)=zw(k-1)+dz(i,k-1,j)
              ENDIF
           ENDDO ! end k
 
-          zw(kte+1)=zw(kte)+dz(i,kte)
+          zw(kte+1)=zw(kte)+dz(i,kte,j)
           !EDMF
           s_aw1(kte+1)=0.
           s_awthl1(kte+1)=0.
@@ -5159,14 +4825,6 @@ ENDIF
           s_awqni1(kte+1)=0.
           s_awqnwfa1(kte+1)=0.
           s_awqnifa1(kte+1)=0.
-          sd_aw1(kte+1)=0.
-          sd_awthl1(kte+1)=0.
-          sd_awqt1(kte+1)=0.
-          sd_awqv1(kte+1)=0.
-          sd_awqc1(kte+1)=0.
-          sd_awu1(kte+1)=0.
-          sd_awv1(kte+1)=0.
-          sd_awqke1(kte+1)=0.
 #if (WRF_CHEM == 1)
           DO ic = 1,nchem
              s_awchem1(kte+1,ic)=0.
@@ -5175,102 +4833,183 @@ ENDIF
 
 !>  - Call get_pblh() to calculate the hybrid \f$\theta_{vli}-TKE\f$
 !! PBL height diagnostic.
-!          CALL GET_PBLH(KTS,KTE,PBLH(i),thetav,&
-          CALL GET_PBLH(KTS,KTE,PBLH(i),thvl,&
-          & Qke1,zw,dz1,xland(i),KPBL(i))
+!          CALL GET_PBLH(KTS,KTE,PBLH(i,j),thetav,&
+          CALL GET_PBLH(KTS,KTE,PBLH(i,j),thvl,&
+          & Qke1,zw,dz1,xland(i,j),KPBL(i,j))
 
 !>  - Call scale_aware() to calculate the similarity functions,
 !! \f$P_{\sigma-PBL}\f$ and \f$P_{\sigma-shcu}\f$, to control 
 !! the scale-adaptive behaviour for the local and nonlocal 
 !! components, respectively.
           IF (scaleaware > 0.) THEN
-             CALL SCALE_AWARE(dx(i),PBLH(i),Psig_bl(i),Psig_shcu(i))
+             CALL SCALE_AWARE(dx(i,j),PBLH(i,j),Psig_bl(i,j),Psig_shcu(i,j))
           ELSE
-             Psig_bl(i)=1.0
-             Psig_shcu(i)=1.0
+             Psig_bl(i,j)=1.0
+             Psig_shcu(i,j)=1.0
           ENDIF
 
-          sqcg= 0.0   !JOE, it was: qcg(i)/(1.+qcg(i))
+          sqcg= 0.0   !JOE, it was: qcg(i,j)/(1.+qcg(i,j))
           cpm=cp*(1.+0.84*qv1(kts))
-          exnerg=(ps(i)/p1000mb)**rcp
+          exnerg=(ps(i,j)/p1000mb)**rcp
 
           !-----------------------------------------------------
           !ORIGINAL CODE
-          !flt = hfx(i)/( rho(i,kts)*cpm ) &
-          ! +xlvcp*ch(i)*(sqc(kts)/exner(i,kts) -sqcg/exnerg)
-          !flq = qfx(i)/  rho(i,kts)       &
-          !    -ch(i)*(sqc(kts)   -sqcg )
+          !flt = hfx(i,j)/( rho(i,kts,j)*cpm ) &
+          ! +xlvcp*ch(i,j)*(sqc(kts)/exner(i,kts,j) -sqcg/exnerg)
+          !flq = qfx(i,j)/  rho(i,kts,j)       &
+          !    -ch(i,j)*(sqc(kts)   -sqcg )
           !-----------------------------------------------------
           ! Katata-added - The deposition velocity of cloud (fog)
           ! water is used instead of CH.
-          !flt = hfx(i)/( rho(i,kts)*cpm ) &
-          !  & +xlvcp*vdfg(i)*(sqc(kts)/exner(i,kts)- sqcg/exnerg)
-          !flq = qfx(i)/  rho(i,kts)       &
-          !  & -vdfg(i)*(sqc(kts) - sqcg )
-          !-----------------------------------------------------
-          flqv = qfx(i)/rho1(kts)
-          flqc = -vdfg(i)*(sqc(kts) - sqcg )
-          th_sfc = ts(i)/ex1(kts)
+          flt = hfx(i,j)/( rho(i,kts,j)*cpm ) &
+            & +xlvcp*vdfg(i,j)*(sqc(kts)/exner(i,kts,j)- sqcg/exnerg)
+          flq = qfx(i,j)/  rho(i,kts,j)       &
+            & -vdfg(i,j)*(sqc(kts) - sqcg )
+!JOE-test- should this be after the call to mym_condensation?-using old vt & vq
+!same as original form
+!         flt = flt + xlvcp*ch(i,j)*(sqc(kts)/exner(i,kts,j) -sqcg/exnerg)
+          flqv = qfx(i,j)/rho(i,kts,j)
+          flqc = -vdfg(i,j)*(sqc(kts) - sqcg )
+          th_sfc = ts(i,j)/ex1(kts)
 
-          ! TURBULENT FLUX FOR TKE BOUNDARY CONDITIONS
-          flq =flqv+flqc !! LATENT
-          flt =hfx(i)/(rho1(kts)*cpm )-xlvcp*flqc/ex1(kts)   !! Temperature flux
-          fltv=flt + flqv*ep_1*th_sfc                                   !! Virtual temperature flux
-
-          ! Update 1/L using updated sfc heat flux and friction velocity
-          rmol(i) = -vk*gtr*fltv/max(ust(i)**3,1.0e-6)
-          zet = 0.5*dz(i,kts)*rmol(i)
-          zet = MAX(zet, -20.)
-          zet = MIN(zet,  20.)
-          if (bl_mynn_stfunc == 0) then
-             !Original Kansas-type stability functions
-             if ( zet >= 0.0 ) then
-                pmz = 1.0 + (cphm_st-1.0) * zet
-                phh = 1.0 +  cphh_st      * zet
-             else
-                pmz = 1.0/    (1.0-cphm_unst*zet)**0.25 - zet
-                phh = 1.0/SQRT(1.0-cphh_unst*zet)
-             end if
+          zet = 0.5*dz(i,kts,j)*rmol(i,j)
+          if ( zet >= 0.0 ) then
+            pmz = 1.0 + (cphm_st-1.0) * zet
+            phh = 1.0 +  cphh_st      * zet
           else
-             !Updated stability functions (Puhales, 2020)
-             phi_m = phim(zet)
-             pmz   = phi_m - zet
-             phh   = phih(zet)
+            pmz = 1.0/    (1.0-cphm_unst*zet)**0.25 - zet
+            phh = 1.0/SQRT(1.0-cphh_unst*zet)
           end if
+
+          !-- Estimate wstar & delta for GRIMS shallow-cu-------
+          govrth = g/th1(kts)
+          sflux = hfx(i,j)/rho(i,kts,j)/cpm + &
+                  qfx(i,j)/rho(i,kts,j)*ep_1*th1(kts)
+          bfx0 = max(sflux,0.)
+          wstar3     = (govrth*bfx0*pblh(i,j))
+          wstar(i,j) = wstar3**h1
+          wm3        = wstar3 + 5.*ust(i,j)**3.
+          wm2        = wm3**h2
+          delb       = govrth*d3*pblh(i,j)
+          delta(i,j) = min(d1*pblh(i,j) + d2*wm2/delb, 100.)
+          !-- End GRIMS-----------------------------------------
 
 !>  - Call mym_condensation() to calculate the nonconvective component
 !! of the subgrid cloud fraction and mixing ratio as well as the functions
-!! used to calculate the buoyancy flux. Different cloud PDFs can be
+!! used to calculate the buoyancy flux. Different cloud PDFs can be 
 !! selected by use of the namelist parameter \p bl_mynn_cloudpdf.
 
           CALL  mym_condensation ( kts,kte,      &
-               &dx(i),dz1,zw,thl,sqw,sqv,sqc,sqi,&
-               &p1,ex1,tsq1,qsq1,cov1,           &
+               &dx(i,j),dz1,zw,thl,sqw,sqv,sqc,sqi,sqs,&
+               &p1,ex1,xland(i,j),tsq1,qsq1,cov1,&
                &Sh,el,bl_mynn_cloudpdf,          &
                &qc_bl1D,qi_bl1D,cldfra_bl1D,     &
-               &PBLH(i),HFX(i),                  &
-               &Vt, Vq, th1, sgm, rmol(i),       &
+               &PBLH(i,j),HFX(i,j),              &
+               &Vt, Vq, th1, sgm, rmol(i,j),     &
                &spp_pbl, rstoch_col              )
 
-!>  - Add TKE source driven by cloud top cooling
-!!  Calculate the buoyancy production of TKE from cloud-top cooling when
+          !ADD TKE source driven by cloud top cooling
+!>  - Calculate the buoyancy production of TKE from cloud-top cooling when
 !! \p bl_mynn_topdown =1.
           IF (bl_mynn_topdown.eq.1)then
-             CALL topdown_cloudrad(kts,kte,dz1,zw,          &
-                &xland(i),kpbl(i),PBLH(i),                  &
-                &sqc,sqi,sqw,thl,th1,ex1,p1,rho1,thetav,    &
-                &cldfra_bl1D,rthraten,                      &
-                &maxKHtopdown(i),KHtopdown,TKEprodTD        )
+             cloudflg=.false.
+             minrad=100.
+             kminrad=kpbl(i,j)
+             zminrad=PBLH(i,j)
+             KHtopdown(kts:kte)=0.0
+             TKEprodTD(kts:kte)=0.0
+             maxKHtopdown(i,j)=0.0
+             !CHECK FOR STRATOCUMULUS-TOPPED BOUNDARY LAYERS
+             DO kk = MAX(1,kpbl(i,j)-2),kpbl(i,j)+3
+                if(sqc(kk).gt. 1.e-6 .OR. sqi(kk).gt. 1.e-6 .OR. &
+                   cldfra_bl1D(kk).gt.0.5) then
+                   cloudflg=.true.
+                endif
+                if(rthraten(i,kk,j) < minrad)then
+                   minrad=rthraten(i,kk,j)
+                   kminrad=kk
+                   zminrad=zw(kk) + 0.5*dz1(kk)
+                endif
+             ENDDO
+             IF (MAX(kminrad,kpbl(i,j)) < 2)cloudflg = .false.
+             IF (cloudflg) THEN
+                zl1 = dz1(kts)
+                k = MAX(kpbl(i,j)-1, kminrad-1)
+                !Best estimate of height of TKE source (top of downdrafts):
+                !zminrad = 0.5*pblh(i,j) + 0.5*zminrad
+
+                templ=thl(k)*ex1(k)
+                !rvls is ws at full level
+                rvls=100.*6.112*EXP(17.67*(templ-273.16)/(templ-29.65))*(ep_2/p1(k+1))
+                temps=templ + (sqw(k)-rvls)/(cp/xlv  +  ep_2*xlv*rvls/(rd*templ**2))
+                rvls=100.*6.112*EXP(17.67*(temps-273.15)/(temps-29.65))*(ep_2/p1(k+1))
+                rcldb=max(sqw(k)-rvls,0.)
+
+                !entrainment efficiency
+                dthvx     = (thl(k+2) + th1(k+2)*ep_1*sqw(k+2)) &
+                          - (thl(k)   + th1(k)  *ep_1*sqw(k))
+                dthvx     = max(dthvx,0.1)
+                tmp1      = xlvcp * rcldb/(ex1(k)*dthvx)
+                !Originally from Nichols and Turton (1986), where a2 = 60, but lowered
+                !here to 8, as in Grenier and Bretherton (2001).
+                ent_eff   = 0.2 + 0.2*8.*tmp1
+
+                radsum=0.
+                DO kk = MAX(1,kpbl(i,j)-3),kpbl(i,j)+3
+                   radflux=rthraten(i,kk,j)*ex1(kk)         !converts theta/s to temp/s
+                   radflux=radflux*cp/g*(p1(kk)-p1(kk+1)) ! converts temp/s to W/m^2
+                   if (radflux < 0.0 ) radsum=abs(radflux)+radsum
+                ENDDO
+
+                !More strict limits over land to reduce stable-layer mixouts
+                if ((xland(i,j)-1.5).GE.0)THEN ! WATER
+                   radsum=MIN(radsum,90.0)
+                   bfx0 = max(radsum/rho1(k)/cp,0.)
+                else                           ! LAND
+                   radsum=MIN(0.25*radsum,30.0)!practically turn off over land
+                   bfx0 = max(radsum/rho1(k)/cp - max(sflux,0.0),0.)
+                endif
+
+                !entrainment from PBL top thermals
+                wm3    = g/thetav(k)*bfx0*MIN(pblh(i,j),1500.) ! this is wstar3(i)
+                wm2    = wm2 + wm3**h2
+                bfxpbl = - ent_eff * bfx0
+                dthvx  = max(thetav(k+1)-thetav(k),0.1)
+                we     = max(bfxpbl/dthvx,-sqrt(wm3**h2))
+
+                DO kk = kts,kpbl(i,j)+3
+                   !Analytic vertical profile
+                   zfac(kk) = min(max((1.-(zw(kk+1)-zl1)/(zminrad-zl1)),zfmin),1.)
+                   zfacent(kk) = 10.*MAX((zminrad-zw(kk+1))/zminrad,0.0)*(1.-zfac(kk))**3
+
+                   !Calculate an eddy diffusivity profile (not used at the moment)
+                   wscalek2(kk) = (phifac*karman*wm3*(zfac(kk)))**h1
+                   !Modify shape of KH to be similar to Lock et al (2000): use pfac = 3.0
+                   KHtopdown(kk) = wscalek2(kk)*karman*(zminrad-zw(kk+1))*(1.-zfac(kk))**3 !pfac
+                   KHtopdown(kk) = MAX(KHtopdown(kk),0.0)
+                   !Do not include xkzm at kpbl-1 since it changes entrainment
+                   !if (kk.eq.kpbl(i,j)-1 .and. cloudflg .and. we.lt.0.0) then
+                   !   KHtopdown(kk) = 0.0
+                   !endif
+                   
+                   !Calculate TKE production = 2(g/TH)(w'TH'), where w'TH' = A(TH/g)wstar^3/PBLH,
+                   !A = ent_eff, and wstar is associated with the radiative cooling at top of PBL.
+                   !An analytic profile controls the magnitude of this TKE prod in the vertical. 
+                   TKEprodTD(kk)=2.*ent_eff*wm3/MAX(pblh(i,j),100.)*zfacent(kk)
+                   TKEprodTD(kk)= MAX(TKEprodTD(kk),0.0)
+                ENDDO
+             ENDIF !end cloud check
+             maxKHtopdown(i,j)=MAXVAL(KHtopdown(:))
           ELSE
-             maxKHtopdown(i)  = 0.0
+             maxKHtopdown(i,j)=0.0
              KHtopdown(kts:kte) = 0.0
-             TKEprodTD(kts:kte) = 0.0
-          ENDIF
+             TKEprodTD(kts:kte)=0.0
+          ENDIF !end top-down check
 
           IF (bl_mynn_edmf > 0) THEN
-            !PRINT*,"Calling DMP Mass-Flux: i= ",i
+            !PRINT*,"Calling DMP Mass-Flux: i= ",i," j=",j
             CALL DMP_mf(                          &
-               &kts,kte,delt,zw,dz1,p1,rho1,      &
+               &kts,kte,delt,zw,dz1,p1,           &
                &bl_mynn_edmf_mom,                 &
                &bl_mynn_edmf_tke,                 &
                &bl_mynn_mixscalars,               &
@@ -5278,11 +5017,11 @@ ENDIF
                &sqw,sqv,sqc,qke1,                 &
                &qnc1,qni1,qnwfa1,qnifa1,          &
                &ex1,Vt,Vq,sgm,                    &
-               &ust(i),flt,flq,flqv,flqc,         &
-               &PBLH(i),KPBL(i),DX(i),            &
-               &xland(i),th_sfc,                  &
+               &ust(i,j),flt,flq,flqv,flqc,       &
+               &PBLH(i,j),KPBL(i,j),DX(i,j),      &
+               &xland(i,j),th_sfc,                &
             ! now outputs - tendencies
-            ! &,dth1mf,dqv1mf,dqc1mf,du1mf,dv1mf  &
+            ! &,dth1mf,dqv1mf,dqc1mf,du1mf,dv1mf &
             ! outputs - updraft properties
                & edmf_a1,edmf_w1,edmf_qt1,        &
                & edmf_thl1,edmf_ent1,edmf_qc1,    &
@@ -5298,55 +5037,37 @@ ENDIF
                & det_u,det_v,                     &
 #if (WRF_CHEM == 1)
                & nchem,chem1,s_awchem1,           &
-               & mynn_chem_vertmx,                &
 #endif
                & qc_bl1D,cldfra_bl1D,             &
                & qc_bl1D_old,cldfra_bl1D_old,     &
                & FLAG_QC,FLAG_QI,                 &
                & FLAG_QNC,FLAG_QNI,               &
                & FLAG_QNWFA,FLAG_QNIFA,           &
-               & Psig_shcu(i),                    &
-               & nupdraft(i),ktop_plume(i),       &
-               & maxmf(i),ztop_plume,             &
-               & spp_pbl,rstoch_col               )
+               & Psig_shcu(i,j),                  &
+               & nupdraft(i,j),ktop_plume(i,j),   &
+               & maxmf(i,j),ztop_plume,           &
+               & spp_pbl,rstoch_col               &
+            )
+
           ENDIF
 
-          IF (bl_mynn_edmf_dd == 1) THEN
-            CALL DDMF_JPL(kts,kte,delt,zw,dz1,p1, &
-              &u1,v1,th1,thl,thetav,tk1,          &
-              sqw,sqv,sqc,rho1,ex1,               &
-              &ust(i),flt,flq,                    &
-              &PBLH(i),KPBL(i),                   &
-              &edmf_a_dd1,edmf_w_dd1,edmf_qt_dd1, &
-              &edmf_thl_dd1,edmf_ent_dd1,         &
-              &edmf_qc_dd1,                       &
-              &sd_aw1,sd_awthl1,sd_awqt1,         &
-              &sd_awqv1,sd_awqc1,sd_awu1,sd_awv1, &
-              &sd_awqke1,                         &
-              &qc_bl1d,cldfra_bl1d,               &
-              &rthraten(i,:)                      )
-          ENDIF
-
-          !Capability to substep the eddy-diffusivity portion
-          !do nsub = 1,2
-          delt2 = delt !*0.5    !only works if topdown=0
-
+!>  - Call mym_turbulence() to collect the necessary variable
+!! to carry out successive claculations.
           CALL mym_turbulence (                  & 
-               &kts,kte,closure,                 &
-               &dz1, DX(i), zw,                  &
-               &u1, v1, thl, thetav, sqc, sqw,   &
-               &thlsg, sqwsg,                    &
+               &kts,kte,levflag,                 &
+               &dz1, DX(i,j), zw,                &
+               &u1, v1, thl, sqc, sqw,           &
                &qke1, tsq1, qsq1, cov1,          &
                &vt, vq,                          &
-               &rmol(i), flt, flq,               &
-               &PBLH(i),th1,                     &
-               &Sh,Sm,el,                        &
+               &rmol(i,j), flt, flq,             &
+               &PBLH(i,j),th1,                   &
+               &Sh,el,                           &
                &Dfm,Dfh,Dfq,                     &
                &Tcd,Qcd,Pdk,                     &
                &Pdt,Pdq,Pdc,                     &
                &qWT1,qSHEAR1,qBUOY1,qDISS1,      &
                &bl_mynn_tkebudget,               &
-               &Psig_bl(i),Psig_shcu(i),         &
+               &Psig_bl(i,j),Psig_shcu(i,j),     &     
                &cldfra_bl1D,bl_mynn_mixlength,   &
                &edmf_w1,edmf_a1,edmf_qc1,bl_mynn_edmf,   &
                &TKEprodTD,                       &
@@ -5355,48 +5076,43 @@ ENDIF
 !>  - Call mym_predict() to solve TKE and 
 !! \f$\theta^{'2}, q^{'2}, and \theta^{'}q^{'}\f$
 !! for the following time step.
-          CALL mym_predict (kts,kte,closure,     &
-               &delt2, dz1,                      &
-               &ust(i), flt, flq, pmz, phh,      &
-               &el, dfq, rho1, pdk, pdt, pdq, pdc,&
+          CALL mym_predict (kts,kte,levflag,     &
+               &delt, dz1,                       &
+               &ust(i,j), flt, flq, pmz, phh,    &
+               &el, dfq, pdk, pdt, pdq, pdc,     &
                &Qke1, Tsq1, Qsq1, Cov1,          &
-               &s_aw1, s_awqke1, bl_mynn_edmf_tke,&
-               &qWT1, qDISS1,bl_mynn_tkebudget) !! TKE budget  (Puhales, 2020)
+               &s_aw1, s_awqke1, bl_mynn_edmf_tke)
 
           DO k=kts,kte-1
-             ! Set max dissipative heating rate to 7.2 K per hour
-             diss_heat(k) = MIN(MAX(0.75*(qke1(k)**1.5)/(b1*MAX(0.5*(el(k)+el(k+1)),1.))/cp, 0.0),0.002)
-             diss_heat(k) = diss_heat(k) * exp(-10000./MAX(p1(k),1.))
+             ! Set max dissipative heating rate close to 0.1 K per hour (=0.000027...)
+             diss_heat(k) = MIN(MAX(twothirds*(qke1(k)**1.5)/(b1*MAX(0.5*(el(k)+el(k+1)),1.))/cp, 0.0),0.00003)
           ENDDO
           diss_heat(kte) = 0.
 
 !>  - Call mynn_tendencies() to solve for tendencies of 
 !! \f$U, V, \theta, q_{v}, q_{c}, and q_{i}\f$.
           CALL mynn_tendencies(kts,kte,          &
-               &closure,grav_settling,           &
+               &levflag,grav_settling,           &
                &delt, dz1, rho1,                 &
                &u1, v1, th1, tk1, qv1,           &
                &qc1, qi1, qnc1, qni1,            &
-               &ps(i), p1, ex1, thl,             &
-               &sqv, sqc, sqi, sqw,              &
+               &p1, ex1, thl, sqv, sqc, sqi, sqw,&
                &qnwfa1, qnifa1, ozone1,          &
-               &ust(i),flt,flq,flqv,flqc,        &
-               &wspd(i),qcg(i),                  &
-               &uoce(i),voce(i),                 &
+               &ust(i,j),flt,flq,flqv,flqc,      &
+               &wspd(i,j),qcg(i,j),              &
+               &uoce(i,j),voce(i,j),             &
                &tsq1, qsq1, cov1,                &
                &tcd, qcd,                        &
                &dfm, dfh, dfq,                   &
                &Du1, Dv1, Dth1, Dqv1,            &
                &Dqc1, Dqi1, Dqnc1, Dqni1,        &
                &Dqnwfa1, Dqnifa1, Dozone1,       &
-               &vdfg(i), diss_heat,              &
+               &vdfg(i,j), diss_heat,            &
                ! mass flux components
                &s_aw1,s_awthl1,s_awqt1,          &
                &s_awqv1,s_awqc1,s_awu1,s_awv1,   &
                &s_awqnc1,s_awqni1,               &
                &s_awqnwfa1,s_awqnifa1,           &
-               &sd_aw1,sd_awthl1,sd_awqt1,       &
-               &sd_awqv1,sd_awqc1,sd_awu1,sd_awv1,&
                &sub_thl,sub_sqv,                 &
                &sub_u,sub_v,                     &
                &det_thl,det_sqv,det_sqc,         &
@@ -5408,67 +5124,60 @@ ENDIF
                &bl_mynn_mixqt,                   &
                &bl_mynn_edmf,                    &
                &bl_mynn_edmf_mom,                &
-               &bl_mynn_mixscalars               )
+               &bl_mynn_mixscalars             )
 
 #if (WRF_CHEM == 1)
-    IF ( mynn_chem_vertmx ) THEN
-          CALL mynn_mix_chem(kts,kte,i,          &
-               grav_settling,                    &
-               delt, dz1, pblh(i),               &
-               nchem, kdvel, ndvel, num_vert_mix,&
-               chem1, vd1,                       &
-               qnc1,qni1,                        &
-               p1, ex1, thl, sqv, sqc, sqi, sqw, &
-               rho1, ust(i),flt,flq,flqv,flqc,   &
-               wspd(i),qcg(i),                   &
-               tcd, qcd,                         &
-               &dfm, dfh, dfq,                   &
+    IF (bl_mynn_mixchem == 1) THEN
+          CALL mynn_mix_chem(kts,kte,           &
+               levflag,grav_settling,           &
+               delt, dz1,                       &
+               nchem, kdvel, ndvel, num_vert_mix, &
+               chem1, vd1,                      &
+               qnc1,qni1,                       &
+               p1, ex1, thl, sqv, sqc, sqi, sqw,&
+               ust(i,j),flt,flq,flqv,flqc,      &
+               wspd(i,j),qcg(i,j),              &
+               uoce(i,j),voce(i,j),             &
+               tsq1, qsq1, cov1,                &
+               tcd, qcd,                        &
+               &dfm, dfh, dfq,                  &
                ! mass flux components
-               & s_aw1,                          &
-               & s_awchem1,                      &
-               &bl_mynn_cloudmix,                &
-               EMIS_ANT_NO(i),                   &
-               FRP_MEAN(i),                      &
-               enh_vermix)
-        IF (PRESENT(chem3d) ) THEN
-           DO ic = 1,nchem
-              DO k = kts,kte
-                 chem3d(i,k,ic) = chem1(k,ic)
-              ENDDO
-           ENDDO
-        ENDIF
+               & s_aw1,                         &
+               & s_awchem1,                     &
+               &bl_mynn_cloudmix)
     ENDIF
 #endif
 
- 
+!>  - Call retrieve_exchange_coeffs() to retrieve K_m1
+!! and K_h1. 
           CALL retrieve_exchange_coeffs(kts,kte,&
                &dfm, dfh, dz1, K_m1, K_h1)
 
           !UPDATE 3D ARRAYS
           DO k=KTS,KTE !KTF
-             exch_m(i,k)=K_m1(k)
-             exch_h(i,k)=K_h1(k)
-             RUBLTEN(i,k)=du1(k)
-             RVBLTEN(i,k)=dv1(k)
-             RTHBLTEN(i,k)=dth1(k)
-             RQVBLTEN(i,k)=dqv1(k)
+             exch_m(i,k,j)=K_m1(k)
+             exch_h(i,k,j)=K_h1(k)
+             RUBLTEN(i,k,j)=du1(k)
+             RVBLTEN(i,k,j)=dv1(k)
+             RTHBLTEN(i,k,j)=dth1(k)
+             RQVBLTEN(i,k,j)=dqv1(k)
              IF(bl_mynn_cloudmix > 0)THEN
-               IF (PRESENT(sqc3D) .AND. FLAG_QC) RQCBLTEN(i,k)=dqc1(k)
-               IF (PRESENT(sqi3D) .AND. FLAG_QI) RQIBLTEN(i,k)=dqi1(k)
+               IF (PRESENT(sqc3D) .AND. FLAG_QC) RQCBLTEN(i,k,j)=dqc1(k)
+               IF (PRESENT(sqi3D) .AND. FLAG_QI) RQIBLTEN(i,k,j)=dqi1(k)
              ELSE
-               IF (PRESENT(sqc3D) .AND. FLAG_QC) RQCBLTEN(i,k)=0.
-               IF (PRESENT(sqi3D) .AND. FLAG_QI) RQIBLTEN(i,k)=0.
+               IF (PRESENT(sqc3D) .AND. FLAG_QC) RQCBLTEN(i,k,j)=0.
+               IF (PRESENT(sqi3D) .AND. FLAG_QI) RQIBLTEN(i,k,j)=0.
              ENDIF
              IF(bl_mynn_cloudmix > 0 .AND. bl_mynn_mixscalars > 0)THEN
-               IF (PRESENT(qnc) .AND. FLAG_QNC) RQNCBLTEN(i,k)=dqnc1(k)
-               IF (PRESENT(qni) .AND. FLAG_QNI) RQNIBLTEN(i,k)=dqni1(k)
-               IF (PRESENT(qnwfa) .AND. FLAG_QNWFA) RQNWFABLTEN(i,k)=dqnwfa1(k)
-               IF (PRESENT(qnifa) .AND. FLAG_QNIFA) RQNIFABLTEN(i,k)=dqnifa1(k)
+               IF (PRESENT(qnc) .AND. FLAG_QNC) RQNCBLTEN(i,k,j)=dqnc1(k)
+               IF (PRESENT(qni) .AND. FLAG_QNI) RQNIBLTEN(i,k,j)=dqni1(k)
+               IF (PRESENT(qnwfa) .AND. FLAG_QNWFA) RQNWFABLTEN(i,k,j)=dqnwfa1(k)
+               IF (PRESENT(qnifa) .AND. FLAG_QNIFA) RQNIFABLTEN(i,k,j)=dqnifa1(k)
              ELSE
-               IF (PRESENT(qnc) .AND. FLAG_QNC) RQNCBLTEN(i,k)=0.
-               IF (PRESENT(qni) .AND. FLAG_QNI) RQNIBLTEN(i,k)=0.
-               IF (PRESENT(qnwfa) .AND. FLAG_QNWFA) RQNWFABLTEN(i,k)=0.
-               IF (PRESENT(qnifa) .AND. FLAG_QNIFA) RQNIFABLTEN(i,k)=0.
+               IF (PRESENT(qnc) .AND. FLAG_QNC) RQNCBLTEN(i,k,j)=0.
+               IF (PRESENT(qni) .AND. FLAG_QNI) RQNIBLTEN(i,k,j)=0.
+               IF (PRESENT(qnwfa) .AND. FLAG_QNWFA) RQNWFABLTEN(i,k,j)=0.
+               IF (PRESENT(qnifa) .AND. FLAG_QNIFA) RQNIFABLTEN(i,k,j)=0.
              ENDIF
              DOZONE(i,k)=DOZONE1(k)
 
@@ -5478,120 +5187,97 @@ ENDIF
                   !DECAY TIMESCALE FOR CALM CONDITION IS THE EDDY TURNOVER
                   !TIMESCALE, BUT FOR WINDY CONDITIONS, IT IS THE ADVECTIVE 
                   !TIMESCALE. USE THE MINIMUM OF THE TWO.
-                  ts_decay = MIN( 1800., 3.*dx(i)/MAX(SQRT(u1(k)**2 + v1(k)**2),1.0) )
-                  cldfra_bl(i,k)= MAX(cldfra_bl1D(k),cldfra_bl1D_old(k)-(0.20*delt/ts_decay))
-                  ! qc_bl2 and qi_bl2 are linked to decay rates 
+                  ts_decay = MIN( 1800., 3.*dx(i,j)/MAX(SQRT(u1(k)**2 + v1(k)**2),1.0) )
+                  cldfra_bl(i,k,j)= MAX(cldfra_bl1D(k),cldfra_bl1D_old(k)-(0.25*delt/ts_decay))
+                  ! qc_bl2 and qi_bl2 are decay rates 
                   qc_bl2          = MAX(qc_bl1D(k),qc_bl1D_old(k))
+                  qc_bl2          = MAX(qc_bl2,1.0E-5)
                   qi_bl2          = MAX(qi_bl1D(k),qi_bl1D_old(k))
-                  qc_bl(i,k)    = MAX(qc_bl1D(k),qc_bl1D_old(k)-(MIN(qc_bl2,1.0E-5) * delt/ts_decay))
-                  qi_bl(i,k)    = MAX(qi_bl1D(k),qi_bl1D_old(k)-(MIN(qi_bl2,1.0E-6) * delt/ts_decay))
-                  IF (cldfra_bl(i,k) < 0.005 .OR. &
-                     (qc_bl(i,k) + qi_bl(i,k)) < 1E-9) THEN
-                     CLDFRA_BL(i,k)= 0.
-                     QC_BL(i,k)    = 0.
-                     QI_BL(i,k)    = 0.
+                  qi_bl2          = MAX(qi_bl2,1.0E-6)
+                  qc_bl(i,k,j)    = MAX(qc_bl1D(k),qc_bl1D_old(k)-(MIN(qc_bl2,1.0E-4) * delt/ts_decay))
+                  qi_bl(i,k,j)    = MAX(qi_bl1D(k),qi_bl1D_old(k)-(MIN(qi_bl2,1.0E-5) * delt/ts_decay))
+                  IF (cldfra_bl(i,k,j) < 0.005 .OR. &
+                     (qc_bl(i,k,j) + qi_bl(i,k,j)) < 1E-9) THEN
+                     CLDFRA_BL(i,k,j)= 0.
+                     QC_BL(i,k,j)    = 0.
+                     QI_BL(i,k,j)    = 0.
                   ENDIF
                ELSE
-                  qc_bl(i,k)=qc_bl1D(k)
-                  qi_bl(i,k)=qi_bl1D(k)
-                  cldfra_bl(i,k)=cldfra_bl1D(k)
+                  qc_bl(i,k,j)=qc_bl1D(k)
+                  qi_bl(i,k,j)=qi_bl1D(k)
+                  cldfra_bl(i,k,j)=cldfra_bl1D(k)
                ENDIF
              ENDIF
 
-             el_pbl(i,k)=el(k)
-             qke(i,k)=qke1(k)
-             tsq(i,k)=tsq1(k)
-             qsq(i,k)=qsq1(k)
-             cov(i,k)=cov1(k)
-             sh3d(i,k)=sh(k)
+             el_pbl(i,k,j)=el(k)
+             qke(i,k,j)=qke1(k)
+             tsq(i,k,j)=tsq1(k)
+             qsq(i,k,j)=qsq1(k)
+             cov(i,k,j)=cov1(k)
+             sh3d(i,k,j)=sh(k)
 
           ENDDO !end-k
 
           IF ( bl_mynn_tkebudget == 1) THEN
-             !! TKE budget is now given in m**2/s**-3 (Puhales, 2020)
-             !! Lower boundary condtions (using similarity relationships such as the prognostic equation for Qke)
-             k=kts
-             qSHEAR1(k)=4.*(ust(i)**3*phi_m/(vk*dz(i,k)))-qSHEAR1(k+1) !! staggered
-             qBUOY1(k)=4.*(-ust(i)**3*zet/(vk*dz(i,k)))-qBUOY1(k+1) !! staggered
-             !! unstaggering SHEAR and BUOY and trasfering all TKE budget to 3D array               
-             DO k = kts,kte-1
-                qSHEAR(i,k)=0.5*(qSHEAR1(k)+qSHEAR1(k+1)) !!! unstaggering in z
-                qBUOY(i,k)=0.5*(qBUOY1(k)+qBUOY1(k+1)) !!! unstaggering in z
-                qWT(i,k)=qWT1(k)
-                qDISS(i,k)=qDISS1(k)
-                dqke(i,k)=(qke1(k)-dqke(i,k))*0.5/delt
+             DO k = kts,kte
+                dqke(i,k,j)  = (qke1(k)-dqke(i,k,j))*0.5  !qke->tke
+                qWT(i,k,j)   = qWT1(k)*delt
+                qSHEAR(i,k,j)= qSHEAR1(k)*delt
+                qBUOY(i,k,j) = qBUOY1(k)*delt
+                qDISS(i,k,j) = qDISS1(k)*delt
              ENDDO
-             !! Upper boundary conditions               
-             k=kte
-             qSHEAR(i,k)=0.
-             qBUOY(i,k)=0.
-             qWT(i,k)=0.
-             qDISS(i,k)=0.
-             dqke(i,k)=0.
           ENDIF
 
-          !update updraft/downdraft properties
-          if (bl_mynn_output > 0) THEN !research mode == 1
-             if (bl_mynn_edmf > 0) THEN
-                DO k = kts,kte
-                   edmf_a(i,k)=edmf_a1(k)
-                   edmf_w(i,k)=edmf_w1(k)
-                   edmf_qt(i,k)=edmf_qt1(k)
-                   edmf_thl(i,k)=edmf_thl1(k)
-                   edmf_ent(i,k)=edmf_ent1(k)
-                   edmf_qc(i,k)=edmf_qc1(k)
-                   sub_thl3D(i,k)=sub_thl(k)
-                   sub_sqv3D(i,k)=sub_sqv(k)
-                   det_thl3D(i,k)=det_thl(k)
-                   det_sqv3D(i,k)=det_sqv(k)
-                ENDDO
-             endif
-!             if (bl_mynn_edmf_dd > 0) THEN
-!                DO k = kts,kte
-!                   edmf_a_dd(i,k)=edmf_a_dd1(k)
-!                   edmf_w_dd(i,k)=edmf_w_dd1(k)
-!                   edmf_qt_dd(i,k)=edmf_qt_dd1(k)
-!                   edmf_thl_dd(i,k)=edmf_thl_dd1(k)
-!                   edmf_ent_dd(i,k)=edmf_ent_dd1(k)
-!                   edmf_qc_dd(i,k)=edmf_qc_dd1(k)
-!                ENDDO
-!             ENDIF
+          !update updraft properties
+          IF (bl_mynn_output > 0) THEN !research mode == 1
+             DO k = kts,kte
+                edmf_a(i,k)=edmf_a1(k)
+                edmf_w(i,k)=edmf_w1(k)
+                edmf_qt(i,k)=edmf_qt1(k)
+                edmf_thl(i,k)=edmf_thl1(k)
+                edmf_ent(i,k)=edmf_ent1(k)
+                edmf_qc(i,k)=edmf_qc1(k)
+                sub_thl3D(i,k)=sub_thl(k)
+                sub_sqv3D(i,k)=sub_sqv(k)
+                det_thl3D(i,k)=det_thl(k)
+                det_sqv3D(i,k)=det_sqv(k)
+             ENDDO
           ENDIF
 
           !***  Begin debug prints
           IF ( debug_code ) THEN
              DO k = kts,kte
                IF ( sh(k) < 0. .OR. sh(k)> 200.)print*,&
-                  "SUSPICIOUS VALUES AT: i,k=",i,k," sh=",sh(k)
-               IF ( qke(i,k) < -1. .OR. qke(i,k)> 200.)print*,&
-                  "SUSPICIOUS VALUES AT: i,k=",i,k," qke=",qke(i,k)
-               IF ( el_pbl(i,k) < 0. .OR. el_pbl(i,k)> 2000.)print*,&
-                  "SUSPICIOUS VALUES AT: i,k=",i,k," el_pbl=",el_pbl(i,k)
+                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," sh=",sh(k)
+               IF ( qke(i,k,j) < -1. .OR. qke(i,k,j)> 200.)print*,&
+                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," qke=",qke(i,k,j)
+               IF ( el_pbl(i,k,j) < 0. .OR. el_pbl(i,k,j)> 2000.)print*,&
+                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," el_pbl=",el_pbl(i,k,j)
                IF ( ABS(vt(k)) > 0.8 )print*,&
-                  "SUSPICIOUS VALUES AT: i,k=",i,k," vt=",vt(k)
+                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," vt=",vt(k)
                IF ( ABS(vq(k)) > 6000.)print*,&
-                  "SUSPICIOUS VALUES AT: i,k=",i,k," vq=",vq(k) 
-               IF ( exch_m(i,k) < 0. .OR. exch_m(i,k)> 2000.)print*,&
-                  "SUSPICIOUS VALUES AT: i,k=",i,k," exxch_m=",exch_m(i,k)
-               IF ( vdfg(i) < 0. .OR. vdfg(i)>5. )print*,&
-                  "SUSPICIOUS VALUES AT: i,k=",i,k," vdfg=",vdfg(i)
-               IF ( ABS(QFX(i))>.001)print*,&
-                  "SUSPICIOUS VALUES AT: i=",i," QFX=",QFX(i)
-               IF ( ABS(HFX(i))>1000.)print*,&
-                  "SUSPICIOUS VALUES AT: i=",i," HFX=",HFX(i)
+                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," vq=",vq(k) 
+               IF ( exch_m(i,k,j) < 0. .OR. exch_m(i,k,j)> 2000.)print*,&
+                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," exxch_m=",exch_m(i,k,j)
+               IF ( vdfg(i,j) < 0. .OR. vdfg(i,j)>5. )print*,&
+                  "SUSPICIOUS VALUES AT: i,j,k=",i,j,k," vdfg=",vdfg(i,j)
+               IF ( ABS(QFX(i,j))>.001)print*,&
+                  "SUSPICIOUS VALUES AT: i,j=",i,j," QFX=",QFX(i,j)
+               IF ( ABS(HFX(i,j))>1000.)print*,&
+                  "SUSPICIOUS VALUES AT: i,j=",i,j," HFX=",HFX(i,j)
                IF (icloud_bl > 0) then
-                  IF( cldfra_bl(i,k) < 0.0 .OR. cldfra_bl(i,k)> 1.)THEN
-                  PRINT*,"SUSPICIOUS VALUES: CLDFRA_BL=",cldfra_bl(i,k)," qc_bl=",QC_BL(i,k)
+                  IF( cldfra_bl(i,k,j) < 0.0 .OR. cldfra_bl(i,k,j)> 1.)THEN
+                  PRINT*,"SUSPICIOUS VALUES: CLDFRA_BL=",cldfra_bl(i,k,j)," qc_bl=",QC_BL(i,k,j)
                   ENDIF
                ENDIF
 
                !IF (I==IMD .AND. J==JMD) THEN
                !   PRINT*,"MYNN DRIVER END: k=",k," sh=",sh(k)
-               !   PRINT*," sqw=",sqw(k)," thl=",thl(k)," exch_m=",exch_m(i,k)
-               !   PRINT*," xland=",xland(i)," rmol=",rmol(i)," ust=",ust(i)
-               !   PRINT*," qke=",qke(i,k)," el=",el_pbl(i,k)," tsq=",tsq(i,k)
-               !   PRINT*," PBLH=",PBLH(i)," u=",u(i,k)," v=",v(i,k)
-               !   PRINT*," vq=",vq(k)," vt=",vt(k)," vdfg=",vdfg(i)
+               !   PRINT*," sqw=",sqw(k)," thl=",thl(k)," exch_m=",exch_m(i,k,j)
+               !   PRINT*," xland=",xland(i,j)," rmol=",rmol(i,j)," ust=",ust(i,j)
+               !   PRINT*," qke=",qke(i,k,j)," el=",el_pbl(i,k,j)," tsq=",tsq(i,k,j)
+               !   PRINT*," PBLH=",PBLH(i,j)," u=",u(i,k,j)," v=",v(i,k,j)
+               !   PRINT*," vq=",vq(k)," vt=",vt(k)," vdfg=",vdfg(i,j)
                !ENDIF
              ENDDO !end-k
           ENDIF
@@ -5599,14 +5285,15 @@ ENDIF
 
           !JOE-add tke_pbl for coupling w/shallow-cu schemes (TKE_PBL = QKE/2.)
           !    TKE_PBL is defined on interfaces, while QKE is at middle of layer.
-          !tke_pbl(i,kts) = 0.5*MAX(qke(i,kts),1.0e-10)
+          !tke_pbl(i,kts,j) = 0.5*MAX(qke(i,kts,j),1.0e-10)
           !DO k = kts+1,kte
           !   afk = dz1(k)/( dz1(k)+dz1(k-1) )
           !   abk = 1.0 -afk
-          !   tke_pbl(i,k) = 0.5*MAX(qke(i,k)*abk+qke(i,k-1)*afk,1.0e-3)
+          !   tke_pbl(i,k,j) = 0.5*MAX(qke(i,k,j)*abk+qke(i,k-1,j)*afk,1.0e-3)
           !ENDDO
 
-    ENDDO !end i-loop
+       ENDDO
+    ENDDO
 
 !ACF copy qke into qke_adv if using advection
     IF (bl_mynn_tkeadvect) THEN
@@ -5644,10 +5331,13 @@ ENDIF
          &                ITS,ITE,JTS,JTE,KTS,KTE
     
     
-    REAL,DIMENSION(IMS:IME,KMS:KME),INTENT(INOUT) ::     &
-         &RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,             &
+    REAL,DIMENSION(IMS:IME,KMS:KME,JMS:JME),INTENT(INOUT) :: &
+         &RUBLTEN,RVBLTEN,RTHBLTEN,RQVBLTEN,                 &
          &RQCBLTEN,RQIBLTEN,& !RQNIBLTEN,RQNCBLTEN       &
          &QKE,EXCH_H
+
+!    REAL,DIMENSION(IMS:IME,KMS:KME,JMS:JME),INTENT(INOUT) :: &
+!         &qc_bl,cldfra_bl
 
     INTEGER :: I,J,K,ITF,JTF,KTF
     
@@ -5656,20 +5346,22 @@ ENDIF
     ITF=MIN0(ITE,IDE-1)
     
     IF(.NOT.RESTART)THEN
-       DO K=KTS,KTF
-          DO I=ITS,ITF
-             RUBLTEN(i,k)=0.
-             RVBLTEN(i,k)=0.
-             RTHBLTEN(i,k)=0.
-             RQVBLTEN(i,k)=0.
-             if( p_qc >= param_first_scalar ) RQCBLTEN(i,k)=0.
-             if( p_qi >= param_first_scalar ) RQIBLTEN(i,k)=0.
-             !if( p_qnc >= param_first_scalar ) RQNCBLTEN(i,k)=0.
-             !if( p_qni >= param_first_scalar ) RQNIBLTEN(i,k)=0.
-             !QKE(i,k)=0.
-             EXCH_H(i,k)=0.
-!                if(icloud_bl > 0) qc_bl(i,k)=0.
-!                if(icloud_bl > 0) cldfra_bl(i,k)=0.
+       DO J=JTS,JTF
+          DO K=KTS,KTF
+             DO I=ITS,ITF
+                RUBLTEN(i,k,j)=0.
+                RVBLTEN(i,k,j)=0.
+                RTHBLTEN(i,k,j)=0.
+                RQVBLTEN(i,k,j)=0.
+                if( p_qc >= param_first_scalar ) RQCBLTEN(i,k,j)=0.
+                if( p_qi >= param_first_scalar ) RQIBLTEN(i,k,j)=0.
+                !if( p_qnc >= param_first_scalar ) RQNCBLTEN(i,k,j)=0.
+                !if( p_qni >= param_first_scalar ) RQNIBLTEN(i,k,j)=0.
+                !QKE(i,k,j)=0.
+                EXCH_H(i,k,j)=0.
+!                if(icloud_bl > 0) qc_bl(i,k,j)=0.
+!                if(icloud_bl > 0) cldfra_bl(i,k,j)=0.
+             ENDDO
           ENDDO
        ENDDO
     ENDIF
@@ -5801,7 +5493,7 @@ ENDIF
              & MIN((TKEeps-qtke)/MAX(qtkem1-qtke, 1E-6), 1.0)
            !IN CASE OF NEAR ZERO TKE, SET PBLH = LOWEST LEVEL.
            PBLH_TKE = MAX(PBLH_TKE,zw1D(kts+1))
-           !print *,"PBLH_TKE:",i,PBLH_TKE, Qke1D(k)/2., zw1D(kts+1)
+           !print *,"PBLH_TKE:",i,j,PBLH_TKE, Qke1D(k)/2., zw1D(kts+1)
        ENDIF
        !k = k+1
        IF (k .EQ. kte-1) PBLH_TKE = zw1D(kts+1) !EXIT SAFEGUARD
@@ -5860,14 +5552,14 @@ ENDIF
 !!
 !! This scheme remains under development, so consider it experimental code. 
 !!
-  SUBROUTINE DMP_mf(                        &
-                 & kts,kte,dt,zw,dz,p,rho,  &
+  SUBROUTINE DMP_mf(                       &
+                 & kts,kte,dt,zw,dz,p,      &
                  & momentum_opt,            &
                  & tke_opt,                 &
                  & scalar_opt,              &
                  & u,v,w,th,thl,thv,tk,     &
                  & qt,qv,qc,qke,            &
-                 & qnc,qni,qnwfa,qnifa,     &
+                 qnc,qni,qnwfa,qnifa,       &
                  & exner,vt,vq,sgm,         &
                  & ust,flt,flq,flqv,flqc,   &
                  & pblh,kpbl,DX,landsea,ts, &
@@ -5887,7 +5579,6 @@ ENDIF
                  & det_u,det_v,             &
 #if (WRF_CHEM == 1)
                  & nchem,chem,s_awchem,     &
-                 & mynn_chem_vertmx,        &
 #endif
             ! in/outputs - subgrid scale clouds
                  & qc_bl1d,cldfra_bl1d,         &
@@ -5915,8 +5606,8 @@ ENDIF
      REAL, DIMENSION(KTS:KTE)      :: rstoch_col
 
      REAL,DIMENSION(KTS:KTE), INTENT(IN) :: U,V,W,TH,THL,TK,QT,QV,QC,&
-                      exner,dz,THV,P,rho,qke,qnc,qni,qnwfa,qnifa
-     REAL,DIMENSION(KTS:KTE+1), INTENT(IN) :: ZW    !height at full-sigma
+                      exner,dz,THV,P,qke,qnc,qni,qnwfa,qnifa
+     REAL,DIMENSION(KTS:KTE+1), INTENT(IN) :: ZW  !height at full-sigma
      REAL, INTENT(IN) :: DT,UST,FLT,FLQ,FLQV,FLQC,PBLH,&
                          DX,Psig_shcu,landsea,ts
      LOGICAL, OPTIONAL :: F_QC,F_QI,F_QNC,F_QNI,F_QNWFA,F_QNIFA
@@ -5930,8 +5621,8 @@ ENDIF
      INTEGER, INTENT(OUT) :: nup2,ktop
      REAL, INTENT(OUT) :: maxmf,ztop
   ! outputs - variables needed for solver
-     REAL,DIMENSION(KTS:KTE+1) :: s_aw,      & !sum ai*rho*wis_awphi
-                               s_awthl,      & !sum ai*rho*wi*phii
+     REAL,DIMENSION(KTS:KTE+1) :: s_aw,      & !sum ai*wis_awphi
+                               s_awthl,      & !sum ai*wi*phii
                                 s_awqt,      &
                                 s_awqv,      &
                                 s_awqc,      &
@@ -5962,7 +5653,7 @@ ENDIF
      REAL :: fltv,wstar,qstar,thstar,sigmaW,sigmaQT,sigmaTH,z0,    &
              pwmin,pwmax,wmin,wmax,wlv,Psig_w,maxw,maxqc,wpbl
      REAL :: B,QTn,THLn,THVn,QCn,Un,Vn,QKEn,QNCn,QNIn,QNWFAn,QNIFAn, &
-             Wn2,Wn,EntEXP,EntW,BCOEFF,THVkm1,THVk,Pk,rho_int
+             Wn2,Wn,EntEXP,EntW,BCOEFF,THVkm1,THVk,Pk
 
   ! w parameters
      REAL,PARAMETER :: &
@@ -5994,7 +5685,6 @@ ENDIF
      REAL,DIMENSION(KTS:KTE+1,1:NUP, nchem) :: UPCHEM
      INTEGER :: ic
      REAL,DIMENSION(KTS:KTE+1, nchem) :: edmf_chem
-     LOGICAL, INTENT(IN) :: mynn_chem_vertmx
 #endif
 
   !JOE: add declaration of ERF
@@ -6032,19 +5722,14 @@ ENDIF
                                        envm_u,envm_v  !environmental variables defined at middle of layer
    REAL,DIMENSION(KTS:KTE+1) ::  envi_a,envi_w        !environmental variables defined at model interface
    REAL :: temp,sublim,qc_ent,qv_ent,qt_ent,thl_ent,detrate,  &
-           detrateUV,oow,exc_fac,aratio,detturb,qc_grid,qc_sgs,&
-           qc_plume
-   REAL, PARAMETER :: Cdet   = 1./45.
+           detrateUV,oow,exc_fac,aratio,detturb,qc_grid
+   REAL, PARAMETER :: Cdet = 1./45.
    REAL, PARAMETER :: dzpmax = 300. !limit dz used in detrainment - can be excessing in thick layers
    !parameter "Csub" determines the propotion of upward vertical velocity that contributes to
    !environmenatal subsidence. Some portion is expected to be compensated by downdrafts instead of
    !gentle environmental subsidence. 1.0 assumes all upward vertical velocity in the mass-flux scheme
    !is compensated by "gentle" environmental subsidence. 
    REAL, PARAMETER :: Csub=0.25
-
-   !Factor for the pressure gradient effects on momentum transport
-   REAL, PARAMETER :: pgfac = 0.00  ! Zhang and Wu showed 0.4 is more appropriate for lower troposphere
-   REAL :: Uk,Ukm1,Vk,Vkm1,dxsa
 
 ! check the inputs
 !     print *,'dt',dt
@@ -6074,7 +5759,7 @@ ENDIF
   UPQNWFA=0.
   UPQNIFA=0.
 #if (WRF_CHEM == 1)
-    IF ( mynn_chem_vertmx ) THEN
+    IF (bl_mynn_mixchem == 1) THEN
       UPCHEM(KTS:KTE+1,1:NUP,1:nchem)=0.0
     ENDIF
 #endif
@@ -6087,7 +5772,7 @@ ENDIF
   edmf_ent=0.
   edmf_qc =0.
 #if (WRF_CHEM == 1)
-    IF ( mynn_chem_vertmx ) THEN
+    IF (bl_mynn_mixchem == 1) THEN
       edmf_chem(kts:kte+1,1:nchem) = 0.0
     ENDIF
 #endif
@@ -6105,7 +5790,7 @@ ENDIF
   s_awqnwfa=0.
   s_awqnifa=0.
 #if (WRF_CHEM == 1)
-    IF ( mynn_chem_vertmx ) THEN
+    IF (bl_mynn_mixchem == 1) THEN
       s_awchem(kts:kte+1,1:nchem) = 0.0
     ENDIF
 #endif
@@ -6137,9 +5822,7 @@ ENDIF
      IF(ZW(k)<=50.)k50=k
 
      !Search for cloud base
-     qc_sgs = MAX(qc(k), qc_bl1d(k)*cldfra_bl1d(k))
-     !IF(qc(k) >1E-5 .AND. cloud_base == 9000.0)THEN
-     IF(qc_sgs> 1E-5 .AND. cloud_base == 9000.0)THEN
+     IF(qc(k)>1E-5 .AND. cloud_base == 9000.0)THEN
        cloud_base = 0.5*(ZW(k)+ZW(k+1))
      ENDIF
 
@@ -6196,7 +5879,7 @@ ENDIF
   !Criteria (2)
     maxwidth = 1.2*PBLH 
   ! Criteria (3)
-    maxwidth = MIN(maxwidth,0.666*cloud_base)
+    maxwidth = MIN(maxwidth,0.75*cloud_base)
   ! Criteria (4)
     wspd_pbl=SQRT(MAX(u(kts)**2 + v(kts)**2, 0.01))
     !Note: area fraction (acfac) is modified below
@@ -6279,6 +5962,9 @@ ENDIF
     wmin=MIN(sigmaW*pwmin,0.05)
     wmax=MIN(sigmaW*pwmax,0.4)
 
+    !recompute acfac for plume excess
+    acfac = .5*tanh((fltv - 0.03)/0.07) + .5
+
     !SPECIFY SURFACE UPDRAFT PROPERTIES AT MODEL INTERFACE BETWEEN K = 1 & 2
     DO I=1,NUP !NUP2
        IF(I > NUP2) exit
@@ -6307,7 +5993,7 @@ ENDIF
     ENDDO
 
 #if (WRF_CHEM == 1)
-    IF ( mynn_chem_vertmx ) THEN
+    IF (bl_mynn_mixchem == 1) THEN
       DO I=1,NUP !NUP2
         IF(I > NUP2) exit
         do ic = 1,nchem
@@ -6326,9 +6012,6 @@ ENDIF
        envm_v(k)=V(k)
     ENDDO
 
-  !dxsa is scale-adaptive factor governing the pressure-gradient term of the momentum transport
-  dxsa = 1. - MIN(MAX((12000.0-dx)/(12000.0-3000.0), 0.), 1.)
-
   !QCn = 0.
   ! do integration  updraft
     DO I=1,NUP !NUP2
@@ -6337,19 +6020,15 @@ ENDIF
        overshoot = 0
        l  = dl*I                            ! diameter of plume
        DO k=KTS+1,KTE-1
-          !Entrainment from Tian and Kuang (2016)
+          !w-dependency for entrainment a la Tian and Kuang (2016)
           !ENT(k,i) = 0.35/(MIN(MAX(UPW(K-1,I),0.75),1.9)*l)
-          !wmin = 0.3 + l*0.0005 !* MAX(pblh-ZW(k+1), 0.0)/pblh
-          !ENT(k,i) = 0.33/(MIN(MAX(UPW(K-1,I),wmin),0.9)*l)
-
+          wmin = 0.3 + l*0.0005 !* MAX(pblh-ZW(k+1), 0.0)/pblh
+          ENT(k,i) = 0.33/(MIN(MAX(UPW(K-1,I),wmin),1.9)*l)
           !Entrainment from Negggers (2015, JAMES)
           !ENT(k,i) = 0.02*l**-0.35 - 0.0009
-          ENT(k,i) = 0.04*l**-0.50 - 0.0009   !more plume diversity
-
           !Minimum background entrainment 
           ENT(k,i) = max(ENT(k,i),0.0003)
-          ENT(k,i) = max(ENT(k,i),0.05/ZW(k))  !not needed for Tian and Kuang
-
+          !ENT(k,i) = max(ENT(k,i),0.05/ZW(k))  !not needed for Tian and Kuang
           !JOE - increase entrainment for plumes extending very high.
           IF(ZW(k) >= MIN(pblh+1500., 4000.))THEN
             ENT(k,i)=ENT(k,i) + (ZW(k)-MIN(pblh+1500.,4000.))*5.0E-6
@@ -6360,18 +6039,12 @@ ENDIF
 
           ENT(k,i) = min(ENT(k,i),0.9/(ZW(k+1)-ZW(k)))
 
-           ! Define environment U & V at the model interface levels
-           Uk  =(U(k)*DZ(k+1)+U(k+1)*DZ(k))/(DZ(k+1)+DZ(k))
-           Ukm1=(U(k-1)*DZ(k)+U(k)*DZ(k-1))/(DZ(k-1)+DZ(k))
-           Vk  =(V(k)*DZ(k+1)+V(k+1)*DZ(k))/(DZ(k+1)+DZ(k))
-           Vkm1=(V(k-1)*DZ(k)+V(k)*DZ(k-1))/(DZ(k-1)+DZ(k))
-
           ! Linear entrainment:
           EntExp= ENT(K,I)*(ZW(k+1)-ZW(k))
           QTn =UPQT(k-1,I) *(1.-EntExp) + QT(k)*EntExp
           THLn=UPTHL(k-1,I)*(1.-EntExp) + THL(k)*EntExp
-          Un  =UPU(k-1,I)  *(1.-EntExp) + U(k)*EntExp + dxsa*pgfac*(Uk - Ukm1)
-          Vn  =UPV(k-1,I)  *(1.-EntExp) + V(k)*EntExp + dxsa*pgfac*(Vk - Vkm1)
+          Un  =UPU(k-1,I)  *(1.-EntExp) + U(k)*EntExp
+          Vn  =UPV(k-1,I)  *(1.-EntExp) + V(k)*EntExp
           QKEn=UPQKE(k-1,I)*(1.-EntExp) + QKE(k)*EntExp
           QNCn=UPQNC(k-1,I)*(1.-EntExp) + QNC(k)*EntExp
           QNIn=UPQNI(k-1,I)*(1.-EntExp) + QNI(k)*EntExp
@@ -6393,7 +6066,7 @@ ENDIF
           !QKEn=QKE(k)*(1-EntExp)+UPQKE(K-1,I)*EntExp
 
 #if (WRF_CHEM == 1)
-    IF ( mynn_chem_vertmx ) THEN
+    IF (bl_mynn_mixchem == 1) THEN
           do ic = 1,nchem
              ! Exponential Entrainment:
              !chemn(ic) = chem(k,ic)*(1-EntExp)+UPCHEM(K-1,I,ic)*EntExp
@@ -6443,7 +6116,6 @@ ENDIF
              Wn = UPW(K-1,I) - MIN(1.25*(ZW(k)-ZW(k-1))/200., 2.0)
           ENDIF
           Wn = MIN(MAX(Wn,0.0), 3.0)
-
           !Check to make sure that the plume made it up at least one level.
           !if it failed, then set nup2=0 and exit the mass-flux portion.
           IF (k==kts+1 .AND. Wn == 0.) THEN
@@ -6513,7 +6185,7 @@ ENDIF
 
           IF (Wn > 0.) THEN
              !Update plume variables at current k index
-             UPW(K,I)=Wn  !sqrt(Wn2)
+             UPW(K,I)=Wn  !Wn !sqrt(Wn2)
              UPTHV(K,I)=THVn
              UPTHL(K,I)=THLn
              UPQT(K,I)=QTn
@@ -6527,7 +6199,7 @@ ENDIF
              UPQNIFA(K,I)=QNIFAn
              UPA(K,I)=UPA(K-1,I)
 #if (WRF_CHEM == 1)
-    IF ( mynn_chem_vertmx ) THEN
+    IF (bl_mynn_mixchem == 1) THEN
              do ic = 1,nchem
                 UPCHEM(k,I,ic) = chemn(ic)
              enddo
@@ -6559,7 +6231,7 @@ ENDIF
     ENDDO
   ELSE
     !At least one of the conditions was not met for activating the MF scheme.
-    NUP2=0.
+    NUP2=0. 
   END IF !end criteria for mass-flux scheme
 
   ktop=MIN(ktop,KTE-1)  !  Just to be safe...
@@ -6573,60 +6245,32 @@ ENDIF
 
     !Calculate the fluxes for each variable
     !All s_aw* variable are == 0 at k=1
-!    DO k=KTS,KTE
-!      IF(k > KTOP) exit
-!      DO i=1,NUP !NUP2
-!        IF(I > NUP2) exit
-!        s_aw(k+1)   = s_aw(k+1)    + UPA(K,i)*UPW(K,i)*Psig_w
-!        s_awthl(k+1)= s_awthl(k+1) + UPA(K,i)*UPW(K,i)*UPTHL(K,i)*Psig_w
-!        s_awqt(k+1) = s_awqt(k+1)  + UPA(K,i)*UPW(K,i)*UPQT(K,i)*Psig_w
-!        s_awqc(k+1) = s_awqc(k+1)  + UPA(K,i)*UPW(K,i)*UPQC(K,i)*Psig_w
-!        IF (momentum_opt > 0) THEN
-!          s_awu(k+1)  = s_awu(k+1)   + UPA(K,i)*UPW(K,i)*UPU(K,i)*Psig_w
-!          s_awv(k+1)  = s_awv(k+1)   + UPA(K,i)*UPW(K,i)*UPV(K,i)*Psig_w
-!        ENDIF
-!        IF (tke_opt > 0) THEN
-!          s_awqke(k+1)= s_awqke(k+1) + UPA(K,i)*UPW(K,i)*UPQKE(K,i)*Psig_w
-!        ENDIF
-!      ENDDO
-!      s_awqv(k+1) = s_awqt(k+1)  - s_awqc(k+1)
-!    ENDDO
-    DO i=1,NUP !NUP2
-      IF(I > NUP2) exit
-      DO k=KTS,KTE-1
-        IF(k > ktop) exit
-        rho_int     = (rho(k)*DZ(k+1)+rho(k+1)*DZ(k))/(DZ(k+1)+DZ(k))
-        s_aw(k+1)   = s_aw(k+1)    + rho_int*UPA(K,i)*UPW(K,i)*Psig_w
-        s_awthl(k+1)= s_awthl(k+1) + rho_int*UPA(K,i)*UPW(K,i)*UPTHL(K,i)*Psig_w
-        s_awqt(k+1) = s_awqt(k+1)  + rho_int*UPA(K,i)*UPW(K,i)*UPQT(K,i)*Psig_w
-        !to conform to grid mean properties, move qc to qv in grid mean
-        !saturated layers, so total water fluxes are preserve but 
-        !negative qc fluxes in unsaturated layers is reduced.
-        IF (qc(k) > 1e-12 .OR. qc(k+1) > 1e-12) then
-          qc_plume = UPQC(K,i)
-        ELSE
-          qc_plume = 0.0
-        ENDIF
-        s_awqc(k+1) = s_awqc(k+1)  + rho_int*UPA(K,i)*UPW(K,i)*qc_plume*Psig_w
+    DO k=KTS,KTE
+      IF(k > KTOP) exit
+      DO i=1,NUP !NUP2
+        IF(I > NUP2) exit
+        s_aw(k+1)   = s_aw(k+1)    + UPA(K,i)*UPW(K,i)*Psig_w
+        s_awthl(k+1)= s_awthl(k+1) + UPA(K,i)*UPW(K,i)*UPTHL(K,i)*Psig_w
+        s_awqt(k+1) = s_awqt(k+1)  + UPA(K,i)*UPW(K,i)*UPQT(K,i)*Psig_w
+        s_awqc(k+1) = s_awqc(k+1)  + UPA(K,i)*UPW(K,i)*UPQC(K,i)*Psig_w
         IF (momentum_opt > 0) THEN
-          s_awu(k+1)  = s_awu(k+1)   + rho_int*UPA(K,i)*UPW(K,i)*UPU(K,i)*Psig_w
-          s_awv(k+1)  = s_awv(k+1)   + rho_int*UPA(K,i)*UPW(K,i)*UPV(K,i)*Psig_w
+          s_awu(k+1)  = s_awu(k+1)   + UPA(K,i)*UPW(K,i)*UPU(K,i)*Psig_w
+          s_awv(k+1)  = s_awv(k+1)   + UPA(K,i)*UPW(K,i)*UPV(K,i)*Psig_w
         ENDIF
         IF (tke_opt > 0) THEN
-          s_awqke(k+1)= s_awqke(k+1) + rho_int*UPA(K,i)*UPW(K,i)*UPQKE(K,i)*Psig_w
+          s_awqke(k+1)= s_awqke(k+1) + UPA(K,i)*UPW(K,i)*UPQKE(K,i)*Psig_w
         ENDIF
-        s_awqv(k+1) = s_awqt(k+1)  - s_awqc(k+1)
       ENDDO
+      s_awqv(k+1) = s_awqt(k+1)  - s_awqc(k+1)
     ENDDO
 #if (WRF_CHEM == 1)
-    IF ( mynn_chem_vertmx ) THEN
+    IF (bl_mynn_mixchem == 1) THEN
       DO k=KTS,KTE
         IF(k > KTOP) exit
-        rho_int     = (rho(k)*DZ(k+1)+rho(k+1)*DZ(k))/(DZ(k+1)+DZ(k))
         DO i=1,NUP !NUP2
           IF(I > NUP2) exit
           do ic = 1,nchem
-            s_awchem(k+1,ic) = s_awchem(k+1,ic) + rho_int*UPA(K,i)*UPW(K,i)*UPCHEM(K,i,ic)*Psig_w
+            s_awchem(k+1,ic) = s_awchem(k+1,ic) + UPA(K,i)*UPW(K,i)*UPCHEM(K,i,ic)*Psig_w
           enddo
         ENDDO
       ENDDO
@@ -6636,13 +6280,12 @@ ENDIF
     IF (scalar_opt > 0) THEN
       DO k=KTS,KTE
         IF(k > KTOP) exit
-        rho_int     = (rho(k)*DZ(k+1)+rho(k+1)*DZ(k))/(DZ(k+1)+DZ(k))
         DO I=1,NUP !NUP2
           IF (I > NUP2) exit
-          s_awqnc(k+1)= s_awqnc(K+1) + rho_int*UPA(K,i)*UPW(K,i)*UPQNC(K,i)*Psig_w
-          s_awqni(k+1)= s_awqni(K+1) + rho_int*UPA(K,i)*UPW(K,i)*UPQNI(K,i)*Psig_w
-          s_awqnwfa(k+1)= s_awqnwfa(K+1) + rho_int*UPA(K,i)*UPW(K,i)*UPQNWFA(K,i)*Psig_w
-          s_awqnifa(k+1)= s_awqnifa(K+1) + rho_int*UPA(K,i)*UPW(K,i)*UPQNIFA(K,i)*Psig_w
+          s_awqnc(k+1)= s_awqnc(K+1) + UPA(K,i)*UPW(K,i)*UPQNC(K,i)*Psig_w
+          s_awqni(k+1)= s_awqni(K+1) + UPA(K,i)*UPW(K,i)*UPQNI(K,i)*Psig_w
+          s_awqnwfa(k+1)= s_awqnwfa(K+1) + UPA(K,i)*UPW(K,i)*UPQNWFA(K,i)*Psig_w
+          s_awqnifa(k+1)= s_awqnifa(K+1) + UPA(K,i)*UPW(K,i)*UPQNIFA(K,i)*Psig_w
         ENDDO
       ENDDO
     ENDIF
@@ -6680,7 +6323,7 @@ ENDIF
           s_awqke= s_awqke*adjustment
        ENDIF
 #if (WRF_CHEM == 1)
-    IF ( mynn_chem_vertmx ) THEN
+    IF (bl_mynn_mixchem == 1) THEN
        s_awchem = s_awchem*adjustment
     ENDIF
 #endif
@@ -6692,19 +6335,18 @@ ENDIF
     !all edmf_* variables at k=1 correspond to the interface at top of first model layer
     DO k=KTS,KTE-1
       IF(k > KTOP) exit
-      rho_int     = (rho(k)*DZ(k+1)+rho(k+1)*DZ(k))/(DZ(k+1)+DZ(k))
       DO I=1,NUP !NUP2
         IF(I > NUP2) exit
         edmf_a(K)  =edmf_a(K)  +UPA(K,i)
-        edmf_w(K)  =edmf_w(K)  +rho_int*UPA(K,i)*UPW(K,i)
-        edmf_qt(K) =edmf_qt(K) +rho_int*UPA(K,i)*UPQT(K,i)
-        edmf_thl(K)=edmf_thl(K)+rho_int*UPA(K,i)*UPTHL(K,i)
-        edmf_ent(K)=edmf_ent(K)+rho_int*UPA(K,i)*ENT(K,i)
-        edmf_qc(K) =edmf_qc(K) +rho_int*UPA(K,i)*UPQC(K,i)
+        edmf_w(K)  =edmf_w(K)  +UPA(K,i)*UPW(K,i)
+        edmf_qt(K) =edmf_qt(K) +UPA(K,i)*UPQT(K,i)
+        edmf_thl(K)=edmf_thl(K)+UPA(K,i)*UPTHL(K,i)
+        edmf_ent(K)=edmf_ent(K)+UPA(K,i)*ENT(K,i)
+        edmf_qc(K) =edmf_qc(K) +UPA(K,i)*UPQC(K,i)
 #if (WRF_CHEM == 1)
-    IF ( mynn_chem_vertmx ) THEN
+    IF (bl_mynn_mixchem == 1) THEN
         do ic = 1,nchem
-          edmf_chem(k,ic) = edmf_chem(k,ic) + rho_int*UPA(K,I)*UPCHEM(k,i,ic)
+          edmf_chem(k,ic) = edmf_chem(k,ic) + UPA(K,I)*UPCHEM(k,i,ic)
         enddo
     ENDIF
 #endif
@@ -6719,7 +6361,7 @@ ENDIF
         edmf_ent(k)=edmf_ent(k)/edmf_a(k)
         edmf_qc(k)=edmf_qc(k)/edmf_a(k)
 #if (WRF_CHEM == 1)
-    IF ( mynn_chem_vertmx ) THEN
+    IF (bl_mynn_mixchem == 1) THEN
         do ic = 1,nchem
           edmf_chem(k,ic) = edmf_chem(k,ic)/edmf_a(k)
         enddo
@@ -6784,7 +6426,6 @@ ENDIF
           det_sqv(k)=Cdet*(envm_sqv(k)-qv(k))*envi_a(k)*Psig_w
           det_sqc(k)=Cdet*(envm_sqc(k)-qc(k))*envi_a(k)*Psig_w
        ENDDO
-
        IF (momentum_opt > 0) THEN
          sub_u(kts)=0.5*envi_w(kts)*envi_a(kts)*(u(kts+1)-u(kts))/dzi(kts)
          sub_v(kts)=0.5*envi_w(kts)*envi_a(kts)*(v(kts+1)-v(kts))/dzi(kts)
@@ -6874,11 +6515,11 @@ ENDIF
 
             sigq = 9.E-3 * 0.5*(edmf_a(k)+edmf_a(k-1)) * &
                &           0.5*(edmf_w(k)+edmf_w(k-1)) * f       ! convective component of sigma (CB2005)
+            !sigq = MAX(sigq, 1.0E-4)
             sigq = SQRT(sigq**2 + sgm(k)**2)    ! combined conv + stratus components
-            sigq = MAX(sigq, 1.0E-6) 
 
             qmq = a * (qt(k) - qsat_tl)           ! saturation deficit/excess;
-                                                  !   the numerator of Q1
+                                                !   the numerator of Q1
             mf_cf = min(max(0.5 + 0.36 * atan(1.55*(qmq/sigq)),0.01),0.6)
             IF ( debug_code ) THEN
                print*,"In MYNN, StEM edmf"
@@ -6919,7 +6560,7 @@ ENDIF
                   qc_bl1d(k) = (QCp*Ac_mf + QCs*Ac_strat)/cldfra_bl1d(k)
                ENDIF
             ELSE
-               Ac_mf = mf_cf
+               Ac_mf      = mf_cf
             ENDIF
 
             !Now recalculate the terms for the buoyancy flux for mass-flux clouds:
@@ -6928,7 +6569,7 @@ ENDIF
             !following RAP and HRRR testing.
             !Fng = 2.05 ! the non-Gaussian transport factor (assumed constant)
             !Use Bechtold and Siebesma (1998) piecewise estimation of Fng:
-            Q1 = qmq/MAX(sigq,1E-6)
+            Q1 = qmq/MAX(sigq,1E-10)
             Q1=MAX(Q1,-5.0)
             IF (Q1 .GE. 1.0) THEN
                Fng = 1.0
@@ -6943,6 +6584,7 @@ ENDIF
             vt(k) = qww   - MIN(0.40,Ac_mf)*beta*bb*Fng - 1.
             vq(k) = alpha + MIN(0.40,Ac_mf)*beta*a*Fng  - tv0
          ENDIF
+
       ENDDO
 
     ENDIF  !end nup2 > 0
@@ -7026,12 +6668,12 @@ real :: diff,exn,t,th,qs,qcold
 ! number of iterations
   niter=50
 ! minimum difference (usually converges in < 8 iterations with diff = 2e-5)
-  diff=1.e-6
+  diff=2.e-5
 
   EXN=(P/p1000mb)**rcp
   !QC=0.  !better first guess QC is incoming from lower level, do not set to zero
   do i=1,NITER
-     T=EXN*THL + xlvcp*QC
+     T=EXN*THL + xlvcp*QC        
      QS=qsat_blend(T,P)
      QCOLD=QC
      QC=0.5*QC + 0.5*MAX((QT-QS),0.)
@@ -7065,418 +6707,17 @@ real :: diff,exn,t,th,qs,qcold
 end subroutine condensation_edmf
 
 !===============================================================
-
-subroutine condensation_edmf_r(QT,THL,P,zagl,THV,QC)
-!                                                                                                
-! zero or one condensation for edmf: calculates THL and QC                                       
-! similar to condensation_edmf but with different inputs                                         
-!                                                                                                
-real,intent(in)   :: QT,THV,P,zagl
-real,intent(out)  :: THL, QC
-
-integer :: niter,i
-real :: diff,exn,t,th,qs,qcold
-
-! number of iterations                                                                           
-  niter=50
-! minimum difference                                                                             
-  diff=2.e-5
-
-  EXN=(P/p1000mb)**rcp
-  ! assume first that th = thv                                                                   
-  T = THV*EXN
-  !QS = qsat_blend(T,P)                                                                          
-  !QC = QS - QT                                                                                  
-
-  QC=0.
-
-  do i=1,NITER
-     QCOLD = QC
-     T = EXN*THV/(1.+QT*(rvovrd-1.)-rvovrd*QC)
-     QS=qsat_blend(T,P)
-     QC= MAX((QT-QS),0.)
-     if (abs(QC-QCOLD)<Diff) exit
-  enddo
-  THL = (T - xlv/cp*QC)/EXN
-
-end subroutine condensation_edmf_r
-
-!===============================================================
-! ===================================================================
-! This is the downdraft mass flux scheme - analogus to edmf_JPL but  
-! flipped updraft to downdraft. This scheme is currently only tested 
-! for Stratocumulus cloud conditions. For a detailed desctiption of the
-! model, see paper.
-
-SUBROUTINE DDMF_JPL(kts,kte,dt,zw,dz,p,              &
-              &u,v,th,thl,thv,tk,qt,qv,qc,           &
-              &rho,exner,                            &
-              &ust,wthl,wqt,pblh,kpbl,               &
-              &edmf_a_dd,edmf_w_dd, edmf_qt_dd,      &
-              &edmf_thl_dd,edmf_ent_dd,edmf_qc_dd,   &
-              &sd_aw,sd_awthl,sd_awqt,               &
-              &sd_awqv,sd_awqc,sd_awu,sd_awv,        &
-              &sd_awqke,                             &
-              &qc_bl1d,cldfra_bl1d,                  &
-              &rthraten                              )
-
-        INTEGER, INTENT(IN) :: KTS,KTE,KPBL
-        REAL,DIMENSION(KTS:KTE), INTENT(IN) :: U,V,TH,THL,TK,QT,QV,QC,&
-            THV,P,rho,exner,rthraten,dz
-        ! zw .. heights of the downdraft levels (edges of boxes)
-        REAL,DIMENSION(KTS:KTE+1), INTENT(IN) :: ZW
-        REAL, INTENT(IN) :: DT,UST,WTHL,WQT,PBLH
-
-  ! outputs - downdraft properties
-        REAL,DIMENSION(KTS:KTE), INTENT(OUT) :: edmf_a_dd,edmf_w_dd,   &
-                      & edmf_qt_dd,edmf_thl_dd, edmf_ent_dd,edmf_qc_dd
-
-  ! outputs - variables needed for solver (sd_aw - sum ai*wi, sd_awphi - sum ai*wi*phii)
-        REAL,DIMENSION(KTS:KTE+1) :: sd_aw, sd_awthl, sd_awqt, sd_awu, &
-                            sd_awv, sd_awqc, sd_awqv, sd_awqke, sd_aw2
-
-        REAL,DIMENSION(KTS:KTE), INTENT(IN) :: qc_bl1d, cldfra_bl1d
-
-        INTEGER, PARAMETER :: NDOWN=5, debug_mf=0 !fixing number of plumes to 5
-  ! draw downdraft starting height randomly between cloud base and cloud top
-        INTEGER, DIMENSION(1:NDOWN) :: DD_initK
-        REAL   , DIMENSION(1:NDOWN) :: randNum
-  ! downdraft properties
-        REAL,DIMENSION(KTS:KTE+1,1:NDOWN) :: DOWNW,DOWNTHL,DOWNQT,&
-                    DOWNQC,DOWNA,DOWNU,DOWNV,DOWNTHV
-
-  ! entrainment variables
-        REAl,DIMENSION(KTS+1:KTE+1,1:NDOWN) :: ENT,ENTf
-        INTEGER,DIMENSION(KTS+1:KTE+1,1:NDOWN) :: ENTi
-
-  ! internal variables
-        INTEGER :: K,I,ki, kminrad, qlTop, p700_ind, qlBase
-        REAL :: wthv,wstar,qstar,thstar,sigmaW,sigmaQT,sigmaTH,z0, &
-            pwmin,pwmax,wmin,wmax,wlv,wtv,went,mindownw
-        REAL :: B,QTn,THLn,THVn,QCn,Un,Vn,QKEn,Wn2,Wn,THVk,Pk, &
-                EntEXP,EntW, Beta_dm, EntExp_M, rho_int
-        REAL :: jump_thetav, jump_qt, jump_thetal, &
-                refTHL, refTHV, refQT
-  ! DD specific internal variables
-        REAL :: minrad,zminrad, radflux, F0, wst_rad, wst_dd, deltaZ
-        logical :: cloudflg
-
-        REAL :: sigq,xl,tlk,qsat_tl,rsl,cpm,a,qmq,mf_cf,diffqt,&
-               Fng,qww,alpha,beta,bb,f,pt,t,q2p,b9,satvp,rhgrid
-
-  ! w parameters
-        REAL,PARAMETER :: &
-            &Wa=1., &
-            &Wb=1.5,&
-            &Z00=100.,&
-            &BCOEFF=0.2
-  ! entrainment parameters
-        REAL,PARAMETER :: &
-        & L0=80,&
-        & ENT0=0.2
-
-   pwmin=-3. ! drawing from the neagtive tail -3sigma to -1sigma
-   pwmax=-1.
-
-  ! initialize downdraft properties
-   DOWNW=0.
-   DOWNTHL=0.
-   DOWNTHV=0.
-   DOWNQT=0.
-   DOWNA=0.
-   DOWNU=0.
-   DOWNV=0.
-   DOWNQC=0.
-   ENT=0.
-   DD_initK=0
-
-   edmf_a_dd  =0.
-   edmf_w_dd  =0.
-   edmf_qt_dd =0.
-   edmf_thl_dd=0.
-   edmf_ent_dd=0.
-   edmf_qc_dd =0.
-
-   sd_aw=0.
-   sd_awthl=0.
-   sd_awqt=0.
-   sd_awqv=0.
-   sd_awqc=0.
-   sd_awu=0.
-   sd_awv=0.
-   sd_awqke=0.
-
-  ! FIRST, CHECK FOR STRATOCUMULUS-TOPPED BOUNDARY LAYERS
-   cloudflg=.false.
-   minrad=100.
-   kminrad=kpbl
-   zminrad=PBLH
-   qlTop = 1 !initialize at 0
-   qlBase = 1
-   wthv=wthl+svp1*wqt
-   do k = MAX(3,kpbl-2),kpbl+3
-      if (qc(k).gt. 1.e-6 .AND. cldfra_bl1D(k).gt.0.5) then
-          cloudflg=.true. ! found Sc cloud
-          qlTop = k       ! index for Sc cloud top
-      endif
-   enddo
-
-   do k = qlTop, kts, -1
-      if (qc(k) .gt. 1E-6) then
-         qlBase = k ! index for Sc cloud base
-      endif
-   enddo
-   qlBase = (qlTop+qlBase)/2 ! changed base to half way through the cloud
-
-!   call init_random_seed_1()
-!   call RANDOM_NUMBER(randNum)
-   do i=1,NDOWN
-      ! downdraft starts somewhere between cloud base to cloud top
-      ! the probability is equally distributed
-      DD_initK(i) = qlTop ! nint(randNum(i)*REAL(qlTop-qlBase)) + qlBase
-   enddo
-
-   ! LOOP RADFLUX
-   F0 = 0.
-   do k = 1, qlTop ! Snippet from YSU, YSU loops until qlTop - 1
-      radflux = rthraten(k) * exner(k) ! Converts theta/s to temperature/s
-      radflux = radflux * cp / g * ( p(k) - p(k+1) ) ! Converts K/s to W/m^2
-      if ( radflux < 0.0 ) F0 = abs(radflux) + F0
-   enddo
-   F0 = max(F0, 1.0)
-   !found Sc cloud and cloud not at surface, trigger downdraft
-   if (cloudflg) then
-
-!      !get entrainent coefficient
-!      do i=1,NDOWN
-!         do k=kts+1,kte
-!            ENTf(k,i)=(ZW(k+1)-ZW(k))/L0
-!         enddo
-!      enddo
-!
-!      ! get Poisson P(dz/L0)
-!      call Poisson(1,NDOWN,kts+1,kte,ENTf,ENTi)
-
-
-      ! entrainent: Ent=Ent0/dz*P(dz/L0)
-      do i=1,NDOWN
-         do k=kts+1,kte
-!            ENT(k,i)=real(ENTi(k,i))*Ent0/(ZW(k+1)-ZW(k))
-            ENT(k,i) = 0.002
-            ENT(k,i) = min(ENT(k,i),0.9/(ZW(k+1)-ZW(k)))
-         enddo
-      enddo
-
-      !!![EW: INVJUMP] find 700mb height then subtract trpospheric lapse rate!!!
-      p700_ind = MINLOC(ABS(p-70000),1)!p1D is 70000
-      jump_thetav = thv(p700_ind) - thv(1) - (thv(p700_ind)-thv(qlTop+3))/(ZW(p700_ind)-ZW(qlTop+3))*(ZW(p700_ind)-ZW(qlTop))
-      jump_qt = qc(p700_ind) + qv(p700_ind) - qc(1) - qv(1)
-      jump_thetal = thl(p700_ind) - thl(1) - (thl(p700_ind)-thl(qlTop+3))/(ZW(p700_ind)-ZW(qlTop+3))*(ZW(p700_ind)-ZW(qlTop))
-
-      refTHL = thl(qlTop) !sum(thl(1:qlTop)) / (qlTop) ! avg over BL for now or just at qlTop
-      refTHV = thv(qlTop) !sum(thv(1:qlTop)) / (qlTop)
-      refQT  = qt(qlTop)  !sum(qt(1:qlTop))  / (qlTop)
-
-      ! wstar_rad, following Lock and MacVean (1999a)
-      wst_rad = ( g * zw(qlTop) * F0 / (refTHL * rho(qlTop) * cp) ) ** (0.333)
-      wst_rad = max(wst_rad, 0.1)
-      wstar   = max(0.,(g/thv(1)*wthv*pblh)**(1./3.))
-      went    = thv(1) / ( g * jump_thetav * zw(qlTop) ) * &
-                (0.15 * (wstar**3 + 5*ust**3) + 0.35 * wst_rad**3 )
-      qstar  = abs(went*jump_qt/wst_rad)
-      thstar = F0/rho(qlTop)/cp/wst_rad - went*jump_thetav/wst_rad
-      !wstar_dd = mixrad + surface wst
-      wst_dd = (0.15 * (wstar**3 + 5*ust**3) + 0.35 * wst_rad**3 ) ** (0.333)
-
-      print*,"qstar=",qstar," thstar=",thstar," wst_dd=",wst_dd
-      print*,"F0=",F0," wst_rad=",wst_rad," jump_thv=",jump_thetav
-      print*,"entrainment velocity=",went
-
-      sigmaW  = 0.2*wst_dd  ! 0.8*wst_dd !wst_rad tuning parameter ! 0.5 was good
-      sigmaQT = 40  * qstar ! 50 was good
-      sigmaTH = 1.0 * thstar! 0.5 was good
-
-      wmin=sigmaW*pwmin
-      wmax=sigmaW*pwmax
-      !print*,"sigw=",sigmaW," wmin=",wmin," wmax=",wmax
-
-      do I=1,NDOWN !downdraft now starts at different height
-         ki = DD_initK(I)
-
-         wlv=wmin+(wmax-wmin)/REAL(NDOWN)*(i-1)
-         wtv=wmin+(wmax-wmin)/REAL(NDOWN)*i
-
-         !DOWNW(ki,I)=0.5*(wlv+wtv)
-         DOWNW(ki,I)=wlv
-         !DOWNA(ki,I)=0.5*ERF(wtv/(sqrt(2.)*sigmaW))-0.5*ERF(wlv/(sqrt(2.)*sigmaW))
-         DOWNA(ki,I)=.1/REAL(NDOWN)
-         DOWNU(ki,I)=(u(ki-1)*DZ(ki) + u(ki)*DZ(ki-1)) /(DZ(ki)+DZ(ki-1))
-         DOWNV(ki,I)=(v(ki-1)*DZ(ki) + v(ki)*DZ(ki-1)) /(DZ(ki)+DZ(ki-1))
-
-         !reference now depends on where dd starts
-!         refTHL = 0.5 * (thl(ki) + thl(ki-1))
-!         refTHV = 0.5 * (thv(ki) + thv(ki-1))
-!         refQT  = 0.5 * (qt(ki)  + qt(ki-1) )
-
-         refTHL = (thl(ki-1)*DZ(ki) + thl(ki)*DZ(ki-1)) /(DZ(ki)+DZ(ki-1))
-         refTHV = (thv(ki-1)*DZ(ki) + thv(ki)*DZ(ki-1)) /(DZ(ki)+DZ(ki-1))
-         refQT  = (qt(ki-1)*DZ(ki)  + qt(ki)*DZ(ki-1))  /(DZ(ki)+DZ(ki-1))
-
-         !DOWNQC(ki,I) = 0.0
-         DOWNQC(ki,I) = (qc(ki-1)*DZ(ki) + qc(ki)*DZ(ki-1)) /(DZ(ki)+DZ(ki-1))
-         DOWNQT(ki,I) = refQT  !+ 0.5  *DOWNW(ki,I)*sigmaQT/sigmaW
-         DOWNTHV(ki,I)= refTHV + 0.01 *DOWNW(ki,I)*sigmaTH/sigmaW
-         DOWNTHL(ki,I)= refTHL + 0.01 *DOWNW(ki,I)*sigmaTH/sigmaW
-
-         !input :: QT,THV,P,zagl,  output :: THL, QC
-!         Pk  =(P(ki-1)*DZ(ki)+P(ki)*DZ(ki-1))/(DZ(ki)+DZ(ki-1))
-!         call condensation_edmf_r(DOWNQT(ki,I),   &
-!              &        DOWNTHL(ki,I),Pk,ZW(ki),   &
-!              &     DOWNTHV(ki,I),DOWNQC(ki,I)    )
-
-      enddo
-
-
-      !print*, " Begin integration of downdrafts:"
-      DO I=1,NDOWN
-         !print *, "Plume # =", I,"======================="
-         DO k=DD_initK(I)-1,KTS+1,-1 
-            !starting at the first interface level below cloud top
-            deltaZ = ZW(k+1)-ZW(k)
-            !EntExp=exp(-ENT(K,I)*deltaZ)
-            !EntExp_M=exp(-ENT(K,I)/3.*deltaZ)
-            EntExp  =ENT(K,I)*deltaZ
-            EntExp_M=ENT(K,I)*0.333*deltaZ
-
-            QTn =DOWNQT(k+1,I) *(1.-EntExp) + QT(k)*EntExp
-            THLn=DOWNTHL(k+1,I)*(1.-EntExp) + THL(k)*EntExp
-            Un  =DOWNU(k+1,I)  *(1.-EntExp) + U(k)*EntExp_M
-            Vn  =DOWNV(k+1,I)  *(1.-EntExp) + V(k)*EntExp_M
-            !QKEn=DOWNQKE(k-1,I)*(1.-EntExp) + QKE(k)*EntExp
-
-!            QTn =DOWNQT(K+1,I) +(QT(K) -DOWNQT(K+1,I)) *(1.-EntExp)
-!            THLn=DOWNTHL(K+1,I)+(THL(K)-DOWNTHL(K+1,I))*(1.-EntExp)
-!            Un  =DOWNU(K+1,I)  +(U(K)  -DOWNU(K+1,I))*(1.-EntExp_M)
-!            Vn  =DOWNV(K+1,I)  +(V(K)  -DOWNV(K+1,I))*(1.-EntExp_M)
-
-            ! given new p & z, solve for thvn & qcn
-            Pk  =(P(k-1)*DZ(k)+P(k)*DZ(k-1))/(DZ(k)+DZ(k-1))
-            call condensation_edmf(QTn,THLn,Pk,ZW(k),THVn,QCn)
-!            B=g*(0.5*(THVn+DOWNTHV(k+1,I))/THV(k)-1.)
-            THVk  =(THV(k-1)*DZ(k)+THV(k)*DZ(k-1))/(DZ(k)+DZ(k-1))
-            B=g*(THVn/THVk - 1.0)
-!            Beta_dm = 2*Wb*ENT(K,I) + 0.5/(ZW(k)-deltaZ) * &
-!                 &    max(1. - exp((ZW(k) -deltaZ)/Z00 - 1. ) , 0.)
-!            EntW=exp(-Beta_dm * deltaZ)
-            EntW=EntExp
-!            if (Beta_dm >0) then
-!               Wn2=DOWNW(K+1,I)**2*EntW - Wa*B/Beta_dm * (1. - EntW)
-!            else
-!               Wn2=DOWNW(K+1,I)**2      - 2.*Wa*B*deltaZ
-!            end if
-
-            mindownw = MIN(DOWNW(K+1,I),-0.2)
-            Wn = DOWNW(K+1,I) + (-2.*ENT(K,I)*DOWNW(K+1,I) - &
-                    BCOEFF*B/mindownw)*MIN(deltaZ, 250.)
-
-            !Do not allow a parcel to accelerate more than 1.25 m/s over 200 m.
-            !Add max increase of 2.0 m/s for coarse vertical resolution.
-            IF (Wn < DOWNW(K+1,I) - MIN(1.25*deltaZ/200., 2.0))THEN
-                Wn = DOWNW(K+1,I) - MIN(1.25*deltaZ/200., 2.0)
-            ENDIF
-            !Add symmetrical max decrease in w
-            IF (Wn > DOWNW(K+1,I) + MIN(1.25*deltaZ/200., 2.0))THEN
-                Wn = DOWNW(K+1,I) + MIN(1.25*deltaZ/200., 2.0)
-            ENDIF
-            Wn = MAX(MIN(Wn,0.0), -3.0)
-
-            !print *, "  k       =",      k,      " z    =", ZW(k)
-            !print *, "  entw    =",ENT(K,I),     " Bouy =", B
-            !print *, "  downthv =",   THVn,      " thvk =", thvk
-            !print *, "  downthl =",   THLn,      " thl  =", thl(k)
-            !print *, "  downqt  =",   QTn ,      " qt   =", qt(k)
-            !print *, "  downw+1 =",DOWNW(K+1,I), " Wn2  =", Wn
-
-            IF (Wn .lt. 0.) THEN !terminate when velocity is too small
-               DOWNW(K,I)  = Wn !-sqrt(Wn2)
-               DOWNTHV(K,I)= THVn
-               DOWNTHL(K,I)= THLn
-               DOWNQT(K,I) = QTn
-               DOWNQC(K,I) = QCn
-               DOWNU(K,I)  = Un
-               DOWNV(K,I)  = Vn
-               DOWNA(K,I)  = DOWNA(K+1,I)
-            ELSE
-               !plumes must go at least 2 levels
-               if (DD_initK(I) - K .lt. 2) then
-                  DOWNW(:,I)  = 0.0
-                  DOWNTHV(:,I)= 0.0
-                  DOWNTHL(:,I)= 0.0
-                  DOWNQT(:,I) = 0.0
-                  DOWNQC(:,I) = 0.0
-                  DOWNU(:,I)  = 0.0
-                  DOWNV(:,I)  = 0.0
-               endif
-               exit
-            ENDIF
-         ENDDO
-      ENDDO
-   endif ! end cloud flag
-
-   DOWNW(1,:) = 0. !make sure downdraft does not go to the surface
-   DOWNA(1,:) = 0.
-
-   ! Combine both moist and dry plume, write as one averaged plume
-   ! Even though downdraft starts at different height, average all up to qlTop
-   DO k=qlTop,KTS,-1
-      DO I=1,NDOWN
-         IF (I > NDOWN) exit
-         edmf_a_dd(K)  =edmf_a_dd(K)  +DOWNA(K-1,I)
-         edmf_w_dd(K)  =edmf_w_dd(K)  +DOWNA(K-1,I)*DOWNW(K-1,I)
-         edmf_qt_dd(K) =edmf_qt_dd(K) +DOWNA(K-1,I)*DOWNQT(K-1,I)
-         edmf_thl_dd(K)=edmf_thl_dd(K)+DOWNA(K-1,I)*DOWNTHL(K-1,I)
-         edmf_ent_dd(K)=edmf_ent_dd(K)+DOWNA(K-1,I)*ENT(K-1,I)
-         edmf_qc_dd(K) =edmf_qc_dd(K) +DOWNA(K-1,I)*DOWNQC(K-1,I)
-      ENDDO
-
-      IF (edmf_a_dd(k) >0.) THEN
-          edmf_w_dd(k)  =edmf_w_dd(k)  /edmf_a_dd(k)
-          edmf_qt_dd(k) =edmf_qt_dd(k) /edmf_a_dd(k)
-          edmf_thl_dd(k)=edmf_thl_dd(k)/edmf_a_dd(k)
-          edmf_ent_dd(k)=edmf_ent_dd(k)/edmf_a_dd(k)
-          edmf_qc_dd(k) =edmf_qc_dd(k) /edmf_a_dd(k)
-      ENDIF
-   ENDDO
-
-   !
-   ! computing variables needed for solver
-   !
-
-   DO k=KTS,qlTop
-      rho_int = (rho(k)*DZ(k+1)+rho(k+1)*DZ(k))/(DZ(k+1)+DZ(k))
-      DO I=1,NDOWN
-         sd_aw(k)   =sd_aw(k)   +rho_int*DOWNA(k,i)*DOWNW(k,i)
-         sd_awthl(k)=sd_awthl(k)+rho_int*DOWNA(k,i)*DOWNW(k,i)*DOWNTHL(k,i)
-         sd_awqt(k) =sd_awqt(k) +rho_int*DOWNA(k,i)*DOWNW(k,i)*DOWNQT(k,i)
-         sd_awqc(k) =sd_awqc(k) +rho_int*DOWNA(k,i)*DOWNW(k,i)*DOWNQC(k,i)
-         sd_awu(k)  =sd_awu(k)  +rho_int*DOWNA(k,i)*DOWNW(k,i)*DOWNU(k,i)
-         sd_awv(k)  =sd_awv(k)  +rho_int*DOWNA(k,i)*DOWNW(k,i)*DOWNV(k,i)
-      ENDDO
-      sd_awqv(k) = sd_awqt(k)  - sd_awqc(k)
-   ENDDO
-
-END SUBROUTINE DDMF_JPL
-!===============================================================
-
-
+!>\ingroup gsd_mynn_edmf
+!! This subroutine calculates the similarity functions, 
+!!\f$P_{\sigma-PBL}\f$ and \f$P_{\sigma-shcu}\f$, to control the 
+!! scale-adaptive behavior for the local and nonlocal components,
+!! respectively.
+!!
+!! NOTES ON SCALE-AWARE FORMULATION:
+!!JOE: add scale-aware factor (Psig) here, taken from Honnert et al. (2011,
+!! JAS) and/or from Hyeyum Hailey Shin and Song-You Hong (2013, JAS)
 SUBROUTINE SCALE_AWARE(dx,PBL1,Psig_bl,Psig_shcu)
 
-    !---------------------------------------------------------------
-    !             NOTES ON SCALE-AWARE FORMULATION
-    !
-    !JOE: add scale-aware factor (Psig) here, taken from Honnert et al. (2011,
-    !     JAS) and/or from Hyeyum Hailey Shin and Song-You Hong (2013, JAS)
-    !
     ! Psig_bl tapers local mixing
     ! Psig_shcu tapers nonlocal mixing
 
@@ -7643,220 +6884,6 @@ SUBROUTINE SCALE_AWARE(dx,PBL1,Psig_bl,Psig_shcu)
   END FUNCTION xl_blend
 
 ! ===================================================================
-
-  FUNCTION phim(zet)
-     ! New stability function parameters for momentum (Puhales, 2020, WRF 4.2.1)
-     ! The forms in unstable conditions (z/L < 0) use Grachev et al. (2000), which are a blend of 
-     ! the classical (Kansas) forms (i.e., Paulson 1970, Dyer and Hicks 1970), valid for weakly 
-     ! unstable conditions (-1 < z/L < 0). The stability functions for stable conditions use an
-     ! updated form taken from Cheng and Brutsaert (2005), which extends the validity into very
-     ! stable conditions [z/L ~ O(10)].
-      IMPLICIT NONE
-
-      REAL, INTENT(IN):: zet
-      REAL :: dummy_0,dummy_1,dummy_11,dummy_2,dummy_22,dummy_3,dummy_33,dummy_4,dummy_44,dummy_psi
-      REAL, PARAMETER :: am_st=6.1, bm_st=2.5, rbm_st=1./bm_st
-      REAL, PARAMETER :: ah_st=5.3, bh_st=1.1, rbh_st=1./bh_st
-      REAL, PARAMETER :: am_unst=10., ah_unst=34.
-      REAL :: phi_m,phim
-
-      if ( zet >= 0.0 ) then
-         dummy_0=1+zet**bm_st
-         dummy_1=zet+dummy_0**(rbm_st)
-         dummy_11=1+dummy_0**(rbm_st-1)*zet**(bm_st-1)
-         dummy_2=(-am_st/dummy_1)*dummy_11
-         phi_m = 1-zet*dummy_2
-      else
-         dummy_0 = (1.0-cphm_unst*zet)**0.25
-         phi_m = 1./dummy_0
-         dummy_psi = 2.*log(0.5*(1.+dummy_0))+log(0.5*(1.+dummy_0**2))-2.*atan(dummy_0)+1.570796
-
-         dummy_0=(1.-am_unst*zet)          ! parentesis arg
-         dummy_1=dummy_0**0.333333         ! y
-         dummy_11=-0.33333*am_unst*dummy_0**-0.6666667 ! dy/dzet
-         dummy_2 = 0.33333*(dummy_1**2.+dummy_1+1.)    ! f
-         dummy_22 = 0.3333*dummy_11*(2.*dummy_1+1.)    ! df/dzet
-         dummy_3 = 0.57735*(2.*dummy_1+1.) ! g
-         dummy_33 = 1.1547*dummy_11        ! dg/dzet
-         dummy_4 = 1.5*log(dummy_2)-1.73205*atan(dummy_3)+1.813799364 !psic
-         dummy_44 = (1.5/dummy_2)*dummy_22-1.73205*dummy_33/(1.+dummy_3**2)! dpsic/dzet
-
-         dummy_0 = zet**2
-         dummy_1 = 1./(1.+dummy_0) ! denon
-         dummy_11 = 2.*zet         ! denon/dzet
-         dummy_2 = ((1-phi_m)/zet+dummy_11*dummy_4+dummy_0*dummy_44)*dummy_1
-         dummy_22 = -dummy_11*(dummy_psi+dummy_0*dummy_4)*dummy_1**2
-
-         phi_m = 1.-zet*(dummy_2+dummy_22)
-      end if
-
-      !phim = phi_m - zet
-      phim = phi_m
-
-  END FUNCTION phim
-! ===================================================================
-
-  FUNCTION phih(zet)
-    ! New stability function parameters for heat (Puhales, 2020, WRF 4.2.1)
-    ! The forms in unstable conditions (z/L < 0) use Grachev et al. (2000), which are a blend of
-    ! the classical (Kansas) forms (i.e., Paulson 1970, Dyer and Hicks 1970), valid for weakly
-    ! unstable conditions (-1 < z/L < 0). The stability functions for stable conditions use an
-    ! updated form taken from Cheng and Brutsaert (2005), which extends the validity into very
-    ! stable conditions [z/L ~ O(10)].
-      IMPLICIT NONE
-
-      REAL, INTENT(IN):: zet
-      REAL :: dummy_0,dummy_1,dummy_11,dummy_2,dummy_22,dummy_3,dummy_33,dummy_4,dummy_44,dummy_psi
-      REAL, PARAMETER :: am_st=6.1, bm_st=2.5, rbm_st=1./bm_st
-      REAL, PARAMETER :: ah_st=5.3, bh_st=1.1, rbh_st=1./bh_st
-      REAL, PARAMETER :: am_unst=10., ah_unst=34.
-      REAL :: phh,phih
-
-      if ( zet >= 0.0 ) then
-         dummy_0=1+zet**bh_st
-         dummy_1=zet+dummy_0**(rbh_st)
-         dummy_11=1+dummy_0**(rbh_st-1)*zet**(bh_st-1)
-         dummy_2=(-ah_st/dummy_1)*dummy_11
-         phih = 1-zet*dummy_2
-      else
-         dummy_0 = (1.0-cphh_unst*zet)**0.5
-         phh = 1./dummy_0
-         dummy_psi = 2.*log(0.5*(1.+dummy_0))
-
-         dummy_0=(1.-ah_unst*zet)          ! parentesis arg
-         dummy_1=dummy_0**0.333333         ! y
-         dummy_11=-0.33333*ah_unst*dummy_0**-0.6666667 ! dy/dzet
-         dummy_2 = 0.33333*(dummy_1**2.+dummy_1+1.)    ! f
-         dummy_22 = 0.3333*dummy_11*(2.*dummy_1+1.)    ! df/dzet
-         dummy_3 = 0.57735*(2.*dummy_1+1.) ! g
-         dummy_33 = 1.1547*dummy_11        ! dg/dzet
-         dummy_4 = 1.5*log(dummy_2)-1.73205*atan(dummy_3)+1.813799364 !psic
-         dummy_44 = (1.5/dummy_2)*dummy_22-1.73205*dummy_33/(1.+dummy_3**2)! dpsic/dzet
-
-         dummy_0 = zet**2
-         dummy_1 = 1./(1.+dummy_0)         ! denon
-         dummy_11 = 2.*zet                 ! ddenon/dzet
-         dummy_2 = ((1-phh)/zet+dummy_11*dummy_4+dummy_0*dummy_44)*dummy_1
-         dummy_22 = -dummy_11*(dummy_psi+dummy_0*dummy_4)*dummy_1**2
-
-         phih = 1.-zet*(dummy_2+dummy_22)
-      end if
-
-END FUNCTION phih
-! ==================================================================
- SUBROUTINE topdown_cloudrad(kts,kte,dz1,zw,xland,kpbl,PBLH,  &
-               &sqc,sqi,sqw,thl,th1,ex1,p1,rho1,thetav,       &
-               &cldfra_bl1D,rthraten,                         &
-               &maxKHtopdown,KHtopdown,TKEprodTD              )
-
-    !input
-    integer, intent(in) :: kte,kts
-    real, dimension(kts:kte), intent(in) :: dz1,sqc,sqi,sqw,&
-          thl,th1,ex1,p1,rho1,thetav,cldfra_bl1D,rthraten
-    real, dimension(kts:kte+1), intent(in) :: zw
-    real, intent(in) :: pblh,xland
-    integer,intent(in) :: kpbl
-    !output
-    real, intent(out) :: maxKHtopdown
-    real, dimension(kts:kte), intent(out) :: KHtopdown,TKEprodTD
-    !local
-    real, dimension(kts:kte) :: zfac,wscalek2,zfacent
-    real :: bfx0,sflux,wm2,wm3,h1,h2,bfxpbl,dthvx,tmp1
-    real :: temps,templ,zl1,wstar3_2
-    real :: ent_eff,radsum,radflux,we,rcldb,rvls,minrad,zminrad
-    real, parameter :: pfac =2.0, zfmin = 0.01, phifac=8.0
-    integer :: k,kk,kminrad
-    logical :: cloudflg
-
-    cloudflg=.false.
-    minrad=100.
-    kminrad=kpbl
-    zminrad=PBLH
-    KHtopdown(kts:kte)=0.0
-    TKEprodTD(kts:kte)=0.0
-    maxKHtopdown=0.0
-
-    !CHECK FOR STRATOCUMULUS-TOPPED BOUNDARY LAYERS
-    DO kk = MAX(1,kpbl-2),kpbl+3
-       if (sqc(kk).gt. 1.e-6 .OR. sqi(kk).gt. 1.e-6 .OR. &
-           cldfra_bl1D(kk).gt.0.5) then
-          cloudflg=.true.
-       endif
-       if (rthraten(kk) < minrad)then
-          minrad=rthraten(kk)
-          kminrad=kk
-          zminrad=zw(kk) + 0.5*dz1(kk)
-       endif
-    ENDDO
-
-    IF (MAX(kminrad,kpbl) < 2)cloudflg = .false.
-    IF (cloudflg) THEN
-       zl1 = dz1(kts)
-       k = MAX(kpbl-1, kminrad-1)
-       !Best estimate of height of TKE source (top of downdrafts):
-       !zminrad = 0.5*pblh(i) + 0.5*zminrad
-
-       templ=thl(k)*ex1(k)
-       !rvls is ws at full level
-       rvls=100.*6.112*EXP(17.67*(templ-273.16)/(templ-29.65))*(ep_2/p1(k+1))
-       temps=templ + (sqw(k)-rvls)/(cp/xlv  +  ep_2*xlv*rvls/(rd*templ**2))
-       rvls=100.*6.112*EXP(17.67*(temps-273.15)/(temps-29.65))*(ep_2/p1(k+1))
-       rcldb=max(sqw(k)-rvls,0.)
-
-       !entrainment efficiency
-       dthvx     = (thl(k+2) + th1(k+2)*ep_1*sqw(k+2)) &
-                 - (thl(k)   + th1(k)  *ep_1*sqw(k))
-       dthvx     = max(dthvx,0.1)
-       tmp1      = xlvcp * rcldb/(ex1(k)*dthvx)
-       !Originally from Nichols and Turton (1986), where a2 = 60, but lowered
-       !here to 8, as in Grenier and Bretherton (2001).
-       ent_eff   = 0.2 + 0.2*8.*tmp1
-
-       radsum=0.
-       DO kk = MAX(1,kpbl-3),kpbl+3
-          radflux=rthraten(kk)*ex1(kk)         !converts theta/s to temp/s
-          radflux=radflux*cp/g*(p1(kk)-p1(kk+1)) ! converts temp/s to W/m^2
-          if (radflux < 0.0 ) radsum=abs(radflux)+radsum
-       ENDDO
-
-       !More strict limits over land to reduce stable-layer mixouts
-       if ((xland-1.5).GE.0)THEN      ! WATER
-          radsum=MIN(radsum,90.0)
-          bfx0 = max(radsum/rho1(k)/cp,0.)
-       else                           ! LAND
-          radsum=MIN(0.25*radsum,30.0)!practically turn off over land
-          bfx0 = max(radsum/rho1(k)/cp - max(sflux,0.0),0.)
-       endif
-
-       !entrainment from PBL top thermals
-       wm3    = g/thetav(k)*bfx0*MIN(pblh,1500.) ! this is wstar3(i)
-       wm2    = wm2 + wm3**h2
-       bfxpbl = - ent_eff * bfx0
-       dthvx  = max(thetav(k+1)-thetav(k),0.1)
-       we     = max(bfxpbl/dthvx,-sqrt(wm3**h2))
-
-       DO kk = kts,kpbl+3
-          !Analytic vertical profile
-          zfac(kk) = min(max((1.-(zw(kk+1)-zl1)/(zminrad-zl1)),zfmin),1.)
-          zfacent(kk) = 10.*MAX((zminrad-zw(kk+1))/zminrad,0.0)*(1.-zfac(kk))**3
-
-          !Calculate an eddy diffusivity profile (not used at the moment)
-          wscalek2(kk) = (phifac*karman*wm3*(zfac(kk)))**h1
-          !Modify shape of Kh to be similar to Lock et al (2000): use pfac = 3.0
-          KHtopdown(kk) = wscalek2(kk)*karman*(zminrad-zw(kk+1))*(1.-zfac(kk))**3 !pfac
-          KHtopdown(kk) = MAX(KHtopdown(kk),0.0)
-
-          !Calculate TKE production = 2(g/TH)(w'TH'), where w'TH' = A(TH/g)wstar^3/PBLH,
-          !A = ent_eff, and wstar is associated with the radiative cooling at top of PBL.
-          !An analytic profile controls the magnitude of this TKE prod in the vertical.
-          TKEprodTD(kk)=2.*ent_eff*wm3/MAX(pblh,100.)*zfacent(kk)
-          TKEprodTD(kk)= MAX(TKEprodTD(kk),0.0)
-       ENDDO
-    ENDIF !end cloud check
-    maxKHtopdown=MAXVAL(KHtopdown(:))
-
- END SUBROUTINE topdown_cloudrad
-! ==================================================================
 ! ===================================================================
 ! ===================================================================
 


### PR DESCRIPTION
With the recent work of updating Thompson microphysics and cloud fraction scheme for use in UFS/GFS (and RRFS), I altered the MYNN-PBL scheme to include a new cloudpdf option (=3) that basically swaps out the Chaboureau-Bechtold cloud fraction scheme with the updated one from Thompson.  It should only act on the "stratus" clouds by estimating the cloud fraction, liquid, and ice amounts differently than the C-B scheme.

The very large number of changes in module_bl_mynn.F90 are because I got the code from GSL's repo which has a large series of changes by Joe Olson that are not yet merged into the CCPP-Physics repo so once this repo gets updated with Joe's changes, a large number of discrepancies will drop away leaving only my far smaller set of changes.