### PR TITLE
Code update for radiation_clouds.f and GFS_rrtmg_pre.F90 GFS_cloud_di…

### DIFF
--- a/physics/GFS_cloud_diagnostics.F90
+++ b/physics/GFS_cloud_diagnostics.F90
@@ -46,10 +46,10 @@ contains
     implicit none
      
     ! Inputs 
-    integer, intent(in) :: &
-         nCol,              & ! Number of horizontal grid-points
-         nLev                 ! Number of vertical-layers
-    integer, intent(in)  ::                                     &
+    integer, intent(in) ::                 &
+         nCol,                             & ! Number of horizontal grid-points
+         nLev                                ! Number of vertical-layers
+    integer, intent(in) ::                 &
          iovr_rand,                        & ! Flag for random cloud overlap method
          iovr_maxrand,                     & ! Flag for maximum-random cloud overlap method
          iovr_max,                         & ! Flag for maximum cloud overlap method
@@ -57,33 +57,33 @@ contains
          iovr_exp,                         & ! Flag for exponential cloud overlap method
          iovr_exprand                        ! Flag for exponential-random cloud overlap method
     logical, intent(in) :: &
-    	 lsswr,             & ! Call SW radiation?
-    	 lslwr                ! Call LW radiation 
-    real(kind_phys), intent(in) :: &
-         con_pi               ! Physical constant: pi  
-    real(kind_phys), dimension(:), intent(in) :: &
-         lat,               & ! Latitude       
-         de_lgth              ! Decorrelation length     
+    	 lsswr,                            & ! Call SW radiation?
+    	 lslwr                               ! Call LW radiation 
+    real(kind_phys), intent(in) ::         &
+         con_pi                              ! Physical constant: pi  
+    real(kind_phys), dimension(:), intent(in) ::   &
+         lat,                                      & ! Latitude       
+         de_lgth                                     ! Decorrelation length     
     real(kind_phys), dimension(:,:), intent(in) :: &
-         p_lay,             & ! Pressure at model-layer
-         cld_frac             ! Total cloud fraction
+         p_lay,                                    & ! Pressure at model-layer
+         cld_frac                                    ! Total cloud fraction
     real(kind_phys), dimension(:,:), intent(in) :: &
-         p_lev                ! Pressure at model interfaces         
+         p_lev                                       ! Pressure at model interfaces         
     real(kind_phys), dimension(:,:), intent(in) :: &
-    	 deltaZ,              & ! Layer thickness (km)
-         cloud_overlap_param, & ! Cloud-overlap parameter
-         precip_overlap_param   ! Precipitation overlap parameter
+    	 deltaZ,                                   & ! Layer thickness (km)
+         cloud_overlap_param,                      & ! Cloud-overlap parameter
+         precip_overlap_param                        ! Precipitation overlap parameter
     
     ! Outputs
-    character(len=*), intent(out) :: &
-         errmsg                 ! Error message
-    integer, intent(out) :: &  
-         errflg                 ! Error flag
-    integer,dimension(:,:),intent(out) :: &
-         mbota,               & ! Vertical indices for cloud tops
-         mtopa                  ! Vertical indices for cloud bases
-    real(kind_phys), dimension(:,:), intent(out) :: &
-         cldsa                  ! Fraction of clouds for low, middle, high, total and BL 
+    character(len=*), intent(out) ::               &
+         errmsg                                      ! Error message
+    integer, intent(out) ::                        &  
+         errflg                                      ! Error flag
+    integer,dimension(:,:),intent(out) ::          &
+         mbota,                                    & ! Vertical indices for cloud tops
+         mtopa                                       ! Vertical indices for cloud bases
+    real(kind_phys),dimension(:,:), intent(out) :: &
+         cldsa                                       ! Fraction of clouds for low, middle, high, total and BL 
     
     ! Local variables
     integer i,id,iCol,iLay,icld
@@ -125,76 +125,6 @@ contains
   end subroutine GFS_cloud_diagnostics_finalize
   
   ! ######################################################################################
-  ! Initialization routine for High/Mid/Low cloud diagnostics. 
+  ! Subroutine hml_cloud_diagnostics_initialize is removed (refer to GFS_rrtmgp_setup.F90) 
   ! ######################################################################################
-  subroutine hml_cloud_diagnostics_initialize(imp_physics, imp_physics_fer_hires,        &
-          imp_physics_gfdl, imp_physics_thompson, imp_physics_wsm6,                      &
-          imp_physics_zhao_carr, imp_physics_zhao_carr_pdf, imp_physics_mg, nLev,        &
-          mpi_rank, sigmainit, errflg)
-    implicit none
-    ! Inputs
-    integer, intent(in) :: &
-          imp_physics,               & ! Flag for MP scheme
-          imp_physics_fer_hires,     & ! Flag for fer-hires scheme
-          imp_physics_gfdl,          & ! Flag for gfdl scheme
-          imp_physics_thompson,      & ! Flag for thompsonscheme
-          imp_physics_wsm6,          & ! Flag for wsm6 scheme
-          imp_physics_zhao_carr,     & ! Flag for zhao-carr scheme
-          imp_physics_zhao_carr_pdf, & ! Flag for zhao-carr+PDF scheme
-          imp_physics_mg               ! Flag for MG scheme
-    integer, intent(in) :: &
-         nLev,        & ! Number of vertical-layers
-         mpi_rank 
-    real(kind_phys), dimension(:), intent(in) :: &
-         sigmainit
-    ! Outputs
-    integer, intent(out) :: &
-    	errflg
-    
-    ! Local variables
-    integer :: iLay, kl
- 
-    ! Initialize error flag
-    errflg = 0
-    
-    if (mpi_rank == 0) print *, VTAGCLD      !print out version tag
-    
-    if ( icldflg == 0 ) then
-       print *,' - Diagnostic Cloud Method has been discontinued'
-       errflg = 1
-    else
-       if (mpi_rank == 0) then
-          print *,' - Using Prognostic Cloud Method'
-          if (imp_physics == imp_physics_zhao_carr) then
-             print *,'   --- Zhao/Carr/Sundqvist microphysics'
-          elseif (imp_physics == imp_physics_zhao_carr_pdf) then
-             print *,'   --- zhao/carr/sundqvist + pdf cloud'
-          elseif (imp_physics == imp_physics_gfdl) then
-             print *,'   --- GFDL Lin cloud microphysics'
-          elseif (imp_physics == imp_physics_thompson) then
-             print *,'   --- Thompson cloud microphysics'
-          elseif (imp_physics == imp_physics_wsm6) then
-             print *,'   --- WSM6 cloud microphysics'
-          elseif (imp_physics == imp_physics_mg) then
-             print *,'   --- MG cloud microphysics'
-          elseif (imp_physics == imp_physics_fer_hires) then
-             print *,'   --- Ferrier-Aligo cloud microphysics'
-          else
-             print *,'  !!! ERROR in cloud microphysc specification!!!', &
-                  '  imp_physics (NP3D) =',imp_physics
-             errflg = 1
-          endif
-       endif
-    endif
-    
-    ! Compute the top of BL cld (llyr), which is the topmost non cld(low) layer for 
-    ! stratiform (at or above lowest 0.1 of the atmosphere).
-    lab_do_k0 : do iLay = nLev, 2, -1
-       kl = iLay
-       if (sigmainit(iLay) < 0.9e0) exit lab_do_k0
-    enddo  lab_do_k0
-    llyr = kl      
-    
-    return
-  end subroutine hml_cloud_diagnostics_initialize
 end module GFS_cloud_diagnostics

--- a/physics/GFS_cloud_diagnostics.F90
+++ b/physics/GFS_cloud_diagnostics.F90
@@ -39,7 +39,8 @@ contains
 !! \section arg_table_GFS_cloud_diagnostics_run
 !! \htmlinclude GFS_cloud_diagnostics_run.html
 !!  
-  subroutine GFS_cloud_diagnostics_run(nCol, nLev, lsswr, lslwr, lat, de_lgth, p_lay,    &
+  subroutine GFS_cloud_diagnostics_run(nCol, nLev, iovr_rand, iovr_maxrand, iovr_max,    & 
+       iovr_dcorr, iovr_exp, iovr_exprand, lsswr, lslwr, lat, de_lgth, p_lay,            &
        cld_frac, p_lev, deltaZ, cloud_overlap_param, precip_overlap_param, con_pi,       &
        mtopa, mbota, cldsa, errmsg, errflg)
     implicit none
@@ -48,6 +49,13 @@ contains
     integer, intent(in) :: &
          nCol,              & ! Number of horizontal grid-points
          nLev                 ! Number of vertical-layers
+    integer, intent(in)  ::                                     &
+         iovr_rand,                        & ! Flag for random cloud overlap method
+         iovr_maxrand,                     & ! Flag for maximum-random cloud overlap method
+         iovr_max,                         & ! Flag for maximum cloud overlap method
+         iovr_dcorr,                       & ! Flag for decorrelation-length cloud overlap method
+         iovr_exp,                         & ! Flag for exponential cloud overlap method
+         iovr_exprand                        ! Flag for exponential-random cloud overlap method
     logical, intent(in) :: &
     	 lsswr,             & ! Call SW radiation?
     	 lslwr                ! Call LW radiation 
@@ -106,7 +114,8 @@ contains
     ! defined by ptopc. The cloud overlapping method is defined by control flag 'iovr', which may
     ! be different for lw and sw radiation programs.
     call gethml(p_lay/100., ptop1, cld_frac, cldcnv, deltaZ, de_lgth, cloud_overlap_param,&
-         nCol, nLev, cldsa, mtopa, mbota)	
+         nCol, nLev, iovr_rand, iovr_maxrand, iovr_max, iovr_dcorr, iovr_exp,             &
+         iovr_exprand, cldsa, mtopa, mbota)	
     
   end subroutine GFS_cloud_diagnostics_run
   

--- a/physics/GFS_cloud_diagnostics.meta
+++ b/physics/GFS_cloud_diagnostics.meta
@@ -20,6 +20,48 @@
   dimensions = ()
   type = integer
   intent = in
+[iovr_rand]
+  standard_name = flag_for_random_cloud_overlap_method
+  long_name = choice of random cloud overlap method
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+[iovr_maxrand]
+  standard_name = flag_for_maximum_random_cloud_overlap_method
+  long_name = choice of maximum-random cloud overlap method
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+[iovr_max]
+  standard_name = flag_for_maximum_cloud_overlap_method
+  long_name = choice of maximum cloud overlap method
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+[iovr_dcorr]
+  standard_name = flag_for_decorrelation_length_cloud_overlap_method
+  long_name = choice of decorrelation-length cloud overlap method
+  units     = flag
+  dimensions = ()
+  type = integer
+  intent = in
+[iovr_exp]
+  standard_name = flag_for_exponential_cloud_overlap_method
+  long_name = choice of exponential cloud overlap method
+  units     = flag
+  dimensions = ()
+  type = integer
+  intent = in
+[iovr_exprand]
+  standard_name = flag_for_exponential_random_cloud_overlap_method
+  long_name = choice of exponential-random cloud overlap method
+  units     = flag
+  dimensions = ()
+  type = integer
+  intent = in
 [lsswr]
   standard_name = flag_for_calling_shortwave_radiation
   long_name = logical flags for sw radiation calls

--- a/physics/GFS_rrtmg_pre.F90
+++ b/physics/GFS_rrtmg_pre.F90
@@ -22,7 +22,9 @@
         ntclamt, nleffr, nieffr, nseffr, lndp_type, kdt, imp_physics,          &
         imp_physics_thompson, imp_physics_gfdl, imp_physics_zhao_carr,         &
         imp_physics_zhao_carr_pdf, imp_physics_mg, imp_physics_wsm6,           &
-        imp_physics_fer_hires, julian, yearlen, lndp_var_list, lsswr, lslwr,   &
+        imp_physics_fer_hires, iovr_rand, iovr_maxrand, iovr_max, iovr_dcorr,  &
+        iovr_exp, iovr_exprand, idcor_con, idcor_hogan, idcor_oreopoulos,      & 
+        julian, yearlen, lndp_var_list, lsswr, lslwr,                          &
         ltaerosol, lgfdlmprad, uni_cld, effr_in, do_mynnedmf, lmfshal,         &
         lmfdeep2, fhswr, fhlwr, solhr, sup, con_eps, epsm1, fvirt,             &
         rog, rocp, con_rd, xlat_d, xlat, xlon, coslat, sinlat, tsfc, slmsk,    &
@@ -51,12 +53,7 @@
       use module_radiation_aerosols, only: NF_AESW, NF_AELW, setaer, & ! aer_init, aer_update,
      &                                     NSPC1
       use module_radiation_clouds,   only: NF_CLDS,                  & ! cld_init
-     &                                     progcld1, progcld3,       &
-     &                                     progcld2,                 &
-     &                                     progcld4, progcld5,       &
-     &                                     progcld6,                 &
-     &                                     progcld_thompson,         &
-     &                                     progclduni,               &
+     &                                     radiation_clouds_prop,    &
      &                                     cal_cldfra3,              &
      &                                     find_cloudLayers,         &
      &                                     adjust_cloudIce,          &
@@ -97,6 +94,17 @@
                                            imp_physics_mg, imp_physics_wsm6,   &
                                            imp_physics_fer_hires,              &
                                            yearlen, icloud
+
+      integer,              intent(in)  ::                                     &
+         iovr_rand,                        & ! Flag for random cloud overlap method
+         iovr_maxrand,                     & ! Flag for maximum-random cloud overlap method
+         iovr_max,                         & ! Flag for maximum cloud overlap method
+         iovr_dcorr,                       & ! Flag for decorrelation-length cloud overlap method
+         iovr_exp,                         & ! Flag for exponential cloud overlap method
+         iovr_exprand,                     & ! Flag for exponential-random cloud overlap method
+         idcor_con,                        &
+         idcor_hogan,                      &
+         idcor_oreopoulos                            
 
       character(len=3), dimension(:), intent(in) :: lndp_var_list
 
@@ -206,7 +214,9 @@
 
       real(kind=kind_phys), dimension(im,lm+LTP,min(4,ncnd))   :: ccnd
       real(kind=kind_phys), dimension(im,lm+LTP,2:ntrac)       :: tracer1
-      real(kind=kind_phys), dimension(im,lm+LTP,NF_CLDS)       :: clouds
+      real(kind=kind_phys), dimension(im,lm+LTP)               ::        &
+     &   cld_frac, cld_lwp, cld_reliq, cld_iwp, cld_reice,               &
+     &   cld_rwp, cld_rerain, cld_swp, cld_resnow
       real(kind=kind_phys), dimension(im,lm+LTP,NF_VGAS)       :: gasvmr
       real(kind=kind_phys), dimension(im,lm+LTP,NBDSW,NF_AESW) :: faersw
       real(kind=kind_phys), dimension(im,lm+LTP,NBDLW,NF_AELW) :: faerlw
@@ -613,9 +623,9 @@
 !!    (clouds,cldsa,mtopa,mbota)
 !!\n   for  prognostic cloud:
 !!    - For Zhao/Moorthi's prognostic cloud scheme,
-!!      call module_radiation_clouds::progcld1()
+!!      call module_radiation_clouds::progcld_zhao_carr()
 !!    - For Zhao/Moorthi's prognostic cloud+pdfcld,
-!!      call module_radiation_clouds::progcld3()
+!!      call module_radiation_clouds::progcld_zhao_carr_pdf()
 !!      call module_radiation_clouds::progclduni() for unified cloud and ncnd>=2
 
 !  --- ...  obtain cloud information for radiation calculations
@@ -882,135 +892,29 @@
           ccnd(1:IM,1:LMK,1) = ccnd(1:IM,1:LMK,1) + cnvw(1:IM,1:LMK)
         endif
 
-        if (imp_physics == imp_physics_zhao_carr .or. imp_physics == imp_physics_mg) then ! zhao/moorthi's prognostic cloud scheme
-                                         ! or unified cloud and/or with MG microphysics
+        call radiation_clouds_prop                                      &
+     &     ( plyr, plvl, tlyr, tvly, qlyr, qstl, rhly,                  &    !  ---  inputs:
+     &       ccnd, ncndl, cnvw, cnvc, tracer1,                          &
+     &       xlat, xlon, slmsk, dz, delp, IM, LM, LMK, LMP,             &
+     &       deltaq, sup, me, icloud, kdt,                              &
+     &       ntrac, ntcw, ntiw, ntrw, ntsw, ntgl, ntclamt,              &
+     &       imp_physics, imp_physics_fer_hires,imp_physics_gfdl,       &
+     &       imp_physics_thompson, imp_physics_wsm6,                    &
+     &       imp_physics_zhao_carr, imp_physics_zhao_carr_pdf,          &
+     &       imp_physics_mg, iovr_rand, iovr_maxrand, iovr_max,         &
+     &       iovr_dcorr, iovr_exp, iovr_exprand, idcor_con,             &
+     &       idcor_hogan, idcor_oreopoulos,                             &
+     &       imfdeepcnv, imfdeepcnv_gf, do_mynnedmf, lgfdlmprad,        &
+     &       uni_cld, lmfshal, lmfdeep2, cldcov, clouds1,               &
+     &       effrl, effri, effrr, effrs, effr_in,                       &
+     &       effrl_inout, effri_inout, effrs_inout,                     &
+     &       lwp_ex, iwp_ex, lwp_fc, iwp_fc,                            &
+     &       dzb, xlat_d, julian, yearlen, gridkm,                      &
+     &       cld_frac, cld_lwp, cld_reliq, cld_iwp, cld_reice,          &    !  ---  outputs:
+     &       cld_rwp, cld_rerain, cld_swp, cld_resnow,                  &    !  ---  outputs:
+     &       cldsa, mtopa, mbota, de_lgth, alpha                        &    !  ---  outputs:
+     &      )
 
-          if (uni_cld .and. ncndl >= 2) then
-            call progclduni (plyr, plvl, tlyr, tvly, ccnd, ncndl,         & !  ---  inputs
-                             xlat, xlon, slmsk, dz, delp,                 &
-                             IM, LMK, LMP, cldcov,                        &
-                             effrl, effri, effrr, effrs, effr_in,         &
-                             dzb, xlat_d, julian, yearlen,                &
-                             clouds, cldsa, mtopa, mbota, de_lgth, alpha)   !  ---  outputs
-          else
-            call progcld1 (plyr ,plvl, tlyr, tvly, qlyr, qstl, rhly,      & !  ---  inputs
-                           ccnd(1:IM,1:LMK,1), xlat, xlon, slmsk, dz,     &
-                           delp, IM, LMK, LMP, uni_cld, lmfshal, lmfdeep2,&
-                           cldcov, effrl, effri, effrr, effrs, effr_in,   &
-                           dzb, xlat_d, julian, yearlen,                  &
-                           clouds, cldsa, mtopa, mbota, de_lgth, alpha)     !  ---  outputs
-          endif
-
-        elseif(imp_physics == imp_physics_zhao_carr_pdf) then      ! zhao/moorthi's prognostic cloud+pdfcld
-
-          call progcld3 (plyr, plvl, tlyr, tvly, qlyr, qstl, rhly,        &  !  ---  inputs
-                         ccnd(1:IM,1:LMK,1), cnvw, cnvc, xlat, xlon,      &
-                         slmsk, dz, delp, im, lmk, lmp, deltaq, sup, kdt, &
-                         me, dzb, xlat_d, julian, yearlen,                &
-                         clouds, cldsa, mtopa, mbota, de_lgth, alpha)        !  ---  outputs
-
-        elseif (imp_physics == imp_physics_gfdl) then           ! GFDL cloud scheme
-
-          if (.not. lgfdlmprad) then
-            call progcld4 (plyr, plvl, tlyr, tvly, qlyr, qstl, rhly,      &    !  ---  inputs
-                           ccnd(1:IM,1:LMK,1), cnvw, cnvc, xlat, xlon,    &
-                           slmsk, cldcov, dz, delp, im, lmk, lmp,         &
-                           dzb, xlat_d, julian, yearlen,                  &
-                           clouds, cldsa, mtopa, mbota, de_lgth, alpha)        !  ---  outputs
-          else
-
-            call progclduni (plyr, plvl, tlyr, tvly, ccnd, ncndl, xlat,   &    !  ---  inputs
-                            xlon, slmsk, dz,delp, IM, LMK, LMP, cldcov,   &
-                            effrl, effri, effrr, effrs, effr_in,          &
-                            dzb, xlat_d, julian, yearlen,                 &
-                            clouds, cldsa, mtopa, mbota, de_lgth, alpha)       !  ---  outputs
-!           call progcld4o (plyr, plvl, tlyr, tvly, qlyr, qstl, rhly,       &   !  ---  inputs
-!                           tracer1, xlat, xlon, slmsk, dz, delp,           &
-!                           ntrac-1, ntcw-1,ntiw-1,ntrw-1,                  &
-!                           ntsw-1,ntgl-1,ntclamt-1,                        &
-!                           im, lmk, lmp,                                   &
-!                           dzb, xlat_d, julian, yearlen,                   &
-!                           clouds, cldsa, mtopa, mbota, de_lgth, alpha)        !  ---  outputs
-          endif
-
-        elseif(imp_physics == imp_physics_fer_hires) then
-          if (kdt == 1) then
-            effrl_inout(:,:) = 10.
-            effri_inout(:,:) = 50.
-            effrs_inout(:,:) = 250.
-          endif
-
-          call progcld5 (plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,tracer1,       &  !  --- inputs
-                         xlat,xlon,slmsk,dz,delp,                          &
-                         ntrac-1, ntcw-1,ntiw-1,ntrw-1,                    &
-                         im, lmk, lmp, icloud, uni_cld, lmfshal, lmfdeep2, &
-                         cldcov(:,1:LMK),effrl_inout(:,:),                 &
-                         effri_inout(:,:), effrs_inout(:,:),               &
-                         dzb, xlat_d, julian, yearlen,                     &
-                         clouds,cldsa,mtopa,mbota, de_lgth, alpha)            !  --- outputs
-
-        elseif(imp_physics == imp_physics_thompson) then                              ! Thompson MP
-
-          if(do_mynnedmf .or. imfdeepcnv == imfdeepcnv_gf ) then ! MYNN PBL or GF conv
-
-            if (icloud == 3) then
-              call progcld_thompson (plyr,plvl,tlyr,qlyr,qstl,rhly, & !  --- inputs
-                         tracer1,xlat,xlon,slmsk,dz,delp,           &
-                         ntrac-1, ntcw-1,ntiw-1,ntrw-1,             &
-                         ntsw-1,ntgl-1,                             &
-                         im, lm, lmp, uni_cld, lmfshal, lmfdeep2,   &
-                         cldcov(:,1:LM), effrl, effri, effrs,       &
-                         lwp_ex, iwp_ex, lwp_fc, iwp_fc,            &
-                         dzb, xlat_d, julian, yearlen, gridkm,      &
-                         clouds, cldsa, mtopa ,mbota, de_lgth, alpha) !  --- outputs
-            else
-
-              !-- MYNN PBL or convective GF
-              !-- use cloud fractions with SGS clouds
-              do k=1,lmk
-                do i=1,im
-                  clouds(i,k,1)  = clouds1(i,k)
-                enddo
-              enddo
-
-                ! --- use clduni as with the GFDL microphysics.
-                ! --- make sure that effr_in=.true. in the input.nml!
-                call progclduni (plyr, plvl, tlyr, tvly, ccnd, ncndl,   & !  ---  inputs
-                         xlat, xlon, slmsk, dz, delp, IM, LMK, LMP,     &
-                         clouds(:,1:LMK,1),                             &
-                         effrl, effri, effrr, effrs, effr_in ,          &
-                         dzb, xlat_d, julian, yearlen,                  &
-                         clouds, cldsa, mtopa, mbota, de_lgth, alpha)     !  ---  outputs
-            endif
-
-          else
-            ! MYNN PBL or GF convective are not used
-
-            if (icloud == 3) then
-              call progcld_thompson (plyr,plvl,tlyr,qlyr,qstl,rhly, & !  --- inputs
-                         tracer1,xlat,xlon,slmsk,dz,delp,           &
-                         ntrac-1, ntcw-1,ntiw-1,ntrw-1,             &
-                         ntsw-1,ntgl-1,                             &
-                         im, lm, lmp, uni_cld, lmfshal, lmfdeep2,   &
-                         cldcov(:,1:LM), effrl, effri, effrs,       &
-                         lwp_ex, iwp_ex, lwp_fc, iwp_fc,            &
-                         dzb, xlat_d, julian, yearlen, gridkm,      &
-                         clouds, cldsa, mtopa ,mbota, de_lgth, alpha) !  --- outputs
-
-            else
-              call progcld6 (plyr,plvl,tlyr,qlyr,qstl,rhly,         & !  --- inputs
-                         tracer1,xlat,xlon,slmsk,dz,delp,           &
-                         ntrac-1, ntcw-1,ntiw-1,ntrw-1,             &
-                         ntsw-1,ntgl-1,                             &
-                         im, lmk, lmp, uni_cld, lmfshal, lmfdeep2,  &
-                         cldcov(:,1:LMK), cnvw, effrl, effri, effrs,&
-                         lwp_ex, iwp_ex, lwp_fc, iwp_fc,            &
-                         dzb, xlat_d, julian, yearlen,              &
-                         clouds, cldsa, mtopa ,mbota, de_lgth, alpha) !  --- outputs
-            endif
-          endif ! MYNN PBL or GF
-
-        endif                            ! end if_imp_physics
 
 !      endif                             ! end_if_ntcw
 
@@ -1024,7 +928,7 @@
           do k = 1, LMK
              do i = 1, IM
                 ! compute beta distribution parameters
-                m = clouds(i,k,1)
+                m = cld_frac(i,k)
                 if (m<0.99 .AND. m > 0.01) then
                    s = sppt_amp*m*(1.-m)
                    alpha0 = m*m*(1.-m)/(s*s)-m
@@ -1032,25 +936,25 @@
            ! compute beta distribution value corresponding
            ! to the given percentile albPpert to use as new albedo
                    call ppfbet(cldp1d(i),alpha0,beta0,iflag,cldtmp)
-                   clouds(i,k,1) = cldtmp
+                   cld_frac(i,k) = cldtmp
                 else
-                   clouds(i,k,1) = m
+                   cld_frac(i,k) = m
                 endif
              enddo     ! end_do_i_loop
           enddo     ! end_do_k_loop
        endif
        do k = 1, LM
          do i = 1, IM
-            clouds1(i,k)  = clouds(i,k,1)
-            clouds2(i,k)  = clouds(i,k,2)
-            clouds3(i,k)  = clouds(i,k,3)
-            clouds4(i,k)  = clouds(i,k,4)
-            clouds5(i,k)  = clouds(i,k,5)
-            clouds6(i,k)  = clouds(i,k,6)
-            clouds7(i,k)  = clouds(i,k,7)
-            clouds8(i,k)  = clouds(i,k,8)
-            clouds9(i,k)  = clouds(i,k,9)
-            cldfra(i,k)   = clouds(i,k,1)
+            clouds1(i,k)  = cld_frac(i,k)
+            clouds2(i,k)  = cld_lwp(i,k)
+            clouds3(i,k)  = cld_reliq(i,k)
+            clouds4(i,k)  = cld_iwp(i,k)
+            clouds5(i,k)  = cld_reice(i,k)
+            clouds6(i,k)  = cld_rwp(i,k)
+            clouds7(i,k)  = cld_rerain(i,k)
+            clouds8(i,k)  = cld_swp(i,k)
+            clouds9(i,k)  = cld_resnow(i,k)
+            cldfra(i,k)   = cld_frac(i,k)
          enddo
        enddo
        do i = 1, IM

--- a/physics/GFS_rrtmg_pre.meta
+++ b/physics/GFS_rrtmg_pre.meta
@@ -275,6 +275,69 @@
   dimensions = ()
   type = integer
   intent = in
+[iovr_rand]
+  standard_name = flag_for_random_cloud_overlap_method
+  long_name = choice of random cloud overlap method
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+[iovr_maxrand]
+  standard_name = flag_for_maximum_random_cloud_overlap_method
+  long_name = choice of maximum-random cloud overlap method
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+[iovr_max]
+  standard_name = flag_for_maximum_cloud_overlap_method
+  long_name = choice of maximum cloud overlap method
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+[iovr_dcorr]
+  standard_name = flag_for_decorrelation_length_cloud_overlap_method
+  long_name = choice of decorrelation-length cloud overlap method
+  units     = flag
+  dimensions = ()
+  type = integer
+  intent = in
+[iovr_exp]
+  standard_name = flag_for_exponential_cloud_overlap_method
+  long_name = choice of exponential cloud overlap method
+  units     = flag
+  dimensions = ()
+  type = integer
+  intent = in
+[iovr_exprand]
+  standard_name = flag_for_exponential_random_cloud_overlap_method
+  long_name = choice of exponential-random cloud overlap method
+  units     = flag
+  dimensions = ()
+  type = integer
+  intent = in
+[idcor_con]
+  standard_name = flag_for_constant_decorrelation_length_method
+  long_name = choice of decorrelation length computation (costant)
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+[idcor_hogan]
+  standard_name = flag_for_hogan_decorrelation_length_method
+  long_name = choice of decorrelation length computation (hogan)
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+[idcor_oreopoulos]
+  standard_name = flag_for_oreopoulos_decorrelation_length_method
+  long_name = choice of decorrelation length computation (oreopoulos)
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
 [julian]
   standard_name = forecast_julian_day
   long_name = julian day

--- a/physics/GFS_rrtmgp_cloud_overlap_pre.F90
+++ b/physics/GFS_rrtmgp_cloud_overlap_pre.F90
@@ -4,7 +4,7 @@
 module GFS_rrtmgp_cloud_overlap_pre
   use machine,      only: kind_phys
   use radiation_tools,   only: check_error_msg
-  use module_radiation_cloud_overlap, only: cmp_dcorr_lgth, get_alpha_exp  
+  use module_radiation_cloud_overlap, only: cmp_dcorr_lgth, get_alpha_exper  
 
   public GFS_rrtmgp_cloud_overlap_pre_init, GFS_rrtmgp_cloud_overlap_pre_run, GFS_rrtmgp_cloud_overlap_pre_finalize
 
@@ -149,24 +149,25 @@ contains
     ! Cloud overlap parameter
     !
     if (iovr == iovr_dcorr .or. iovr == iovr_exp .or. iovr == iovr_exprand) then
-       call get_alpha_exp(nCol, nLev, deltaZc, de_lgth, cloud_overlap_param)
+       call get_alpha_exper(nCol, nLev, iovr, iovr_exprand, deltaZc,        &
+                            de_lgth, cld_frac, cloud_overlap_param)
     else
        de_lgth(:)               = 0.
        cloud_overlap_param(:,:) = 0.
     endif
 
-    ! For exponential random overlap...
-    ! Decorrelate layers when a clear layer follows a cloudy layer to enforce
-    ! random correlation between non-adjacent blocks of cloudy layers
-    if (iovr == iovr_exprand) then
-       do iLay = 1, nLev
-          do iCol = 1, nCol
-             if (cld_frac(iCol,iLay) .eq. 0. .and. cld_frac(iCol,iLay-1) .gt. 0.) then
-                cloud_overlap_param(iCol,iLay) = 0._kind_phys
-             endif
-          enddo
-       enddo
-    endif
+!    ! For exponential random overlap...
+!    ! Decorrelate layers when a clear layer follows a cloudy layer to enforce
+!    ! random correlation between non-adjacent blocks of cloudy layers
+!    if (iovr == iovr_exprand) then
+!       do iLay = 1, nLev
+!          do iCol = 1, nCol
+!             if (cld_frac(iCol,iLay) .eq. 0. .and. cld_frac(iCol,iLay-1) .gt. 0.) then
+!                cloud_overlap_param(iCol,iLay) = 0._kind_phys
+!             endif
+!          enddo
+!       enddo
+!    endif
 
     ! 
     ! Compute precipitation overlap parameter (Hack. Using same as cloud for now)

--- a/physics/GFS_rrtmgp_gfdlmp_pre.F90
+++ b/physics/GFS_rrtmgp_gfdlmp_pre.F90
@@ -5,7 +5,7 @@
 module GFS_rrtmgp_gfdlmp_pre
   use machine,      only: kind_phys
   use radiation_tools,   only: check_error_msg
-  use module_radiation_cloud_overlap, only: cmp_dcorr_lgth, get_alpha_exp  
+  use module_radiation_cloud_overlap, only: cmp_dcorr_lgth, get_alpha_exper  
   use rrtmgp_lw_cloud_optics, only: radliq_lwr => radliq_lwrLW, radliq_upr => radliq_uprLW,&
                                     radice_lwr => radice_lwrLW, radice_upr => radice_uprLW
 

--- a/physics/GFS_rrtmgp_setup.F90
+++ b/physics/GFS_rrtmgp_setup.F90
@@ -5,7 +5,7 @@ module GFS_rrtmgp_setup
   use module_radiation_astronomy, only : sol_init, sol_update
   use module_radiation_aerosols,  only : aer_init, aer_update
   use module_radiation_gases,     only : gas_init, gas_update
-  use GFS_cloud_diagnostics,      only : hml_cloud_diagnostics_initialize
+  !  use GFS_cloud_diagnostics,      only : hml_cloud_diagnostics_initialize
   ! *NOTE* These parameters below are required radiation_****** modules. They are not
   !        directly used by the RRTMGP routines.
   use physparam,                  only : isolar,  ictmflg, ico2flg, ioznflg, iaerflg,    &
@@ -130,10 +130,10 @@ contains
     call sol_init ( me )
     call aer_init ( levr, me )
     call gas_init ( me )
-    call hml_cloud_diagnostics_initialize(imp_physics, imp_physics_fer_hires,           &
-         imp_physics_gfdl, imp_physics_thompson, imp_physics_wsm6,                      &
-         imp_physics_zhao_carr, imp_physics_zhao_carr_pdf, imp_physics_mg, levr, me, si,&
-         errflg)
+    !call hml_cloud_diagnostics_initialize(imp_physics, imp_physics_fer_hires,           &
+    !     imp_physics_gfdl, imp_physics_thompson, imp_physics_wsm6,                      &
+    !     imp_physics_zhao_carr, imp_physics_zhao_carr_pdf, imp_physics_mg, levr, me, si,&
+    !     errflg)
 
     if ( me == 0 ) then
        print *,' return from rad_initialize (GFS_rrtmgp_setup_init) - after calling radinit'

--- a/physics/radiation_cloud_overlap.F90
+++ b/physics/radiation_cloud_overlap.F90
@@ -98,7 +98,7 @@ contains
          dcorr_lgth  ! Decorrelation length (km)
     real(kind_phys), dimension(nCol,nLay), intent(in) :: &
          dzlay       !
-    real(kind_phys), dimension(:,:), intent(in) ::  &
+    real(kind_phys), dimension(nCol,nLay), intent(in) ::  &
          cld_frac
     
     ! Outputs

--- a/physics/radiation_cloud_overlap.F90
+++ b/physics/radiation_cloud_overlap.F90
@@ -84,16 +84,22 @@ contains
   ! ######################################################################################
   !
   ! ######################################################################################
-  subroutine get_alpha_exp(nCol, nLay, dzlay, dcorr_lgth, alpha)
+  subroutine get_alpha_exper(nCol, nLay, iovr, iovr_exprand, dzlay,    &
+                             dcorr_lgth, cld_frac, alpha)
     
     ! Inputs
     integer, intent(in) :: &
          nCol,     & ! Number of horizontal grid points
          nLay        ! Number of vertical grid points
+    integer, intent(in) :: &
+         iovr,     &
+         iovr_exprand
     real(kind_phys), dimension(nCol), intent(in) :: &
          dcorr_lgth  ! Decorrelation length (km)
     real(kind_phys), dimension(nCol,nLay), intent(in) :: &
          dzlay       !
+    real(kind_phys), dimension(:,:), intent(in) ::  &
+         cld_frac
     
     ! Outputs
     real(kind_phys), dimension(nCol,nLay) :: &
@@ -108,9 +114,22 @@ contains
           alpha(iCol,iLay) = exp( -(dzlay(iCol,iLay)) / dcorr_lgth(iCol))
        enddo
     enddo
-    
+   
+    ! Revise alpha for exponential-random cloud overlap
+    ! Decorrelate layers when a clear layer follows a cloudy layer to enforce
+    ! random correlation between non-adjacent blocks of cloudy layers
+    if (iovr == iovr_exprand) then
+      do iLay = 2, nLay
+        do iCol = 1, nCol
+          if (cld_frac(iCol,iLay) == 0.0 .and. cld_frac(iCol,iLay-1) > 0.0) then
+            alpha(iCol,iLay) = 0.0
+          endif
+        enddo
+      enddo
+    endif
+ 
     return
     
-  end subroutine get_alpha_exp
+  end subroutine get_alpha_exper
   
 end module module_radiation_cloud_overlap

--- a/physics/radiation_clouds.f
+++ b/physics/radiation_clouds.f
@@ -18,82 +18,55 @@
 !          outputs:                                                    !
 !           ( none )                                                   !
 !                                                                      !
-!       'progcld1'           --- zhao/moorthi prognostic cloud scheme  !
+!       'radiation_clouds_prop'         --- radiation cloud properties !
+!            obtained from various cloud schemes                       !
 !          inputs:                                                     !
-!           (plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,                   !
-!            xlat,xlon,slmsk,dz,delp,                                  !
-!            IX, NLAY, NLP1,                                           !
-!            uni_cld, lmfshal, lmfdeep2, cldcov,                       !
-!            effrl,effri,effrr,effrs,effr_in,                          !
-!            dzlay, latdeg, julian, yearlen,                           !
+!           (plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,                       !
+!            ccnd, ncndl, cnvw, cnvc, tracer1,                         !
+!            xlat,xlon,slmsk,dz,delp, IX, LM, NLAY, NLP1,              !
+!            deltaq, sup, me, icloud, kdt,                             !
+!            ntrac, ntcw, ntiw, ntrw, ntsw, ntgl, ntclamt,             !
+!            imp_physics, imp_physics_fer_hires,imp_physics_gfdl,      !
+!            imp_physics_thompson, imp_physics_wsm6,                   !
+!            imp_physics_zhao_carr, imp_physics_zhao_carr_pdf,         !
+!            imp_physics_mg, iovr_rand, iovr_maxrand, iovr_max,        !
+!            iovr_dcorr, iovr_exp, iovr_exprand, idcor_con,            !
+!            idcor_hogan, idcor_oreopoulos,                            !
+!            imfdeepcnv, imfdeepcnv_gf, do_mynnedmf, lgfdlmprad,       !
+!            uni_cld, lmfshal, lmfdeep2, cldcov, clouds1,              !
+!            effrl, effri, effrr, effrs, effr_in,                      !
+!            effrl_inout, effri_inout, effrs_inout,                    !
+!            lwp_ex, iwp_ex, lwp_fc, iwp_fc,                           !
+!            dzlay, latdeg, julian, yearlen, gridkm,                   !
 !          outputs:                                                    !
-!            clouds,clds,mtop,mbot,de_lgth,alpha)                      !
+!            cld_frac, cld_lwp, cld_reliq, cld_iwp, cld_reice,         !
+!            cld_rwp, cld_rerain, cld_swp, cld_resnow,                 !
+!            clds,mtop,mbot,de_lgth,alpha)                             !
 !                                                                      !
-!       'progcld2'           --- ferrier prognostic cloud microphysics !
-!          inputs:                                                     !
-!           (plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,                   !
-!            xlat,xlon,slmsk,dz,delp, f_ice,f_rain,r_rime,flgmin,      !
-!            IX, NLAY, NLP1, lmfshal, lmfdeep2,                        !
-!            dzlay, latdeg, julian, yearlen,                           !
-!          outputs:                                                    !
-!            clouds,clds,mtop,mbot,de_lgth,alpha)                      !
+!    internal/external accessable subroutines:                                  !
+!       'progcld_zhao_carr'      --- zhao/moorthi prognostic cloud scheme     !
+!       'progcld2'               --- inactive                                 !
+!       'progcld_zhao_carr_pdf'  --- zhao/moorthi prognostic cloud + pdfcld   !
+!       'progcld_gfdl_lin'       --- GFDL-Lin cloud microphysics              !
+!       'progcld4o'              --- inactive                                 !
+!       'progcld_fer_hires'      --- Ferrier-Aligo cloud microphysics         !
+!       'progcld_thompson_wsm6'  --- Thompson/wsm6 cloud microphysics (EMC)   !
+!       'progclduni'             --- MG cloud microphysics                    !
+!                                --- GFDL cloud microphysics (EMC)            !
+!                                --- Thompson + MYNN PBL (or GF convection)   !
+!       'progcld_thompson'       --- Thompson MP (added by G. Thompson)       !
+!       'gethml'                 --- get diagnostic hi, mid, low clouds       !
 !                                                                      !
-!       'progcld3'           --- zhao/moorthi prognostic cloud + pdfcld!
-!          inputs:                                                     !
-!           (plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,cnvw,cnvc,         !
-!            xlat,xlon,slmsk, dz, delp,                                !
-!            ix, nlay, nlp1,                                           !
-!            deltaq,sup,kdt,me,                                        !
-!            dzlay, latdeg, julian, yearlen,                           !
-!          outputs:                                                    !
-!            clouds,clds,mtop,mbot,de_lgth,alpha)                      !
-!                                                                      !
-!       'progcld4'           --- gfdl-lin cloud microphysics           !
-!          inputs:                                                     !
-!           (plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,cnvw,cnvc,         !
-!            xlat,xlon,slmsk, dz, delp,                                !
-!            ix, nlay, nlp1,                                           !
-!            dzlay, latdeg, julian, yearlen,                           !
-!          outputs:                                                    !
-!            clouds,clds,mtop,mbot,de_lgth,alpha)                      !
-!                                                                      !
-!       'progcld4o'          --- inactive                              !
-!                                                                      !
-!       'progcld5'           --- wsm6 cloud microphysics               !
-!          inputs:                                                     !
-!           (plyr,plvl,tlyr,qlyr,qstl,rhly,clw,                        !
-!            xlat,xlon,slmsk, dz, delp,                                !
-!            ntrac,ntcw,ntiw,ntrw,ntsw,ntgl,                           !
-!            ix, nlay, nlp1,                                           !
-!            uni_cld, lmfshal, lmfdeep2, cldcov,                       !
-!            re_cloud,re_ice,re_snow,                                  !
-!            dzlay, latdeg, julian, yearlen,                           !
-!          outputs:                                                    !
-!            clouds,clds,mtop,mbot,de_lgth,alpha)                      !
-!                                                                      !
-!       'progclduni'           --- for unified clouds with MG microphys!
-!          inputs:                                                     !
-!           (plyr,plvl,tlyr,tvly,ccnd,ncnd,                            !
-!            xlat,xlon,slmsk,dz,delp, IX, NLAY, NLP1, cldtot,          !
-!            effrl,effri,effrr,effrs,effr_in,                          !
-!            dzlay, latdeg, julian, yearlen,                           !
-!          outputs:                                                    !
-!            clouds,clds,mtop,mbot,de_lgth,alpha)                      !
-!                                                                      !
-!    internal accessable only subroutines:                             !
-!       'gethml'             --- get diagnostic hi, mid, low clouds    !
-!                                                                      !
-!                                                                      !
-!    cloud array description:                                          !
-!          clouds(:,:,1)  -  layer total cloud fraction                !
-!          clouds(:,:,2)  -  layer cloud liq water path                !
-!          clouds(:,:,3)  -  mean effective radius for liquid cloud    !
-!          clouds(:,:,4)  -  layer cloud ice water path                !
-!          clouds(:,:,5)  -  mean effective radius for ice cloud       !
-!          clouds(:,:,6)  -  layer rain drop water path                !
-!          clouds(:,:,7)  -  mean effective radius for rain drop       !
-!   **     clouds(:,:,8)  -  layer snow flake water path               !
-!          clouds(:,:,9)  -  mean effective radius for snow flake      !
+!    cloud property array description:                                 !
+!          cld_frac  (:,:)  -  layer total cloud fraction              ! 
+!          cld_lwp   (:,:)  -  layer cloud liq water path              ! 
+!          cld_reliq (:,:)  -  mean effective radius for liquid cloud  !
+!          cld_iwp   (:,:)  -  layer cloud ice water path              !
+!          cld_reice (:,:)  -  mean effective radius for ice cloud     !
+!          cld_rwp   (:,:)  -  layer rain drop water path              !
+!          cld_rerain(:,:)  -  mean effective radius for rain drop     !
+!   **     cld_swp   (:,:)  -  layer snow flake water path             !
+!          cld_resnow(:,:)  -  mean effective radius for snow flake    !
 !   ** fu's scheme need to be normalized by snow density (g/m**3/1.0e6)!
 !                                                                      !
 !    external modules referenced:                                      !
@@ -141,7 +114,7 @@
 !        adjusted for better agreement with observations.              !
 !      jan 2011,   yu-tai hou        - changed virtual temperature     !
 !        as input variable instead of originally computed inside the   !
-!        two prognostic cld schemes 'progcld1' and 'progcld2'.         !
+!        two prognostic cld schemes 'progcld_zhao_carr' and 'progcld2'.         !
 !      aug 2012,   yu-tai hou        - modified subroutine cld_init    !
 !        to pass all fixed control variables at the start. and set     !
 !        their correponding internal module variables to be used by    !
@@ -165,6 +138,9 @@
 !        either a constant or a latitude-varying and day-of-year       !
 !        varying decorrelation length selected with parameter "idcor". !
 !                                                                      !
+!      Jan 2022, Q.Liu  - add subroutine radiation_clouds_prop, and    !
+!        move all the subroutine call "progcld*" from                  !
+!        GFS_rrtmg_pre.F90 to this new subroutine                      !
 !!!!!  ==========================================================  !!!!!
 !!!!!                       end descriptions                       !!!!!
 !!!!!  ==========================================================  !!!!!
@@ -277,9 +253,10 @@
      &           161.503, 168.262, 175.248, 182.473, 189.952, 197.699,  &
      &           205.728, 214.055, 222.694, 231.661, 240.971, 250.639/)
 
-      public progcld1, progcld2, progcld3, progcld4, progclduni,        &
-     &       cld_init, progcld5, progcld4o,                             &
-     &       progcld6, progcld_thompson, cal_cldfra3,                   &
+      public progcld_zhao_carr, progcld2, progcld_zhao_carr_pdf,        &
+     &       progcld_gfdl_lin, progclduni, progcld_fer_hires,           &
+     &       cld_init, radiation_clouds_prop, progcld4o,                &
+     &       progcld_thompson_wsm6, progcld_thompson, cal_cldfra3,      &
      &       find_cloudLayers, adjust_cloudIce, adjust_cloudH2O,        &
      &       adjust_cloudFinal, gethml
 
@@ -426,6 +403,616 @@
 !-----------------------------------
 
 !> \ingroup module_radiation_clouds
+!> Subroutine radiation_clouds_prop computes cloud related quantities
+!! for different cloud microphysics schemes.
+!!\param plyr        (IX,NLAY), model layer mean pressure in mb (100Pa)
+!!\param plvl        (IX,NLP1), model level pressure in mb (100Pa)
+!!\param tlyr        (IX,NLAY), model layer mean temperature in K
+!!\param tvly        (IX,NLAY), model layer virtual temperature in K
+!!\param qlyr        (IX,NLAY), layer specific humidity in gm/gm
+!!\param qstl        (IX,NLAY), layer saturate humidity in gm/gm
+!!\param rhly        (IX,NLAY), layer relative humidity \f$ (=qlyr/qstl) \f$
+!!\param ccnd        (IX,NLAY,ncndl), layer cloud condensate amount           !
+!!                          water, ice, rain, snow (+ graupel)                !
+!!\param ncndl        number of layer cloud condensate types (max of 4)
+!!\param cnvw        (ix,nlay), layer convective cloud condensate
+!!\param cnvc        (ix,nlay), layer convective cloud cover
+!!\param tracer1     (ix,nlay,1:ntrac-1), all tracers (except sphum)
+!!\param xlat        (IX), grid latitude in radians, default to pi/2 ->
+!!                          -pi/2 range, otherwise see in-line comment
+!!\param xlon        (IX), grid longitude in radians  (not used)
+!!\param slmsk       (IX), sea/land mask array (sea:0,land:1,sea-ice:2)
+!!\param dz          (IX,NLAY), layer thickness (km)
+!!\param delp        (IX,NLAY), model layer pressure thickness in mb (100Pa)
+!!\param IX          horizontal dimention
+!!\param LM          vertical layer for radiation calculation 
+!!\param NLAY        adjusted vertical layer
+!!\param NLP1        level dimensions
+!!\param deltaq      (ix,nlay), half total water distribution width
+!!\param sup         supersaturation
+!!\param me          print control flag
+!!\param icloud      cloud effect to the optical depth in radiation
+!!\param kdt         current time step index
+!>\param ntrac       number of tracers (Model%ntrac)
+!>\param ntcw        tracer index for cloud liquid water (Model%ntcw)
+!>\param ntiw        tracer index for cloud ice water (Model%ntiw)
+!>\param ntrw        tracer index for rain water (Model%ntrw)
+!>\param ntsw        tracer index for snow water (Model%ntsw)
+!>\param ntgl        tracer index for graupel (Model%ntgl)
+!>\param ntclamt     tracer index for cloud amount (Model%ntclamt)
+!!\param imp_physics                cloud microphysics scheme control flag
+!!\param imp_physics_fer_hires      Ferrier-Aligo microphysics (=15)
+!!\param imp_physics_gfdl           GFDL microphysics cloud (=11)
+!!\param imp_physics_thompson       Thompson microphysics (=8)
+!!\param imp_physics_wsm6           WSM6 microphysics (=6)
+!!\param imp_physics_zhao_carr      Zhao-Carr/Sundqvist microphysics cloud (=99)
+!!\param imp_physics_zhao_carr_pdf  Zhao-Carr/Sundqvist microphysics cloud + PDF (=98)
+!!\param imp_physics_mg             MG microphysics (=10)
+!!\param iovr_rand                  cloud-overlap: random
+!!\param iovr_maxrand               cloud-overlap: maximum random
+!!\param iovr_max                   cloud-overlap: maximum
+!!\param iovr_dcorr                 cloud-overlap: decorrelation length
+!!\param iovr_exp                   cloud-overlap: exponential
+!!\param iovr_exprand               cloud-overlap: exponential random
+!!\param idcor_con                  decorrelation-length: Use constant value
+!!\param idcor_hogan                choice for decorrelation-length
+!!\param idcor_oreopoulos           choice for decorrelation-length
+!!\param imfdeepcnv                 flag for mass-flux deep convection scheme
+!!\param imfdeepcnv_gf              flag for scale- & aerosol-aware Grell-Freitas scheme (GSD)
+!!\param do_mynnedmf                flag for MYNN-EDMF
+!!\param lgfdlmprad                 flag for GFDLMP radiation interaction
+!!\param uni_cld     logical, true for cloud fraction from shoc
+!!\param lmfshal     logical, mass-flux shallow convection scheme flag
+!!\param lmfdeep2    logical, scale-aware mass-flux deep convection scheme flag
+!!\param cldcov      layer cloud fraction (used when uni_cld=.true.)
+!!\param clouds1     layer total cloud fraction
+!!\param effrl       effective radius for liquid water
+!!\param effri       effective radius for ice water
+!!\param effrr       effective radius for rain water
+!!\param effrs       effective radius for snow water
+!!\param effr_in     logical, if .true. use input effective radii
+!!\param effrl_inout                eff. radius of cloud liquid water particle
+!!\param effri_inout                eff. radius of cloud ice water particle
+!!\param effrs_inout                effective radius of cloud snow particle
+!!\param lwp_ex      total liquid water path from explicit microphysics
+!!\param iwp_ex      total ice water path from explicit microphysics
+!!\param lwp_fc      total liquid water path from cloud fraction scheme
+!!\param iwp_fc      total ice water path from cloud fraction scheme
+!!\param dzlay(ix,nlay)             distance between model layer centers
+!!\param latdeg(ix)  latitude (in degrees 90 -> -90)
+!!\param julian      day of the year (fractional julian day)
+!!\param yearlen     current length of the year (365/366 days)
+!!\param gridkm      grid length in km 
+!!\param cld_frac(:,:)   - layer total cloud fraction
+!!\param cld_lwp(:,:)    - layer cloud liq water path \f$(g/m^2)\f$
+!!\param cld_reliq(:,:)  - mean eff radius for liq cloud (micron)
+!!\param cld_iwp(:,:)    - layer cloud ice water path \f$(g/m^2)\f$
+!!\param cld_reice(:,:)  - mean eff radius for ice cloud (micron)
+!!\param cld_rwp(:,:)    - layer rain drop water path (not assigned)
+!!\param cld_rerain(:,:) - mean eff radius for rain drop (micron)
+!!\param cld_swp(:,:)    - layer snow flake water path (not assigned)
+!!\param cld_resnow(:,:) - mean eff radius for snow flake (micron)
+!!\param clds        (IX,5), fraction of clouds for low, mid, hi, tot, bl
+!!\param mtop        (IX,3), vertical indices for low, mid, hi cloud tops
+!!\param mbot        (IX,3), vertical indices for low, mid, hi cloud bases
+!!\param de_lgth     (IX),   clouds decorrelation length (km)
+!!\param alpha       (IX,NLAY), alpha decorrelation parameter
+!>\section gen_radiation_clouds_prop radiation_clouds_prop General Algorithm
+!> @{
+      subroutine radiation_clouds_prop                                  &
+     &     ( plyr, plvl, tlyr, tvly, qlyr, qstl, rhly,                  &    !  ---  inputs:
+     &       ccnd, ncndl, cnvw, cnvc, tracer1,                          &
+     &       xlat, xlon, slmsk, dz, delp, IX, LM, NLAY, NLP1,           &
+     &       deltaq, sup, me, icloud, kdt,                              &
+     &       ntrac, ntcw, ntiw, ntrw, ntsw, ntgl, ntclamt,              &
+     &       imp_physics, imp_physics_fer_hires,imp_physics_gfdl,       &
+     &       imp_physics_thompson, imp_physics_wsm6,                    &
+     &       imp_physics_zhao_carr, imp_physics_zhao_carr_pdf,          &
+     &       imp_physics_mg, iovr_rand, iovr_maxrand, iovr_max,         &
+     &       iovr_dcorr, iovr_exp, iovr_exprand, idcor_con,             &
+     &       idcor_hogan, idcor_oreopoulos,                             &
+     &       imfdeepcnv, imfdeepcnv_gf, do_mynnedmf, lgfdlmprad,        &
+     &       uni_cld, lmfshal, lmfdeep2, cldcov, clouds1,               &
+     &       effrl, effri, effrr, effrs, effr_in,                       &
+     &       effrl_inout, effri_inout, effrs_inout,                     &
+     &       lwp_ex, iwp_ex, lwp_fc, iwp_fc,                            &
+     &       dzlay, latdeg, julian, yearlen, gridkm,                    &
+     &       cld_frac, cld_lwp, cld_reliq, cld_iwp, cld_reice,          &    !  ---  outputs:
+     &       cld_rwp, cld_rerain, cld_swp, cld_resnow,                  &    
+     &       clds, mtop, mbot, de_lgth, alpha                           &    
+     &      )
+
+! =================   subprogram documentation block   ================ !
+!                                                                       !
+! subprogram:    radiation_clouds_prop    computes cloud related quantities using    !
+!   zhao/moorthi's prognostic cloud microphysics scheme.                !
+!                                                                       !
+! abstract:  this program computes cloud fractions from cloud           !
+!   condensates, calculates liquid/ice cloud droplet effective radius,  !
+!   and computes the low, mid, high, total and boundary layer cloud     !
+!   fractions and the vertical indices of low, mid, and high cloud      !
+!   top and base.  the three vertical cloud domains are set up in the   !
+!   initial subroutine "radiation_clouds_init".                         !
+!                                                                       !
+! usage:         call radiation_clouds_prop                             !
+!                                                                       !
+! subprograms called:                                                   !
+!                                                                       !
+!       'progcld_zhao_carr'      --- zhao/moorthi prognostic cloud scheme      !
+!       'progcld2'               --- inactive                                  !
+!       'progcld_zhao_carr_pdf'  --- zhao/moorthi prognostic cloud + pdfcld    !
+!       'progcld_gfdl_lin'       --- GFDL-Lin cloud microphysics               !
+!       'progcld4o'              --- inactive                                  !
+!       'progcld_fer_hires'      --- Ferrier-Aligo cloud microphysics          !
+!       'progcld_thompson_wsm6'  --- Thompson/wsm6 cloud microphysics (EMC)    !
+!       'progclduni'             --- MG cloud microphysics                     !
+!                                --- GFDL cloud microphysics (EMC)             !
+!                                --- Thompson + MYNN PBL (or GF convection)    !
+!       'progcld_thompson'       --- Thompson MP (added by G. Thompson)        !
+! attributes:                                                           !
+!   language:   fortran 90                                              !
+!   machine:    ibm-sp, sgi                                             !
+!                                                                       !
+!                                                                       !
+!  ====================  definition of variables  ====================  !
+!                                                                       !
+! input variables:                                                      !
+!   plyr  (IX,NLAY) : model layer mean pressure in mb (100Pa)           !
+!   plvl  (IX,NLP1) : model level pressure in mb (100Pa)                !
+!   tlyr  (IX,NLAY) : model layer mean temperature in k                 !
+!   tvly  (IX,NLAY) : model layer virtual temperature in k              !
+!   qlyr  (IX,NLAY) : layer specific humidity in gm/gm                  !
+!   qstl  (IX,NLAY) : layer saturate humidity in gm/gm                  !
+!   rhly  (IX,NLAY) : layer relative humidity (=qlyr/qstl)              !
+!   ccnd  (IX,NLAY,ncndl) : layer cloud condensate amount               !
+!                          water, ice, rain, snow (+ graupel)           !
+!   ncndl           : number of layer cloud condensate types (max of 4) !
+!   cnvw  (IX,NLAY) : layer convective cloud condensate                 !
+!   cnvc  (IX,NLAY) : layer convective cloud cover                      !
+!   tracer1 (IX,NLAY,1:ntrac-1) : all tracers (except sphum)              !
+!   xlat  (IX)      : grid latitude in radians, default to pi/2 -> -pi/2!
+!                     range, otherwise see in-line comment              !
+!   xlon  (IX)      : grid longitude in radians  (not used)             !
+!   slmsk (IX)      : sea/land mask array (sea:0,land:1,sea-ice:2)      !
+!   dz    (ix,nlay) : layer thickness (km)                              !
+!   delp  (ix,nlay) : model layer pressure thickness in mb (100Pa)      !
+!   IX              : horizontal dimention                              !
+!   LM,NLAY,NLP1    : vertical layer/level dimensions                   !
+!   deltaq     (ix,nlay), half total water distribution width           !
+!   sup        supersaturation                                          !
+!   me         print control flag                                       !
+!   icloud          : cloud effect to the optical depth in radiation    !
+!   kdt             : current time step index                           !
+!   ntrac     number of tracers (Model%ntrac)                           !
+!   ntcw      tracer index for cloud liquid water (Model%ntcw)          !
+!   ntiw      tracer index for cloud ice water (Model%ntiw)             !
+!   ntrw      tracer index for rain water (Model%ntrw)                  !
+!   ntsw      tracer index for snow water (Model%ntsw)                  !
+!   ntgl      tracer index for graupel (Model%ntgl)                     !
+!   ntclamt   tracer index for cloud amount (Model%ntclamt)             !
+!   imp_physics               : cloud microphysics scheme control flag  !
+!   imp_physics_fer_hires     : Ferrier-Aligo microphysics scheme       !
+!   imp_physics_gfdl          : GFDL microphysics scheme                !
+!   imp_physics_thompson      : Thompson microphysics scheme            !
+!   imp_physics_wsm6          : WSMG     microphysics scheme            !
+!   imp_physics_zhao_carr     : Zhao-Carr microphysics scheme           !
+!   imp_physics_zhao_carr_pdf : Zhao-Carr microphysics scheme with PDF clouds
+!   imp_physics_mg  :  Morrison-Gettelman microphysics scheme           !
+!   iovr_rand       :  choice of cloud-overlap: random (=0)
+!   iovr_maxrand    :  choice of cloud-overlap: maximum random (=1)
+!   iovr_max        :  choice of cloud-overlap: maximum (=2)
+!   iovr_dcorr      :  choice of cloud-overlap: decorrelation length (=3)
+!   iovr_exp        :  choice of cloud-overlap: exponential (=4)
+!   iovr_exprand    :  choice of cloud-overlap: exponential random (=5)
+!   idcor_con       :  choice for decorrelation-length: Use constant value (=0)
+!   idcor_hogan     :  choice for decorrelation-length: (=1)
+!   idcor_oreopoulos:  choice for decorrelation-length: (=2)
+!   imfdeepcnv      :  flag for mass-flux deep convection scheme        !
+!   imfdeepcnv_gf   :  flag for scale- & aerosol-aware Grell-Freitas scheme (GSD)
+!   do_mynnedmf     :  flag for MYNN-EDMF                               !
+!   lgfdlmprad      :  flag for GFDLMP radiation interaction            !
+!   uni_cld         : logical - true for cloud fraction from shoc       !
+!   lmfshal         : logical - true for mass flux shallow convection   !
+!   lmfdeep2        : logical - true for mass flux deep convection      !
+!   cldcov          : layer cloud fraction (used when uni_cld=.true.    !
+!   clouds1         : layer total cloud fraction
+!   effrl,          : effective radius for liquid water
+!   effri,          : effective radius for ice water
+!   effrr,          : effective radius for rain water
+!   effrs,          : effective radius for snow water
+!   effr_in,        : flag to use effective radii of cloud species in radiation
+!   effrl_inout,    : eff. radius of cloud liquid water particle
+!   effri_inout,    : eff. radius of cloud ice water particle
+!   effrs_inout     : effective radius of cloud snow particle
+!   lwp_ex          : total liquid water path from explicit microphysics
+!   iwp_ex          : total ice water path from explicit microphysics
+!   lwp_fc          : total liquid water path from cloud fraction scheme
+!   iwp_fc          : total ice water path from cloud fraction scheme
+!   dzlay(ix,nlay)  : thickness between model layer centers (km)        !
+!   latdeg(ix)      : latitude (in degrees 90 -> -90)                   !
+!   julian          : day of the year (fractional julian day)           !
+!   yearlen         : current length of the year (365/366 days)         !
+!   gridkm          : grid length in km
+!                                                                       !
+! output variables:                                                     !
+!   cloud profiles:                                                     !
+!      cld_frac  (:,:) - layer total cloud fraction                     !
+!      cld_lwp   (:,:) - layer cloud liq water path       (g/m**2)      !
+!      cld_reliq (:,:) - mean eff radius for liq cloud    (micron)      !
+!      cld_iwp   (:,:) - layer cloud ice water path       (g/m**2)      !
+!      cld_reice (:,:) - mean eff radius for ice cloud    (micron)      !
+!      cld_rwp   (:,:) - layer rain drop water path       not assigned  !
+!      cld_rerain(:,:) - mean eff radius for rain drop    (micron)      !
+!  *** cld_swp   (:,:) - layer snow flake water path      not assigned  !
+!      cld_resnow(:,:) - mean eff radius for snow flake   (micron)      !
+!  *** fu's scheme need to be normalized by snow density (g/m**3/1.0e6) !
+!   clds  (IX,5)    : fraction of clouds for low, mid, hi, tot, bl      !
+!   mtop  (IX,3)    : vertical indices for low, mid, hi cloud tops      !
+!   mbot  (IX,3)    : vertical indices for low, mid, hi cloud bases     !
+!   de_lgth(ix)     : clouds decorrelation length (km)                  !
+!   alpha(ix,nlay)  : alpha decorrelation parameter
+!                                                                       !
+! module variables:                                                     !
+!   ivflip          : control flag of vertical index direction          !
+!                     =0: index from toa to surface                     !
+!                     =1: index from surface to toa                     !
+!   lmfshal         : mass-flux shallow conv scheme flag                !
+!   lmfdeep2        : scale-aware mass-flux deep conv scheme flag       !
+!   lcrick          : control flag for eliminating CRICK                !
+!                     =t: apply layer smoothing to eliminate CRICK      !
+!                     =f: do not apply layer smoothing                  !
+!   lcnorm          : control flag for in-cld condensate                !
+!                     =t: normalize cloud condensate                    !
+!                     =f: not normalize cloud condensate                !
+!   clouds(IX,NLAY,NF_CLDS) : cloud profiles                            !
+!      clouds(:,:,1) - layer total cloud fraction                       !
+!      clouds(:,:,2) - layer cloud liq water path         (g/m**2)      !
+!      clouds(:,:,3) - mean eff radius for liq cloud      (micron)      !
+!      clouds(:,:,4) - layer cloud ice water path         (g/m**2)      !
+!      clouds(:,:,5) - mean eff radius for ice cloud      (micron)      !
+!      clouds(:,:,6) - layer rain drop water path         not assigned  !
+!      clouds(:,:,7) - mean eff radius for rain drop      (micron)      !
+!  *** clouds(:,:,8) - layer snow flake water path        not assigned  !
+!      clouds(:,:,9) - mean eff radius for snow flake     (micron)      !
+!                                                                       !
+!  ====================    end of description    =====================  !
+      implicit none
+
+!  ---  inputs
+      integer,  intent(in) :: IX, LM, NLAY, NLP1, me, ncndl, icloud
+      integer,  intent(in) :: ntrac, ntcw, ntiw, ntrw, ntsw, ntgl,      &
+     &                        ntclamt
+      integer,  intent(in) :: kdt, imfdeepcnv, imfdeepcnv_gf
+      integer,  intent(in) ::                                           &
+     &     imp_physics,                 ! Flag for MP scheme
+     &     imp_physics_fer_hires,       ! Flag for fer-hires scheme
+     &     imp_physics_gfdl,            ! Flag for gfdl scheme
+     &     imp_physics_thompson,        ! Flag for thompsonscheme
+     &     imp_physics_wsm6,            ! Flag for wsm6 scheme
+     &     imp_physics_zhao_carr,       ! Flag for zhao-carr scheme
+     &     imp_physics_zhao_carr_pdf,   ! Flag for zhao-carr+PDF scheme
+     &     imp_physics_mg               ! Flag for MG scheme
+
+      integer,              intent(in)  ::                               &
+     &     iovr_rand,                    ! Flag for random cloud overlap method
+     &     iovr_maxrand,                 ! Flag for maximum-random cloud overlap method
+     &     iovr_max,                     ! Flag for maximum cloud overlap method
+     &     iovr_dcorr,                   ! Flag for decorrelation-length cloud overlap method
+     &     iovr_exp,                     ! Flag for exponential cloud overlap method
+     &     iovr_exprand,                 ! Flag for exponential-random cloud overlap method
+     &     idcor_con,                   
+     &     idcor_hogan,                 
+     &     idcor_oreopoulos
+
+
+      logical, intent(in)  :: uni_cld, lmfshal, lmfdeep2, effr_in
+      logical, intent(in)  :: do_mynnedmf, lgfdlmprad
+
+      real (kind=kind_phys), dimension(:,:,:), intent(in) :: ccnd,      &
+     &                                                       tracer1
+      real (kind=kind_phys), dimension(:,:), intent(in) :: plvl, plyr,  &
+     &       tlyr,  tvly,  qlyr,  qstl, rhly, cnvw, cnvc, cldcov,       &
+     &       delp, dz, effrl, effri, effrr, effrs, dzlay, clouds1
+
+      real (kind=kind_phys), intent(in) :: sup
+      real (kind=kind_phys), dimension(:),   intent(in) :: xlat, xlon,  &
+     &       slmsk
+
+      real(kind=kind_phys), dimension(:), intent(in) :: latdeg, gridkm
+      real(kind=kind_phys), intent(in) :: julian
+      integer, intent(in)              :: yearlen
+
+!  ---  inout
+      real(kind=kind_phys),dimension(:,:) :: deltaq
+      real(kind=kind_phys),dimension(:,:),intent(inout) ::               &
+     &       effrl_inout, effri_inout, effrs_inout
+      real(kind=kind_phys), dimension(:), intent(inout) ::               &
+     &      lwp_ex, iwp_ex, lwp_fc, iwp_fc
+
+!  ---  outputs
+!      real (kind=kind_phys), dimension(:,:,:), intent(out) :: clouds
+
+      real (kind=kind_phys), dimension(:,:),   intent(out) ::            &
+     &   cld_frac, cld_lwp, cld_reliq, cld_iwp, cld_reice,               &
+     &   cld_rwp, cld_rerain, cld_swp, cld_resnow
+      real (kind=kind_phys), dimension(:,:),   intent(out) :: clds
+      real (kind=kind_phys), dimension(:),     intent(out) :: de_lgth
+      real (kind=kind_phys), dimension(:,:),   intent(out) :: alpha
+
+      integer,               dimension(:,:),   intent(out) :: mtop,mbot
+
+!  ---  local variables:
+      real (kind=kind_phys), dimension(IX,NLAY) :: cldtot, cldcnv,      &
+     &       cwp, cip, crp, csp, rew, rei, res, rer, tem2d, clwf
+
+      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1), rxlat(ix)
+      real (kind=kind_phys), dimension(IX,NLAY,NF_CLDS) :: clouds
+
+      real (kind=kind_phys) :: clwmin, clwm, clwt, onemrh, value,       &
+     &       tem1, tem2, tem3
+
+      integer :: i, k, id, nf
+
+!  ---  constant values
+!     real (kind=kind_phys), parameter :: xrc3 = 200.
+      real (kind=kind_phys), parameter :: xrc3 = 100.
+
+!
+!===> ... begin here
+!
+      if (me == 0 .and. kdt == 1) then                                   &
+          print*, 'in radiation_clouds_prop=', imp_physics, uni_cld,     &
+     &           ncndl, lgfdlmprad, do_mynnedmf, imfdeepcnv, kdt
+      end if
+
+      do nf=1,nf_clds
+        do k=1,nlay
+          do i=1,ix
+            clouds(i,k,nf) = 0.0
+          enddo
+        enddo
+      enddo
+      do k = 1, NLAY
+        do i = 1, IX
+            cldtot(i,k) = 0.0
+            cldcnv(i,k) = 0.0
+        end do
+      end do
+
+      if (imp_physics == imp_physics_zhao_carr .or.                     &
+     &    imp_physics == imp_physics_mg) then ! zhao/moorthi's p
+                  ! or unified cloud and/or with MG microphysics
+
+        if (uni_cld .and. ncndl >= 2) then
+          call progclduni (plyr, plvl, tlyr, tvly, ccnd, ncndl,         & !  ---  inputs
+     &                     xlat, xlon, slmsk, dz, delp,                 &
+     &                     IX, NLAY, NLP1, cldcov,                      &
+     &                     effrl, effri, effrr, effrs, effr_in,         &
+     &                     dzlay,                                       & 
+     &                     cldtot, cldcnv,                              & ! inout
+     &                     clouds)   !  ---  outputs
+        else
+          call progcld_zhao_carr (plyr ,plvl, tlyr, tvly, qlyr,         & !  ---  inputs
+     &                    qstl, rhly, ccnd(1:IX,1:NLAY,1), xlat, xlon,  &
+     &                    slmsk, dz, delp, IX, NLAY, NLP1, uni_cld,     &
+     &                    lmfshal, lmfdeep2,                            &
+     &                    cldcov, effrl, effri, effrr, effrs, effr_in,  &
+     &                    dzlay,                                        &
+     &                    cldtot, cldcnv,                               & ! inout
+     &                    clouds)     !  ---  outputs
+        endif
+
+      elseif(imp_physics == imp_physics_zhao_carr_pdf) then      ! zhao/moorthi's prognostic cloud+pdfcld
+
+        call progcld_zhao_carr_pdf (plyr, plvl, tlyr, tvly, qlyr,       &  !  ---  inputs
+     &                 qstl, rhly, ccnd(1:IX,1:NLAY,1), cnvw, cnvc,     &
+     &                 xlat, xlon, slmsk, dz, delp, IX, NLAY, NLP1,     &
+     &                 deltaq, sup, kdt, me, dzlay,                     & 
+     &                 cldtot, cldcnv,                                  &  ! inout
+     &                 clouds)        !  ---  outputs
+
+      elseif (imp_physics == imp_physics_gfdl) then           ! GFDL cloud scheme
+
+        if (.not. lgfdlmprad) then
+          call progcld_gfdl_lin (plyr, plvl, tlyr, tvly, qlyr,          &    !  ---  inputs
+     &                    qstl, rhly, ccnd(1:IX,1:NLAY,1), cnvw, cnvc,  &
+     &                    xlat, xlon, slmsk, cldcov, dz, delp,          &
+     &                    IX, NLAY, NLP1, dzlay,                        &
+     &                    cldtot, cldcnv,                               &  ! inout
+     &                    clouds)        !  ---  outputs
+        else
+
+          call progclduni (plyr, plvl, tlyr, tvly, ccnd, ncndl, xlat,   &    !  ---  inputs
+     &                   xlon, slmsk, dz,delp, IX, NLAY, NLP1, cldcov,  &
+     &                   effrl, effri, effrr, effrs, effr_in,           &
+     &                   dzlay,                                         &
+     &                   cldtot, cldcnv,                                &  ! inout
+     &                   clouds)       !  ---  outputs
+!         call progcld4o (plyr, plvl, tlyr, tvly, qlyr, qstl, rhly,       &   !  ---  inputs
+!                         tracer1, xlat, xlon, slmsk, dz, delp,           &
+!                         ntrac-1, ntcw-1,ntiw-1,ntrw-1,                  &
+!                         ntsw-1,ntgl-1,ntclamt-1,                        &
+!                         IX,NLAY,NLP1,                                   &
+!                         dzlay,                                          &
+!                         cldtot, cldcnv,                                 &  ! inout
+!                         clouds)        !  ---  outputs
+        endif
+
+
+      elseif(imp_physics == imp_physics_fer_hires) then
+          if (kdt == 1) then
+            effrl_inout(:,:) = 10.
+            effri_inout(:,:) = 50.
+            effrs_inout(:,:) = 250.
+          endif
+
+          call progcld_fer_hires (plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,   &  !  --- inputs
+     &                    tracer1,xlat,xlon,slmsk,dz,delp,              &
+     &                    ntrac-1, ntcw-1,ntiw-1,ntrw-1,                &
+     &                    IX,NLAY,NLP1, icloud, uni_cld,                &
+     &                    lmfshal, lmfdeep2,                            &
+     &                    cldcov(:,1:NLAY),effrl_inout(:,:),            &
+     &                    effri_inout(:,:), effrs_inout(:,:),           &
+     &                    dzlay,                                        &
+     &                    cldtot, cldcnv,                               &  ! inout
+     &                    clouds)            !  --- outputs
+
+        elseif(imp_physics == imp_physics_thompson) then                              ! Thompson MP
+
+          if(do_mynnedmf .or. imfdeepcnv == imfdeepcnv_gf ) then ! MYNN PBL or GF conv
+
+            if (icloud == 3) then
+              call progcld_thompson (plyr,plvl,tlyr,qlyr,qstl,rhly,     & !  --- inputs
+     &                    tracer1,xlat,xlon,slmsk,dz,delp,              &
+     &                    ntrac-1, ntcw-1,ntiw-1,ntrw-1,                &
+     &                    ntsw-1,ntgl-1,                                &
+     &                    IX, LM, NLP1, uni_cld, lmfshal, lmfdeep2,     &
+     &                    cldcov(:,1:LM), effrl, effri, effrs,          &
+     &                    lwp_ex, iwp_ex, lwp_fc, iwp_fc,               &
+     &                    dzlay,  gridkm,                               &
+     &                    cldtot, cldcnv,                               &  ! inout
+     &                    clouds) !  --- outputs
+            else
+
+              !-- MYNN PBL or convective GF
+              !-- use cloud fractions with SGS clouds
+              do k=1,NLAY
+                do i=1,IX
+                  clouds(i,k,1)  = clouds1(i,k)
+                enddo
+              enddo
+
+                ! --- use clduni as with the GFDL microphysics.
+                ! --- make sure that effr_in=.true. in the input.nml!
+                call progclduni (plyr, plvl, tlyr, tvly, ccnd, ncndl,   & !  ---  inputs
+     &                   xlat, xlon, slmsk, dz, delp, IX, NLAY, NLP1,   &
+     &                   clouds(:,1:NLAY,1),                            &
+     &                   effrl, effri, effrr, effrs, effr_in ,          &
+     &                   dzlay,                                         &
+     &                   cldtot, cldcnv,                                &  ! inout
+     &                   clouds)     !  ---  outputs
+            endif
+
+          else
+            ! MYNN PBL or GF convective are not used
+
+            if (icloud == 3) then
+              call progcld_thompson (plyr,plvl,tlyr,qlyr,qstl,rhly,     & !  --- inputs
+     &                   tracer1,xlat,xlon,slmsk,dz,delp,               &
+     &                   ntrac-1, ntcw-1,ntiw-1,ntrw-1,                 &
+     &                   ntsw-1,ntgl-1,                                 &
+     &                   IX, LM, NLP1, uni_cld, lmfshal, lmfdeep2,      &
+     &                   cldcov(:,1:LM), effrl, effri, effrs,           &
+     &                   lwp_ex, iwp_ex, lwp_fc, iwp_fc,                &
+     &                   dzlay,  gridkm,                                &
+     &                   cldtot, cldcnv,                                &  ! inout
+     &                   clouds) !  --- outputs
+
+            else
+              call progcld_thompson_wsm6 (plyr,plvl,tlyr,qlyr,qstl,     & !  --- inputs
+     &                   rhly,tracer1,xlat,xlon,slmsk,dz,delp,          &
+     &                   ntrac-1, ntcw-1,ntiw-1,ntrw-1,                 &
+     &                   ntsw-1,ntgl-1,                                 &
+     &                   IX, NLAY, NLP1, uni_cld, lmfshal, lmfdeep2,    &
+     &                   cldcov(:,1:NLAY), cnvw, effrl, effri, effrs,   &
+     &                   lwp_ex, iwp_ex, lwp_fc, iwp_fc,                &
+     &                   dzlay,                                         &
+     &                   cldtot, cldcnv,                                &  ! inout
+     &                   clouds) !  --- outputs
+            endif
+          endif ! MYNN PBL or GF
+
+        endif                            ! end if_imp_physics
+
+      do k = 1, NLAY
+        do i = 1, IX
+          cld_frac(i,k)   = clouds(i,k,1)
+          cld_lwp(i,k)    = clouds(i,k,2)
+          cld_reliq(i,k)  = clouds(i,k,3)
+          cld_iwp(i,k)    = clouds(i,k,4)
+          cld_reice(i,k)  = clouds(i,k,5)
+          cld_rwp(i,k)    = clouds(i,k,6)
+          cld_rerain(i,k) = clouds(i,k,7)
+          cld_swp(i,k)    = clouds(i,k,8)
+          cld_resnow(i,k) = clouds(i,k,9)
+        enddo
+      enddo
+
+
+!> - Compute SFC/low/middle/high cloud top pressure for each cloud
+!! domain for given latitude.
+!     ptopc(k,i): top presure of each cld domain (k=1-4 are sfc,L,m,h;
+!  ---  i=1,2 are low-lat (<45 degree) and pole regions)
+
+      do i =1, IX
+        rxlat(i) = abs( xlat(i) / con_pi )      ! if xlat in pi/2 -> -pi/2 range
+!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)    ! if xlat in 0 -> pi range
+      enddo
+
+      do id = 1, 4
+        tem1 = ptopc(id,2) - ptopc(id,1)
+
+        do i =1, IX
+          ptop1(i,id) = ptopc(id,1) + tem1*max( 0.0, 4.0*rxlat(i)-1.0 )
+        enddo
+      enddo
+        
+      ! Compute cloud decorrelation length
+      if (idcor == idcor_hogan) then
+        call cmp_dcorr_lgth(ix, xlat, con_pi, de_lgth)
+      endif
+      if (idcor == idcor_oreopoulos) then
+        call cmp_dcorr_lgth(ix, latdeg, julian, yearlen, de_lgth)
+      endif
+      if (idcor == idcor_con) then
+         de_lgth(:) = decorr_con
+      endif
+
+      ! Call subroutine get_alpha_exp to define alpha parameter for exponential cloud overlap options
+      if ( iovr == iovr_dcorr .or. iovr == iovr_exp                      &
+     &     .or. iovr == iovr_exprand) then
+         call get_alpha_exp(ix, nLay, dzlay, de_lgth, alpha)
+      else
+         de_lgth(:) = 0.
+         alpha(:,:) = 0.
+      endif
+
+      ! Revise alpha for exponential-random cloud overlap
+      ! Decorrelate layers when a clear layer follows a cloudy layer to enforce
+      ! random correlation between non-adjacent blocks of cloudy layers
+      if (iovr == iovr_exprand) then
+        do k = 2, nLay
+          do i = 1, ix
+            if (clouds(i,k,1) == 0.0 .and. clouds(i,k-1,1) > 0.0) then
+              alpha(i,k) = 0.0
+            endif
+          enddo
+        enddo
+      endif
+
+!> - Call gethml() to compute low,mid,high,total, and boundary layer
+!!    cloud fractions and clouds top/bottom layer indices for low, mid,
+!!    and high clouds.
+!  ---  compute low, mid, high, total, and boundary layer cloud fractions
+!       and clouds top/bottom layer indices for low, mid, and high clouds.
+!       The three cloud domain boundaries are defined by ptopc.  The cloud
+!       overlapping method is defined by control flag 'iovr', which may
+!       be different for lw and sw radiation programs.
+
+      call gethml                                                       &
+!  ---  inputs:
+     &     ( plyr, ptop1, cldtot, cldcnv, dz, de_lgth, alpha,           &
+     &       IX, NLAY, iovr_rand, iovr_maxrand, iovr_max,               &
+     &       iovr_dcorr, iovr_exp, iovr_exprand,                        &
+!  ---  outputs:
+     &       clds, mtop, mbot                                           &
+     &     )
+
+      return
+!...................................
+      end subroutine radiation_clouds_prop
+
+!> \ingroup module_radiation_clouds
 !> This subroutine computes cloud related quantities using
 !! zhao/moorthi's prognostic cloud microphysics scheme.
 !!\param plyr        (IX,NLAY), model layer mean pressure in mb (100Pa)
@@ -455,9 +1042,6 @@
 !!\param effrs       effective radius for snow water
 !!\param effr_in     logical, if .true. use input effective radii
 !!\param dzlay(ix,nlay) distance between model layer centers
-!!\param latdeg(ix)  latitude (in degrees 90 -> -90)
-!!\param julian      day of the year (fractional julian day)
-!!\param yearlen     current length of the year (365/366 days)
 !!\param clouds      (IX,NLAY,NF_CLDS), cloud profiles
 !!\n                 (:,:,1) - layer total cloud fraction
 !!\n                 (:,:,2) - layer cloud liq water path \f$(g/m^2)\f$
@@ -468,25 +1052,20 @@
 !!\n                 (:,:,7) - mean eff radius for rain drop (micron)
 !!\n                 (:,:,8) - layer snow flake water path (not assigned)
 !!\n                 (:,:,9) - mean eff radius for snow flake (micron)
-!!\param clds        (IX,5), fraction of clouds for low, mid, hi, tot, bl
-!!\param mtop        (IX,3), vertical indices for low, mid, hi cloud tops
-!!\param mbot        (IX,3), vertical indices for low, mid, hi cloud bases
-!!\param de_lgth     (IX),   clouds decorrelation length (km)
-!!\param alpha       (IX,NLAY), alpha decorrelation parameter
-!>\section gen_progcld1 progcld1 General Algorithm
+!>\section gen_progcld_zhao_carr progcld_zhao_carr General Algorithm
 !> @{
-      subroutine progcld1                                               &
+      subroutine progcld_zhao_carr                                      &
      &     ( plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,                    &    !  ---  inputs:
      &       xlat,xlon,slmsk,dz,delp, IX, NLAY, NLP1,                   &
      &       uni_cld, lmfshal, lmfdeep2, cldcov,                        &
      &       effrl,effri,effrr,effrs,effr_in,                           &
-     &       dzlay, latdeg, julian, yearlen,                            &
-     &       clouds,clds,mtop,mbot,de_lgth,alpha                        &    !  ---  outputs:
+     &       dzlay, cldtot, cldcnv,                                     &
+     &       clouds                                                     &    !  ---  outputs:
      &      )
 
 ! =================   subprogram documentation block   ================ !
 !                                                                       !
-! subprogram:    progcld1    computes cloud related quantities using    !
+! subprogram:    progcld_zhao_carr    computes cloud related quantities using    !
 !   zhao/moorthi's prognostic cloud microphysics scheme.                !
 !                                                                       !
 ! abstract:  this program computes cloud fractions from cloud           !
@@ -496,7 +1075,7 @@
 !   top and base.  the three vertical cloud domains are set up in the   !
 !   initial subroutine "cld_init".                                      !
 !                                                                       !
-! usage:         call progcld1                                          !
+! usage:         call progcld_zhao_carr                                          !
 !                                                                       !
 ! subprograms called:   gethml                                          !
 !                                                                       !
@@ -529,9 +1108,6 @@
 !   lmfdeep2        : logical - true for mass flux deep convection      !
 !   cldcov          : layer cloud fraction (used when uni_cld=.true.    !
 !   dzlay(ix,nlay)  : thickness between model layer centers (km)        !
-!   latdeg(ix)      : latitude (in degrees 90 -> -90)                   !
-!   julian          : day of the year (fractional julian day)           !
-!   yearlen         : current length of the year (365/366 days)         !
 !                                                                       !
 ! output variables:                                                     !
 !   clouds(IX,NLAY,NF_CLDS) : cloud profiles                            !
@@ -544,12 +1120,6 @@
 !      clouds(:,:,7) - mean eff radius for rain drop      (micron)      !
 !  *** clouds(:,:,8) - layer snow flake water path        not assigned  !
 !      clouds(:,:,9) - mean eff radius for snow flake     (micron)      !
-!  *** fu's scheme need to be normalized by snow density (g/m**3/1.0e6) !
-!   clds  (IX,5)    : fraction of clouds for low, mid, hi, tot, bl      !
-!   mtop  (IX,3)    : vertical indices for low, mid, hi cloud tops      !
-!   mbot  (IX,3)    : vertical indices for low, mid, hi cloud bases     !
-!   de_lgth(ix)     : clouds decorrelation length (km)                  !
-!   alpha(ix,nlay)  : alpha decorrelation parameter
 !                                                                       !
 ! module variables:                                                     !
 !   ivflip          : control flag of vertical index direction          !
@@ -580,24 +1150,12 @@
       real (kind=kind_phys), dimension(:),   intent(in) :: xlat, xlon,  &
      &       slmsk
 
-      real(kind=kind_phys), dimension(:), intent(in) :: latdeg
-      real(kind=kind_phys), intent(in) :: julian
-      integer, intent(in)              :: yearlen
-
 !  ---  outputs
       real (kind=kind_phys), dimension(:,:,:), intent(out) :: clouds
-
-      real (kind=kind_phys), dimension(:,:),   intent(out) :: clds
-      real (kind=kind_phys), dimension(:),     intent(out) :: de_lgth
-      real (kind=kind_phys), dimension(:,:),   intent(out) :: alpha
-
-      integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
 !  ---  local variables:
       real (kind=kind_phys), dimension(IX,NLAY) :: cldtot, cldcnv,      &
      &       cwp, cip, crp, csp, rew, rei, res, rer, tem2d, clwf
-
-      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1), rxlat(ix)
 
       real (kind=kind_phys) :: clwmin, clwm, clwt, onemrh, value,       &
      &       tem1, tem2, tem3
@@ -611,15 +1169,6 @@
 !
 !===> ... begin here
 !
-      do nf=1,nf_clds
-        do k=1,nlay
-          do i=1,ix
-            clouds(i,k,nf) = 0.0
-          enddo
-        enddo
-      enddo
-!     clouds(:,:,:) = 0.0
-
 !> - Assgin liquid/ice/rain/snow cloud effective radius from input or predefined values.
       if(effr_in) then
         do k = 1, NLAY
@@ -674,24 +1223,6 @@
           enddo
         enddo
       endif
-
-!> - Compute SFC/low/middle/high cloud top pressure for each cloud
-!! domain for given latitude.
-!     ptopc(k,i): top presure of each cld domain (k=1-4 are sfc,L,m,h;
-!  ---  i=1,2 are low-lat (<45 degree) and pole regions)
-
-      do i =1, IX
-        rxlat(i) = abs( xlat(i) / con_pi )      ! if xlat in pi/2 -> -pi/2 range
-!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)    ! if xlat in 0 -> pi range
-      enddo
-
-      do id = 1, 4
-        tem1 = ptopc(id,2) - ptopc(id,1)
-
-        do i =1, IX
-          ptop1(i,id) = ptopc(id,1) + tem1*max( 0.0, 4.0*rxlat(i)-1.0 )
-        enddo
-      enddo
 
 !> - Compute cloud liquid/ice condensate path in \f$ g/m^2 \f$ .
 
@@ -847,66 +1378,10 @@
           clouds(i,k,9) = res(i,k)
         enddo
       enddo
-
-!  --- ...  estimate clouds decorrelation length in km
-!           this is only a tentative test, need to consider change later
-
-      if ( iovr == 3 ) then
-        do i = 1, ix
-          de_lgth(i) = max( 0.6, 2.78-4.6*rxlat(i) )
-        enddo
-      endif
-
-      ! Compute cloud decorrelation length 
-      if (idcor == 1) then
-        call cmp_dcorr_lgth(ix, xlat, con_pi, de_lgth)
-      endif
-      if (idcor == 2) then
-        call cmp_dcorr_lgth(ix, latdeg, julian, yearlen, de_lgth)
-      endif
-      if (idcor == 0) then
-         de_lgth(:) = decorr_con
-      endif
-
-      ! Call subroutine get_alpha_exp to define alpha parameter for exponential cloud overlap options
-      if (iovr == 3 .or. iovr == 4 .or. iovr == 5) then
-         call get_alpha_exp(ix, nLay, dzlay, de_lgth, alpha)
-      else
-         de_lgth(:) = 0.
-         alpha(:,:) = 0.
-      endif
-
-      ! Revise alpha for exponential-random cloud overlap
-      ! Decorrelate layers when a clear layer follows a cloudy layer to enforce
-      ! random correlation between non-adjacent blocks of cloudy layers
-      if (iovr == 5) then
-        do k = 2, nLay
-          do i = 1, ix
-            if (clouds(i,k,1) == 0.0 .and. clouds(i,k-1,1) > 0.0) then
-              alpha(i,k) = 0.0
-            endif
-          enddo
-        enddo
-      endif
-
-!> - Call gethml() to compute low,mid,high,total, and boundary layer
-!!    cloud fractions and clouds top/bottom layer indices for low, mid,
-!!    and high clouds. The three cloud domain boundaries are defined by
-!!    ptopc.  The cloud overlapping method is defined by control flag
-!!    'iovr', which may be different for lw and sw radiation programs.
-      call gethml                                                       &
-!  ---  inputs:
-     &     ( plyr, ptop1, cldtot, cldcnv, dz, de_lgth, alpha,           &
-     &       IX,NLAY,                                                   &
-!  ---  outputs:
-     &       clds, mtop, mbot                                           &
-     &     )
-
-
 !
       return
 !...................................
-      end subroutine progcld1
+      end subroutine progcld_zhao_carr
 !-----------------------------------
 !> @}
 
@@ -936,9 +1411,6 @@
 !!\param lmfshal     flag for mass-flux shallow convection scheme in the cloud fraction calculation
 !!\param lmfdeep2    flag for mass-flux deep convection scheme in the cloud fraction calculation
 !!\param dzlay(ix,nlay) distance between model layer centers
-!!\param latdeg(ix)  latitude (in degrees 90 -> -90)
-!!\param julian      day of the year (fractional julian day)
-!!\param yearlen     current length of the year (365/366 days)
 !!\param clouds      (IX,NLAY,NF_CLDS), cloud profiles
 !!\n                 (:,:,1) - layer total cloud fraction
 !!\n                 (:,:,2) - layer cloud liq water path  \f$(g/m^2)\f$
@@ -949,10 +1421,6 @@
 !!\n                 (:,:,7) - mean eff radius for rain drop (micron)
 !!\n                 (:,:,8) - layer snow flake water path \f$(g/m^2)\f$
 !!\n                 (:,:,9) - mean eff radius for snow flake (micron)
-!!\param clds        (IX,5), fraction of clouds for low, mid, hi, tot, bl
-!!\param mtop        (IX,3), vertical indices for low, mid, hi cloud tops
-!!\param mbot        (IX,3), vertical indices for low, mid, hi cloud bases
-!!\param de_lgth   (IX),   clouds decorrelation length (km)
 !>\section gen_progcld2 progcld2 General Algorithm for the F-A MP scheme
 !> @{
       subroutine progcld2                                               &
@@ -960,8 +1428,8 @@
      &       xlat,xlon,slmsk,dz,delp,                                   &
      &       ntrac, ntcw, ntiw, ntrw,                                   &
      &       IX, NLAY, NLP1, lmfshal, lmfdeep2,                         &
-     &       dzlay, latdeg, julian, yearlen,                            &
-     &       clouds,clds,mtop,mbot,de_lgth,alpha                        &    !  ---  outputs:
+     &       dzlay, cldtot, cldcnv,                                     &
+     &       clouds                                                     &    !  ---  outputs:
      &      )
 
 ! =================   subprogram documentation block   ================ !
@@ -1007,9 +1475,6 @@
 !   lmfshal         : logical - true for mass flux shallow convection   !
 !   lmfdeep2        : logical - true for mass flux deep convection      !
 !   dzlay(ix,nlay)  : thickness between model layer centers (km)        !
-!   latdeg(ix)      : latitude (in degrees 90 -> -90)                   !
-!   julian          : day of the year (fractional julian day)           !
-!   yearlen         : current length of the year (365/366 days)         !
 !                                                                       !
 ! output variables:                                                     !
 !   clouds(IX,NLAY,NF_CLDS) : cloud profiles                            !
@@ -1022,12 +1487,6 @@
 !      clouds(:,:,7) - mean eff radius for rain drop      (micron)      !
 !  *** clouds(:,:,8) - layer snow flake water path        not assigned  !
 !      clouds(:,:,9) - mean eff radius for snow flake     (micron)      !
-!  *** fu's scheme need to be normalized by snow density (g/m**3/1.0e6) !
-!   clds  (IX,5)    : fraction of clouds for low, mid, hi, tot, bl      !
-!   mtop  (IX,3)    : vertical indices for low, mid, hi cloud tops      !
-!   mbot  (IX,3)    : vertical indices for low, mid, hi cloud bases     !
-!   de_lgth(ix)     : clouds decorrelation length (km)                  !
-!   alpha(ix,nlay)  : alpha decorrelation parameter
 !                                                                       !
 ! module variables:                                                     !
 !   ivflip          : control flag of vertical index direction          !
@@ -1060,24 +1519,12 @@
       real (kind=kind_phys), dimension(:),   intent(in) :: xlat, xlon,  &
      &       slmsk
 
-      real(kind=kind_phys), dimension(:), intent(in) :: latdeg
-      real(kind=kind_phys), intent(in) :: julian
-      integer, intent(in)              :: yearlen
-
 !  ---  outputs
       real (kind=kind_phys), dimension(:,:,:), intent(out) :: clouds
-
-      real (kind=kind_phys), dimension(:,:),   intent(out) :: clds
-      real (kind=kind_phys), dimension(:),     intent(out) :: de_lgth
-      real (kind=kind_phys), dimension(:,:),   intent(out) :: alpha
-
-      integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
 !  ---  local variables:
       real (kind=kind_phys), dimension(IX,NLAY) :: cldtot, cldcnv,      &
      &       cwp, cip, crp, csp, rew, rei, res, rer, tem2d, clwf
-
-      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1), rxlat(ix)
 
       real (kind=kind_phys) :: clwmin, clwm, clwt, onemrh, value,       &
      &       tem1, tem2, tem3
@@ -1091,15 +1538,6 @@
 !
 !===> ... begin here
 !
-      do nf=1,nf_clds
-        do k=1,nlay
-          do i=1,ix
-            clouds(i,k,nf) = 0.0
-          enddo
-        enddo
-      enddo
-!     clouds(:,:,:) = 0.0
-
       do k = 1, NLAY
         do i = 1, IX
           cldtot(i,k) = 0.0
@@ -1121,22 +1559,6 @@
           do i = 1, IX
             clwf(i,k) = clw(i,k,ntcw) +  clw(i,k,ntiw)
           enddo
-      enddo
-!> - Find top pressure for each cloud domain for given latitude.
-!! ptopc(k,i): top presure of each cld domain (k=1-4 are sfc,L,m,h;
-!! i=1,2 are low-lat (<45 degree) and pole regions)
-
-      do i =1, IX
-        rxlat(i) = abs( xlat(i) / con_pi )      ! if xlat in pi/2 -> -pi/2 range
-!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)    ! if xlat in 0 -> pi range
-      enddo
-
-      do id = 1, 4
-        tem1 = ptopc(id,2) - ptopc(id,1)
-
-        do i =1, IX
-          ptop1(i,id) = ptopc(id,1) + tem1*max( 0.0, 4.0*rxlat(i)-1.0 )
-        enddo
       enddo
 
 !> - Compute cloud liquid/ice condensate path in \f$ g/m^2 \f$ .
@@ -1265,57 +1687,6 @@
           clouds(i,k,9) = res(i,k)
         enddo
       enddo
-
-      ! Compute cloud decorrelation length 
-      if (idcor == 1) then
-        call cmp_dcorr_lgth(ix, xlat, con_pi, de_lgth)
-      endif
-      if (idcor == 2) then
-        call cmp_dcorr_lgth(ix, latdeg, julian, yearlen, de_lgth)
-      endif
-      if (idcor == 0) then
-         de_lgth(:) = decorr_con
-      endif
-
-      ! Call subroutine get_alpha_exp to define alpha parameter for exponential cloud overlap options     
-      if (iovr == 3 .or. iovr == 4 .or. iovr == 5) then
-         call get_alpha_exp(ix, nLay, dzlay, de_lgth, alpha)
-      else
-         de_lgth(:) = 0.
-         alpha(:,:) = 0.
-      endif
-
-      ! Revise alpha for exponential-random cloud overlap
-      ! Decorrelate layers when a clear layer follows a cloudy layer to enforce
-      ! random correlation between non-adjacent blocks of cloudy layers
-      if (iovr == 5) then
-        do k = 2, nLay
-          do i = 1, ix
-            if (clouds(i,k,1) == 0.0 .and. clouds(i,k-1,1) > 0.0) then
-              alpha(i,k) = 0.0
-            endif
-          enddo
-        enddo
-      endif
-
-!> - Call gethml() to compute low,mid,high,total, and boundary layer
-!! cloud fractions and clouds top/bottom layer indices for low, mid,
-!! and high clouds.
-!  ---  compute low, mid, high, total, and boundary layer cloud fractions
-!       and clouds top/bottom layer indices for low, mid, and high clouds.
-!       The three cloud domain boundaries are defined by ptopc.  The cloud
-!       overlapping method is defined by control flag 'iovr', which may
-!       be different for lw and sw radiation programs.
-
-      call gethml                                                       &
-!  ---  inputs:
-     &     ( plyr, ptop1, cldtot, cldcnv, dz, de_lgth, alpha,           &
-     &       IX,NLAY,                                                   &
-!  ---  outputs:
-     &       clds, mtop, mbot                                           &
-     &     )
-
-
 !
       return
 !...................................
@@ -1351,9 +1722,6 @@
 !!\param kdt
 !!\param me         print control flag
 !!\param dzlay(ix,nlay) distance between model layer centers
-!!\param latdeg(ix)  latitude (in degrees 90 -> -90)
-!!\param julian      day of the year (fractional julian day)
-!!\param yearlen     current length of the year (365/366 days)
 !!\param clouds     (ix,nlay,nf_clds), cloud profiles
 !!\n                (:,:,1) - layer total cloud fraction
 !!\n                (:,:,2) - layer cloud liq water path (g/m**2)
@@ -1364,25 +1732,20 @@
 !!\n                (:,:,7) - mean eff radius for rain drop (micron)
 !!\n                (:,:,8) - layer snow flake water path        not assigned
 !!\n                (:,:,9) - mean eff radius for snow flake(micron)
-!!\param clds       (ix,5), fraction of clouds for low, mid, hi, tot, bl
-!!\param mtop       (ix,3), vertical indices for low, mid, hi cloud tops
-!!\param mbot       (ix,3), vertical indices for low, mid, hi cloud bases
-!!\param de_lgth   (ix),   clouds decorrelation length (km)
-!!\param alpha      (IX,NLAY), alpha decorrelation parameter
-!>\section gen_progcld3 progcld3 General Algorithm
+!>\section gen_progcld_zhao_carr_pdf progcld_zhao_carr_pdf General Algorithm
 !! @{
-      subroutine progcld3                                               &
+      subroutine progcld_zhao_carr_pdf                                  &
      &     ( plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,cnvw,cnvc,          &    !  ---  inputs:
      &       xlat,xlon,slmsk, dz, delp,                                 &
      &       ix, nlay, nlp1,                                            &
      &       deltaq,sup,kdt,me,                                         &
-     &       dzlay, latdeg, julian, yearlen,                            &
-     &       clouds,clds,mtop,mbot,de_lgth,alpha                        &    !  ---  outputs:
+     &       dzlay, cldtot, cldcnv,                                     &
+     &       clouds                                                     &    !  ---  outputs:
      &      )
 
 ! =================   subprogram documentation block   ================ !
 !                                                                       !
-! subprogram:    progcld3    computes cloud related quantities using    !
+! subprogram:    progcld_zhao_carr_pdf    computes cloud related quantities using    !
 !   zhao/moorthi's prognostic cloud microphysics scheme.                !
 !                                                                       !
 ! abstract:  this program computes cloud fractions from cloud           !
@@ -1392,7 +1755,7 @@
 !   top and base.  the three vertical cloud domains are set up in the   !
 !   initial subroutine "cld_init".                                      !
 !                                                                       !
-! usage:         call progcld3                                          !
+! usage:         call progcld_zhao_carr_pdf                                          !
 !                                                                       !
 ! subprograms called:   gethml                                          !
 !                                                                       !
@@ -1425,10 +1788,6 @@
 !   deltaq(ix,nlay) : half total water distribution width               !
 !   sup             : supersaturation                                   !
 !   dzlay(ix,nlay)  : thickness between model layer centers (km)        !
-!   latdeg(ix)      : latitude (in degrees 90 -> -90)                   !
-!   julian          : day of the year (fractional julian day)           !
-!   yearlen         : current length of the year (365/366 days)         !
-
 !                                                                       !
 ! output variables:                                                     !
 !   clouds(ix,nlay,nf_clds) : cloud profiles                            !
@@ -1441,12 +1800,6 @@
 !      clouds(:,:,7) - mean eff radius for rain drop      (micron)      !
 !  *** clouds(:,:,8) - layer snow flake water path        not assigned  !
 !      clouds(:,:,9) - mean eff radius for snow flake     (micron)      !
-!  *** fu's scheme need to be normalized by snow density (g/m**3/1.0e6) !
-!   clds  (ix,5)    : fraction of clouds for low, mid, hi, tot, bl      !
-!   mtop  (ix,3)    : vertical indices for low, mid, hi cloud tops      !
-!   mbot  (ix,3)    : vertical indices for low, mid, hi cloud bases     !
-!   de_lgth(ix)     : clouds decorrelation length (km)                  !
-!   alpha(ix,nlay)  : alpha decorrelation parameter
 !                                                                       !
 ! module variables:                                                     !
 !   ivflip          : control flag of vertical index direction          !
@@ -1479,24 +1832,12 @@
      &       slmsk
       integer :: me
 
-      real(kind=kind_phys), dimension(:), intent(in) :: latdeg
-      real(kind=kind_phys), intent(in) :: julian
-      integer, intent(in)              :: yearlen
-
 !  ---  outputs
       real (kind=kind_phys), dimension(:,:,:), intent(out) :: clouds
-
-      real (kind=kind_phys), dimension(:,:),   intent(out) :: clds
-      real (kind=kind_phys), dimension(:),     intent(out) :: de_lgth
-      real (kind=kind_phys), dimension(:,:),   intent(out) :: alpha
-
-      integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
 !  ---  local variables:
       real (kind=kind_phys), dimension(ix,nlay) :: cldtot, cldcnv,      &
      &       cwp, cip, crp, csp, rew, rei, res, rer, tem2d, clwf
-
-      real (kind=kind_phys) :: ptop1(ix,nk_clds+1), rxlat(ix)
 
       real (kind=kind_phys) :: clwmin, clwm, clwt, onemrh, value,       &
      &       tem1, tem2, tem3
@@ -1506,15 +1847,6 @@
 !
 !===> ... begin here
 !
-      do nf=1,nf_clds
-        do k=1,nlay
-          do i=1,ix
-            clouds(i,k,nf) = 0.0
-          enddo
-        enddo
-      enddo
-!     clouds(:,:,:) = 0.0
-
       do k = 1, nlay
         do i = 1, ix
           cldtot(i,k) = 0.0
@@ -1557,23 +1889,6 @@
           enddo
         enddo
       endif
-
-!> -# Find top pressure (ptopc) for each cloud domain for given latitude.
-!     ptopc(k,i): top presure of each cld domain (k=1-4 are sfc,l,m,h;
-!  ---  i=1,2 are low-lat (<45 degree) and pole regions)
-
-      do i =1, IX
-        rxlat(i) = abs( xlat(i) / con_pi )      ! if xlat in pi/2 -> -pi/2 range
-!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)    ! if xlat in 0 -> pi range
-      enddo
-
-      do id = 1, 4
-        tem1 = ptopc(id,2) - ptopc(id,1)
-
-        do i =1, ix
-          ptop1(i,id) = ptopc(id,1) + tem1*max( 0.0, 4.0*rxlat(i)-1.0 )
-        enddo
-      enddo
 
 !> -# Calculate liquid/ice condensate path in \f$ g/m^2 \f$
 
@@ -1705,60 +2020,10 @@
           clouds(i,k,9) = res(i,k)
         enddo
       enddo
-
-      ! Compute cloud decorrelation length 
-      if (idcor == 1) then
-         call cmp_dcorr_lgth(ix, xlat, con_pi, de_lgth)
-      endif
-      if (idcor == 2) then
-        call cmp_dcorr_lgth(ix, latdeg, julian, yearlen, de_lgth)
-      endif
-      if (idcor == 0) then
-         de_lgth(:) = decorr_con
-      endif
-
-      ! Call subroutine get_alpha_exp to define alpha parameter for exponential cloud overlap options
-      if (iovr == 3 .or. iovr == 4 .or. iovr == 5) then
-         call get_alpha_exp(ix, nLay, dzlay, de_lgth, alpha)
-      else
-         de_lgth(:) = 0.
-         alpha(:,:) = 0.
-      endif
-
-      ! Revise alpha for exponential-random cloud overlap
-      ! Decorrelate layers when a clear layer follows a cloudy layer to enforce
-      ! random correlation between non-adjacent blocks of cloudy layers
-      if (iovr == 5) then
-        do k = 2, nLay
-          do i = 1, ix
-            if (clouds(i,k,1) == 0.0 .and. clouds(i,k-1,1) > 0.0) then
-              alpha(i,k) = 0.0
-            endif
-          enddo
-        enddo
-      endif
-
-!> -# Call gethml() to compute low,mid,high,total, and boundary layer
-!! cloud fractions and clouds top/bottom layer indices for low, mid,
-!! and high clouds.
-!       the three cloud domain boundaries are defined by ptopc.  the cloud
-!       overlapping method is defined by control flag 'iovr', which may
-!       be different for lw and sw radiation programs.
-
-
-      call gethml                                                       &
-!  ---  inputs:
-     &     ( plyr, ptop1, cldtot, cldcnv, dz, de_lgth, alpha,           &
-     &       ix,nlay,                                                   &
-!  ---  outputs:
-     &       clds, mtop, mbot                                           &
-     &     )
-
-
 !
       return
 !...................................
-      end subroutine progcld3
+      end subroutine progcld_zhao_carr_pdf
 !! @}
 !-----------------------------------
 
@@ -1788,9 +2053,6 @@
 !!\param  nlay    vertical layer dimension
 !!\param  nlp1    vertical level dimension
 !!\param  dzlay(ix,nlay) distance between model layer centers
-!!\param  latdeg(ix)  latitude (in degrees 90 -> -90)
-!!\param  julian      day of the year (fractional julian day)
-!!\param  yearlen     current length of the year (365/366 days)
 !!\param  clouds  (ix,nlay,nf_clds), cloud profiles
 !!\n              clouds(:,:,1) - layer total cloud fraction
 !!\n              clouds(:,:,2) - layer cloud liquid water path (\f$g m^{-2}\f$)
@@ -1801,24 +2063,19 @@
 !!\n              clouds(:,:,7) - mean effective radius for rain drop (micron)
 !!\n              clouds(:,:,8) - layer snow flake water path (not assigned) (\f$g m^{-2}\f$) (not assigned)
 !!\n              clouds(:,:,9) - mean effective radius for snow flake (micron)
-!!\param  clds    fraction of clouds for low, mid, hi cloud tops
-!!\param  mtop    vertical indices for low, mid, hi cloud tops
-!!\param  mbot    vertical indices for low, mid, hi cloud bases
-!!\param  de_lgth clouds decorrelation length (km)
-!!\param alpha       (IX,NLAY), alpha decorrelation parameter
-!>\section gen_progcld4  progcld4 General Algorithm
+!>\section gen_progcld_gfdl_lin  progcld_gfdl_lin General Algorithm
 !! @{
-      subroutine progcld4                                               &
+      subroutine progcld_gfdl_lin                                       &
      &     ( plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,cnvw,cnvc,          & !  ---  inputs:
      &       xlat,xlon,slmsk,cldtot, dz, delp,                          &
      &       IX, NLAY, NLP1,                                            &
-     &       dzlay, latdeg, julian, yearlen,                            &
-     &       clouds,clds,mtop,mbot,de_lgth,alpha                        & !  ---  outputs:
+     &       dzlay, cldtot1, cldcnv,                                    &
+     &       clouds                                                     & !  ---  outputs:
      &      )
 
 ! =================   subprogram documentation block   ================ !
 !                                                                       !
-! subprogram:    progcld4    computes cloud related quantities using    !
+! subprogram:    progcld_gfdl_lin    computes cloud related quantities using    !
 !   GFDL Lin MP prognostic cloud microphysics scheme.                   !
 !                                                                       !
 ! abstract:  this program computes cloud fractions from cloud           !
@@ -1828,7 +2085,7 @@
 !   top and base.  the three vertical cloud domains are set up in the   !
 !   initial subroutine "cld_init".                                      !
 !                                                                       !
-! usage:         call progcld4                                          !
+! usage:         call progcld_gfdl_lin                                          !
 !                                                                       !
 ! subprograms called:   gethml                                          !
 !                                                                       !
@@ -1859,9 +2116,6 @@
 !   IX              : horizontal dimention                              !
 !   NLAY,NLP1       : vertical layer/level dimensions                   !
 !   dzlay(ix,nlay)  : thickness between model layer centers (km)        !
-!   latdeg(ix)      : latitude (in degrees 90 -> -90)                   !
-!   julian          : day of the year (fractional julian day)           !
-!   yearlen         : current length of the year (365/366 days)         !
 !                                                                       !
 ! output variables:                                                     !
 !   clouds(IX,NLAY,NF_CLDS) : cloud profiles                            !
@@ -1874,12 +2128,6 @@
 !      clouds(:,:,7) - mean eff radius for rain drop      (micron)      !
 !  *** clouds(:,:,8) - layer snow flake water path        not assigned  !
 !      clouds(:,:,9) - mean eff radius for snow flake     (micron)      !
-!  *** fu's scheme need to be normalized by snow density (g/m**3/1.0e6) !
-!   clds  (IX,5)    : fraction of clouds for low, mid, hi, tot, bl      !
-!   mtop  (IX,3)    : vertical indices for low, mid, hi cloud tops      !
-!   mbot  (IX,3)    : vertical indices for low, mid, hi cloud bases     !
-!   de_lgth(ix)     : clouds decorrelation length (km)                  !
-!   alpha(ix,nlay)  : alpha decorrelation parameter
 !                                                                       !
 ! module variables:                                                     !
 !   ivflip          : control flag of vertical index direction          !
@@ -1907,24 +2155,13 @@
       real (kind=kind_phys), dimension(:),   intent(in) :: xlat, xlon,  &
      &       slmsk
 
-      real(kind=kind_phys), dimension(:), intent(in) :: latdeg
-      real(kind=kind_phys), intent(in) :: julian
-      integer, intent(in)              :: yearlen
-
+      real (kind=kind_phys), dimension(:,:), intent(inout) :: cldtot1
 !  ---  outputs
       real (kind=kind_phys), dimension(:,:,:), intent(out) :: clouds
-
-      real (kind=kind_phys), dimension(:,:),   intent(out) :: clds
-      real (kind=kind_phys), dimension(:),     intent(out) :: de_lgth
-      real (kind=kind_phys), dimension(:,:),   intent(out) :: alpha
-
-      integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
 !  ---  local variables:
       real (kind=kind_phys), dimension(IX,NLAY) :: cldcnv,              &
      &       cwp, cip, crp, csp, rew, rei, res, rer, tem2d, clwf
-
-      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1), rxlat(ix)
 
       real (kind=kind_phys) :: clwmin, clwm, clwt, onemrh, value,       &
      &       tem1, tem2, tem3
@@ -1934,15 +2171,6 @@
 !
 !===> ... begin here
 !
-      do nf=1,nf_clds
-        do k=1,nlay
-          do i=1,ix
-            clouds(i,k,nf) = 0.0
-          enddo
-        enddo
-      enddo
-!     clouds(:,:,:) = 0.0
-
 !> - Assign liquid/ice/rain/snow cloud doplet effective radius as default value.
       do k = 1, NLAY
         do i = 1, IX
@@ -1977,23 +2205,6 @@
           enddo
         enddo
       endif
-
-!> - Compute top pressure for each cloud domain for given latitude.
-!!\n ptopc(k,i): top presure of each cld domain (k=1-4 are sfc,L,m,h;
-!!   i=1,2 are low-lat (<45 degree) and pole regions)
-
-      do i =1, IX
-        rxlat(i) = abs( xlat(i) / con_pi )      ! if xlat in pi/2 -> -pi/2 range
-!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)    ! if xlat in 0 -> pi range
-      enddo
-
-      do id = 1, 4
-        tem1 = ptopc(id,2) - ptopc(id,1)
-
-        do i =1, IX
-          ptop1(i,id) = ptopc(id,1) + tem1*max( 0.0, 4.0*rxlat(i)-1.0 )
-        enddo
-      enddo
 
 !> - Compute liquid/ice condensate path in \f$g m^{-2}\f$.
 
@@ -2067,6 +2278,12 @@
         enddo
       enddo
 
+      do k = 1, NLAY
+        do i = 1, IX
+          cldtot1(i,k) = cldtot(i,k)
+        enddo
+      enddo
+
 !
       do k = 1, NLAY
         do i = 1, IX
@@ -2081,58 +2298,10 @@
           clouds(i,k,9) = res(i,k)
         enddo
       enddo
-
-      ! Compute cloud decorrelation length 
-      if (idcor == 1) then
-         call cmp_dcorr_lgth(ix, xlat, con_pi, de_lgth)
-      endif
-      if (idcor == 2) then
-        call cmp_dcorr_lgth(ix, latdeg, julian, yearlen, de_lgth)
-      endif
-      if (idcor == 0) then
-         de_lgth(:) = decorr_con
-      endif
-
-      ! Call subroutine get_alpha_exp to define alpha parameter for exponential cloud overlap options
-      if (iovr == 3 .or. iovr == 4 .or. iovr == 5) then
-         call get_alpha_exp(ix, nLay, dzlay, de_lgth, alpha)
-      else
-         de_lgth(:) = 0.
-         alpha(:,:) = 0.
-      endif
-
-      ! Revise alpha for exponential-random cloud overlap
-      ! Decorrelate layers when a clear layer follows a cloudy layer to enforce
-      ! random correlation between non-adjacent blocks of cloudy layers
-      if (iovr == 5) then
-        do k = 2, nLay
-          do i = 1, ix
-            if (clouds(i,k,1) == 0.0 .and. clouds(i,k-1,1) > 0.0) then
-              alpha(i,k) = 0.0
-            endif
-          enddo
-        enddo
-      endif
-
-!  ---  compute low, mid, high, total, and boundary layer cloud fractions
-!       and clouds top/bottom layer indices for low, mid, and high clouds.
-!       The three cloud domain boundaries are defined by ptopc.  The cloud
-!       overlapping method is defined by control flag 'iovr', which may
-!       be different for lw and sw radiation programs.
-
-      call gethml                                                       &
-!  ---  inputs:
-     &     ( plyr, ptop1, cldtot, cldcnv, dz, de_lgth, alpha,           &
-     &       IX,NLAY,                                                   &
-!  ---  outputs:
-     &       clds, mtop, mbot                                           &
-     &     )
-
-
 !
       return
 !...................................
-      end subroutine progcld4
+      end subroutine progcld_gfdl_lin
 !! @}
 !-----------------------------------
 
@@ -2167,9 +2336,6 @@
 !>\param nlay      vertical layer dimension
 !>\param nlp1      vertical level dimension
 !!\param dzlay(ix,nlay) distance between model layer centers
-!!\param latdeg(ix)  latitude (in degrees 90 -> -90)
-!!\param julian      day of the year (fractional julian day)
-!!\param yearlen     current length of the year (365/366 days)
 !>\param clouds    (ix,nlay,nf_clds),  cloud profiles
 !!\n               clouds(:,:,1) - layer totoal cloud fraction
 !!\n               clouds(:,:,2) - layer cloud liquid water path (\f$g m^{-2}\f$)
@@ -2180,11 +2346,6 @@
 !!\n               clouds(:,:,7) - mean effective radius for rain drop (micron)
 !!\n               clouds(:,:,8) - layer snow flake water path (\f$g m^{-2}\f$)
 !!\n               clouds(:,:,9) - mean effective radius for snow flake (micron)
-!>\param clds      (ix,5), fraction of clouds for low, mid, hi, tot, bl
-!>\param mtop      (ix,3), vertical indices for low, mid, hi cloud tops
-!>\param mbot      (ix,3), vertical indices for low, mid, hi cloud bases
-!>\param de_lgth   clouds decorrelation length (km)
-!!\param alpha       (IX,NLAY), alpha decorrelation parameter
 !>\section gen_progcld4o progcld4o General Algorithm
 !! @{
       subroutine progcld4o                                              &
@@ -2192,8 +2353,8 @@
      &       xlat,xlon,slmsk, dz, delp,                                 &
      &       ntrac,ntcw,ntiw,ntrw,ntsw,ntgl,ntclamt,                    &
      &       IX, NLAY, NLP1,                                            &
-     &       dzlay, latdeg, julian, yearlen,                            &
-     &       clouds,clds,mtop,mbot,de_lgth,alpha                        & !  ---  outputs:
+     &       dzlay, cldtot, cldcnv,                                     &
+     &       clouds                                                     & !  ---  outputs:
      &      )
 
 ! =================   subprogram documentation block   ================ !
@@ -2238,9 +2399,6 @@
 !   IX              : horizontal dimention                              !
 !   NLAY,NLP1       : vertical layer/level dimensions                   !
 !   dzlay(ix,nlay)  : thickness between model layer centers (km)        !
-!   latdeg(ix)      : latitude (in degrees 90 -> -90)                   !
-!   julian          : day of the year (fractional julian day)           !
-!   yearlen         : current length of the year (365/366 days)         !
 !                                                                       !
 ! output variables:                                                     !
 !   clouds(IX,NLAY,NF_CLDS) : cloud profiles                            !
@@ -2289,24 +2447,12 @@
       real (kind=kind_phys), dimension(:),   intent(in) :: xlat, xlon,  &
      &       slmsk
 
-      real(kind=kind_phys), dimension(:), intent(in) :: latdeg
-      real(kind=kind_phys), intent(in) :: julian
-      integer, intent(in)              :: yearlen
-
 !  ---  outputs
       real (kind=kind_phys), dimension(:,:,:), intent(out) :: clouds
-
-      real (kind=kind_phys), dimension(:,:),   intent(out) :: clds
-      real (kind=kind_phys), dimension(:),     intent(out) :: de_lgth
-      real (kind=kind_phys), dimension(:,:),   intent(out) :: alpha
-
-      integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
 !  ---  local variables:
       real (kind=kind_phys), dimension(IX,NLAY) :: cldcnv,              &
      &       cwp, cip, crp, csp, rew, rei, res, rer, tem2d
-
-      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1), rxlat(ix)
 
       real (kind=kind_phys) :: clwmin, clwm, clwt, onemrh, value,       &
      &       tem1, tem2, tem3
@@ -2317,15 +2463,6 @@
 !
 !===> ... begin here
 !
-      do nf=1,nf_clds
-        do k=1,nlay
-          do i=1,ix
-            clouds(i,k,nf) = 0.0
-          enddo
-        enddo
-      enddo
-!     clouds(:,:,:) = 0.0
-
 !> - Assign liquid/ice/rain/snow cloud droplet effective radius as default value.
       do k = 1, NLAY
         do i = 1, IX
@@ -2340,23 +2477,6 @@
           res   (i,k) = rsnow_def            ! default snow radius to 250 micron
           tem2d (i,k) = min( 1.0, max( 0.0, (con_ttp-tlyr(i,k))*0.05 ) )
           cldtot(i,k) = clw(i,k,ntclamt)
-        enddo
-      enddo
-
-!> - Compute top pressure for each cloud domain for given latitude.
-!! ptopc(k,i): top presure of each cld domain (k=1-4 are sfc,L,m,h;
-!! i=1,2 are low-lat (<45 degree) and pole regions)
-
-      do i =1, IX
-        rxlat(i) = abs( xlat(i) / con_pi )      ! if xlat in pi/2 -> -pi/2 range
-!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)    ! if xlat in 0 -> pi range
-      enddo
-
-      do id = 1, 4
-        tem1 = ptopc(id,2) - ptopc(id,1)
-
-        do i =1, IX
-          ptop1(i,id) = ptopc(id,1) + tem1*max( 0.0, 4.0*rxlat(i)-1.0 )
         enddo
       enddo
 
@@ -2448,54 +2568,6 @@
           clouds(i,k,9) = rei(i,k)
         enddo
       enddo
-
-      ! Compute cloud decorrelation length 
-      if (idcor == 1) then
-         call cmp_dcorr_lgth(ix, xlat, con_pi, de_lgth)
-      endif
-      if (idcor == 2) then
-        call cmp_dcorr_lgth(ix, latdeg, julian, yearlen, de_lgth)
-      endif
-      if (idcor == 0) then
-         de_lgth(:) = decorr_con
-      endif
-
-      ! Call subroutine get_alpha_exp to define alpha parameter for exponential cloud overlap options
-      if (iovr == 3 .or. iovr == 4 .or. iovr == 5) then
-         call get_alpha_exp(ix, nLay, dzlay, de_lgth, alpha)
-      else
-         de_lgth(:) = 0.
-         alpha(:,:) = 0.
-      endif
-
-      ! Revise alpha for exponential-random cloud overlap
-      ! Decorrelate layers when a clear layer follows a cloudy layer to enforce
-      ! random correlation between non-adjacent blocks of cloudy layers
-      if (iovr == 5) then
-        do k = 2, nLay
-          do i = 1, ix
-            if (clouds(i,k,1) == 0.0 .and. clouds(i,k-1,1) > 0.0) then
-              alpha(i,k) = 0.0
-            endif
-          enddo
-        enddo
-      endif
-
-!> - Call gethml() to compute low, mid, high, total, and boundary layer cloud fractions
-!! and clouds top/bottom layer indices for low, mid, and high clouds.
-!! The three cloud domain boundaries are defined by ptopc.  The cloud
-!! overlapping method is defined by control flag 'iovr', which may
-!! be different for lw and sw radiation programs.
-
-      call gethml                                                       &
-!  ---  inputs:
-     &     ( plyr, ptop1, cldtot, cldcnv, dz, de_lgth, alpha,           &
-     &       IX,NLAY,                                                   &
-!  ---  outputs:
-     &       clds, mtop, mbot                                           &
-     &     )
-
-
 !
       return
 !...................................
@@ -2507,20 +2579,20 @@
 !> \ingroup module_radiation_clouds
 !! This subroutine computes cloud related quantities using
 !! Ferrier-Aligo cloud microphysics scheme.
-      subroutine progcld5                                               &
+      subroutine progcld_fer_hires                                      &
      &     ( plyr,plvl,tlyr,tvly,qlyr,qstl,rhly,clw,                    &    !  ---  inputs:
      &       xlat,xlon,slmsk,dz,delp,                                   &
      &       ntrac,ntcw,ntiw,ntrw,                                      &
      &       IX, NLAY, NLP1, icloud,                                    &
      &       uni_cld, lmfshal, lmfdeep2, cldcov,                        &
      &       re_cloud,re_ice,re_snow,                                   &
-     &       dzlay, latdeg, julian, yearlen,                            &
-     &       clouds,clds,mtop,mbot,de_lgth,alpha                        &    !  ---  outputs:
+     &       dzlay, cldtot, cldcnv,                                     &
+     &       clouds                                                     &    !  ---  outputs:
      &      )
 
 ! =================   subprogram documentation block   ================ !
 !                                                                       !
-! subprogram:    progcld5    computes cloud related quantities using    !
+! subprogram:    progcld_fer_hires    computes cloud related quantities using    !
 !   Ferrier-Aligo cloud microphysics scheme.                            !
 !                                                                       !
 ! abstract:  this program computes cloud fractions from cloud           !
@@ -2530,7 +2602,7 @@
 !   top and base.  the three vertical cloud domains are set up in the   !
 !   initial subroutine "cld_init".                                      !
 !                                                                       !
-! usage:         call progcld5                                          !
+! usage:         call progcld_fer_hires                                          !
 !                                                                       !
 ! subprograms called:   gethml                                          !
 !                                                                       !
@@ -2564,9 +2636,6 @@
 !   lmfdeep2        : logical - true for mass flux deep convection      !
 !   cldcov          : layer cloud fraction (used when uni_cld=.true.    !
 !   dzlay(ix,nlay)  : thickness between model layer centers (km)        !
-!   latdeg(ix)      : latitude (in degrees 90 -> -90)                   !
-!   julian          : day of the year (fractional julian day)           !
-!   yearlen         : current length of the year (365/366 days)         !
 !                                                                       !
 ! output variables:                                                     !
 !   clouds(IX,NLAY,NF_CLDS) : cloud profiles                            !
@@ -2579,12 +2648,6 @@
 !      clouds(:,:,7) - mean eff radius for rain drop      (micron)      !
 !  *** clouds(:,:,8) - layer snow flake water path        not assigned  !
 !      clouds(:,:,9) - mean eff radius for snow flake     (micron)      !
-!  *** fu's scheme need to be normalized by snow density (g/m**3/1.0e6) !
-!   clds  (IX,5)    : fraction of clouds for low, mid, hi, tot, bl      !
-!   mtop  (IX,3)    : vertical indices for low, mid, hi cloud tops      !
-!   mbot  (IX,3)    : vertical indices for low, mid, hi cloud bases     !
-!   de_lgth(ix)     : clouds decorrelation length (km)                  !
-!   alpha(ix,nlay)  : alpha decorrelation parameter
 !                                                                       !
 ! module variables:                                                     !
 !   ivflip          : control flag of vertical index direction          !
@@ -2620,24 +2683,12 @@
       real (kind=kind_phys), dimension(:),   intent(in) :: xlat, xlon,  &
      &       slmsk
 
-      real(kind=kind_phys), dimension(:), intent(in) :: latdeg
-      real(kind=kind_phys), intent(in) :: julian
-      integer, intent(in)              :: yearlen
-
 !  ---  outputs
       real (kind=kind_phys), dimension(:,:,:), intent(out) :: clouds
-
-      real (kind=kind_phys), dimension(:,:),   intent(out) :: clds
-      real (kind=kind_phys), dimension(:),     intent(out) :: de_lgth
-      real (kind=kind_phys), dimension(:,:),   intent(out) :: alpha
-
-      integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
 !  ---  local variables:
       real (kind=kind_phys), dimension(IX,NLAY) :: cldtot, cldcnv,      &
      &       cwp, cip, crp, csp, rew, rei, res, rer, tem2d, clwf
-
-      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1), rxlat(ix)
 
       real (kind=kind_phys) :: clwmin, clwm, clwt, onemrh, value,       &
      &       tem1, tem2, tem3
@@ -2651,15 +2702,6 @@
 !
 !===> ... begin here
 !
-      do nf=1,nf_clds
-        do k=1,nlay
-          do i=1,ix
-            clouds(i,k,nf) = 0.0
-          enddo
-        enddo
-      enddo
-!     clouds(:,:,:) = 0.0
-
       do k = 1, NLAY
         do i = 1, IX
           cldtot(i,k) = 0.0
@@ -2700,22 +2742,6 @@
             clwf(i,k) = clw(i,k,ntcw) +  clw(i,k,ntiw)
           enddo
         enddo
-!> - Find top pressure for each cloud domain for given latitude.
-!! ptopc(k,i): top presure of each cld domain (k=1-4 are sfc,L,m,h;
-!! i=1,2 are low-lat (<45 degree) and pole regions)
-
-      do i =1, IX
-        rxlat(i) = abs( xlat(i) / con_pi )      ! if xlat in pi/2 -> -pi/2 range
-!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)    ! if xlat in 0 -> pi range
-      enddo
-
-      do id = 1, 4
-        tem1 = ptopc(id,2) - ptopc(id,1)
-
-        do i =1, IX
-          ptop1(i,id) = ptopc(id,1) + tem1*max( 0.0, 4.0*rxlat(i)-1.0 )
-        enddo
-      enddo
 
 !> - Compute cloud liquid/ice condensate path in \f$ g/m^2 \f$ .
 
@@ -2837,67 +2863,16 @@
 
         enddo
       enddo
-
-      ! Compute cloud decorrelation length 
-      if (idcor == 1) then
-         call cmp_dcorr_lgth(ix, xlat, con_pi, de_lgth)
-      endif
-      if (idcor == 2) then
-        call cmp_dcorr_lgth(ix, latdeg, julian, yearlen, de_lgth)
-      endif
-      if (idcor == 0) then
-         de_lgth(:) = decorr_con
-      endif
-
-      ! Call subroutine get_alpha_exp to define alpha parameter for exponential cloud overlap options
-      if (iovr == 3 .or. iovr == 4 .or. iovr == 5) then
-         call get_alpha_exp(ix, nLay, dzlay, de_lgth, alpha)
-      else
-         de_lgth(:) = 0.
-         alpha(:,:) = 0.
-      endif
-
-      ! Revise alpha for exponential-random cloud overlap
-      ! Decorrelate layers when a clear layer follows a cloudy layer to enforce
-      ! random correlation between non-adjacent blocks of cloudy layers
-      if (iovr == 5) then
-        do k = 2, nLay
-          do i = 1, ix
-            if (clouds(i,k,1) == 0.0 .and. clouds(i,k-1,1) > 0.0) then
-              alpha(i,k) = 0.0
-            endif
-          enddo
-        enddo
-      endif
-
-!> - Call gethml() to compute low,mid,high,total, and boundary layer
-!! cloud fractions and clouds top/bottom layer indices for low, mid,
-!! and high clouds.
-!  ---  compute low, mid, high, total, and boundary layer cloud fractions
-!       and clouds top/bottom layer indices for low, mid, and high clouds.
-!       The three cloud domain boundaries are defined by ptopc.  The cloud
-!       overlapping method is defined by control flag 'iovr', which may
-!       be different for lw and sw radiation programs.
-
-      call gethml                                                       &
-!  ---  inputs:
-     &     ( plyr, ptop1, cldtot, cldcnv, dz, de_lgth, alpha,           &
-     &       IX,NLAY,                                                   &
-!  ---  outputs:
-     &       clds, mtop, mbot                                           &
-     &     )
-
-
 !
       return
 !...................................
-      end subroutine progcld5
+      end subroutine progcld_fer_hires
 !...................................
 
 
-!mz: this is the original progcld5 for Thompson MP (and WSM6),
-! to be replaced by the GSL version of progcld6 for Thompson MP
-      subroutine progcld6                                               &
+!mz: this is the original progcld_fer_hires for Thompson MP (and WSM6),
+! to be replaced by the GSL version of progcld_thompson_wsm6 for Thompson MP
+      subroutine progcld_thompson_wsm6                                  &
      &     ( plyr,plvl,tlyr,qlyr,qstl,rhly,clw,                         &    !  ---  inputs:
      &       xlat,xlon,slmsk,dz,delp,                                   &
      &       ntrac,ntcw,ntiw,ntrw,ntsw,ntgl,                            &
@@ -2905,13 +2880,13 @@
      &       uni_cld, lmfshal, lmfdeep2, cldcov, cnvw,                  &
      &       re_cloud,re_ice,re_snow,                                   &
      &       lwp_ex, iwp_ex, lwp_fc, iwp_fc,                            &
-     &       dzlay, latdeg, julian, yearlen,                            &
-     &       clouds,clds,mtop,mbot,de_lgth,alpha                        &    !  ---  outputs:
+     &       dzlay, cldtot, cldcnv,                                     &
+     &       clouds                                                     &    !  ---  outputs:
      &      )
 
 ! =================   subprogram documentation block   ================ !
 !                                                                       !
-! subprogram:    progcld6    computes cloud related quantities using    !
+! subprogram:    progcld_thompson_wsm6    computes cloud related quantities using    !
 !   Thompson/WSM6 cloud microphysics scheme.                            !
 !                                                                       !
 ! abstract:  this program computes cloud fractions from cloud           !
@@ -2921,7 +2896,7 @@
 !   top and base.  the three vertical cloud domains are set up in the   !
 !   initial subroutine "cld_init".                                      !
 !                                                                       !
-! usage:         call progcld6                                          !
+! usage:         call progcld_thompson_wsm6                                          !
 !                                                                       !
 ! subprograms called:   gethml                                          !
 !                                                                       !
@@ -3006,24 +2981,12 @@
       real (kind=kind_phys), dimension(:),   intent(in) :: xlat, xlon,  &
      &       slmsk
 
-      real(kind=kind_phys), dimension(:), intent(in) :: latdeg
-      real(kind=kind_phys), intent(in) :: julian
-      integer, intent(in)              :: yearlen
-
 !  ---  outputs
       real (kind=kind_phys), dimension(:,:,:), intent(out) :: clouds
-
-      real (kind=kind_phys), dimension(:,:),   intent(out) :: clds
-      real (kind=kind_phys), dimension(:),     intent(out) :: de_lgth
-      real (kind=kind_phys), dimension(:,:),   intent(out) :: alpha
-
-      integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
 !  ---  local variables:
       real (kind=kind_phys), dimension(IX,NLAY) :: cldtot, cldcnv,      &
      &       cwp, cip, crp, csp, rew, rei, res, rer, tem2d, clwf
-
-      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1), rxlat(ix)
 
       real (kind=kind_phys) :: clwmin, clwm, clwt, onemrh, value,       &
      &       tem1, tem2, tem3
@@ -3035,15 +2998,6 @@
 
 !
 !===> ... begin here
-
-      do nf=1,nf_clds
-        do k=1,nlay
-          do i=1,ix
-            clouds(i,k,nf) = 0.0
-          enddo
-        enddo
-      enddo
-!     clouds(:,:,:) = 0.0
 
       do k = 1, NLAY
         do i = 1, IX
@@ -3087,22 +3041,6 @@
      &      + clw(i,k,ntrw) + cnvw(i,k)
           enddo
         enddo
-!> - Find top pressure for each cloud domain for given latitude.
-!! ptopc(k,i): top presure of each cld domain (k=1-4 are sfc,L,m,h;
-!! i=1,2 are low-lat (<45 degree) and pole regions)
-
-      do i =1, IX
-        rxlat(i) = abs( xlat(i) / con_pi )      ! if xlat in pi/2 -> -pi/2 range
-!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)    ! if xlat in 0 -> pi range
-      enddo
-
-      do id = 1, 4
-        tem1 = ptopc(id,2) - ptopc(id,1)
-
-        do i =1, IX
-          ptop1(i,id) = ptopc(id,1) + tem1*max( 0.0, 4.0*rxlat(i)-1.0 )
-        enddo
-      enddo
 
 !> - Compute cloud liquid/ice condensate path in \f$ g/m^2 \f$ .
 
@@ -3247,59 +3185,10 @@
         enddo
       enddo
 
-      ! Compute cloud decorrelation length 
-      if (idcor == 1) then
-         call cmp_dcorr_lgth(ix, xlat, con_pi, de_lgth)
-      endif
-      if (idcor == 2) then
-        call cmp_dcorr_lgth(ix, latdeg, julian, yearlen, de_lgth)
-      endif
-      if (idcor == 0) then
-         de_lgth(:) = decorr_con
-      endif
-
-      ! Call subroutine get_alpha_exp to define alpha parameter for exponential cloud overlap options
-      if ( iovr == 3 .or. iovr == 4 .or. iovr == 5) then
-         call get_alpha_exp(ix, nLay, dzlay, de_lgth, alpha)
-      else
-         de_lgth(:) = 0.
-         alpha(:,:) = 0.
-      endif
-
-      ! Revise alpha for exponential-random cloud overlap
-      ! Decorrelate layers when a clear layer follows a cloudy layer to enforce
-      ! random correlation between non-adjacent blocks of cloudy layers
-      if (iovr == 5) then
-        do k = 2, nLay
-          do i = 1, ix
-            if (clouds(i,k,1) == 0.0 .and. clouds(i,k-1,1) > 0.0) then
-              alpha(i,k) = 0.0
-            endif
-          enddo
-        enddo
-      endif
-
-!> - Call gethml() to compute low,mid,high,total, and boundary layer
-!!    cloud fractions and clouds top/bottom layer indices for low, mid,
-!!    and high clouds.
-!  ---  compute low, mid, high, total, and boundary layer cloud fractions
-!       and clouds top/bottom layer indices for low, mid, and high clouds.
-!       The three cloud domain boundaries are defined by ptopc.  The cloud
-!       overlapping method is defined by control flag 'iovr', which may
-!       be different for lw and sw radiation programs.
-
-      call gethml                                                       &
-!  ---  inputs:
-     &     ( plyr, ptop1, cldtot, cldcnv, dz, de_lgth, alpha,           &
-     &       IX,NLAY,                                                   &
-!  ---  outputs:
-     &       clds, mtop, mbot                                           &
-     &     )
-
       return
 
 !............................................
-      end subroutine progcld6
+      end subroutine progcld_thompson_wsm6
 !............................................
 !mz
 
@@ -3322,8 +3211,8 @@
      &       uni_cld, lmfshal, lmfdeep2, cldcov,                        &
      &       re_cloud,re_ice,re_snow,                                   &
      &       lwp_ex, iwp_ex, lwp_fc, iwp_fc,                            &
-     &       dzlay, latdeg, julian, yearlen, gridkm,                    &
-     &       clouds,clds,mtop,mbot,de_lgth,alpha                        &    !  ---  outputs:
+     &       dzlay,  gridkm, cldtot, cldcnv,                            &
+     &       clouds                                                     &    !  ---  outputs:
      &      )
 
 ! =================   subprogram documentation block   ================ !
@@ -3384,11 +3273,6 @@
 !      clouds(:,:,7) - mean eff radius for rain drop      (micron)      !
 !      clouds(:,:,8) - layer snow flake water path        not assigned  !
 !      clouds(:,:,9) - mean eff radius for snow flake     (micron)      !
-!  *** fu's scheme need to be normalized by snow density (g/m**3/1.0e6) !
-!   clds  (IX,5)    : fraction of clouds for low, mid, hi, tot, bl      !
-!   mtop  (IX,3)    : vertical indices for low, mid, hi cloud tops      !
-!   mbot  (IX,3)    : vertical indices for low, mid, hi cloud bases     !
-!   de_lgth(ix)     : clouds decorrelation length (km)                  !
 !                                                                       !
 ! module variables:                                                     !
 !   ivflip          : control flag of vertical index direction          !
@@ -3423,19 +3307,10 @@
 
       real (kind=kind_phys), dimension(:),   intent(in) :: xlat, xlon,  &
      &       slmsk
-
-      real(kind=kind_phys), dimension(:), intent(in) :: latdeg, gridkm
-      real(kind=kind_phys), intent(in) :: julian
-      integer, intent(in)              :: yearlen
+      real(kind=kind_phys), dimension(:), intent(in) :: gridkm
 
 !  ---  outputs
       real (kind=kind_phys), dimension(:,:,:), intent(out) :: clouds
-
-      real (kind=kind_phys), dimension(:,:),   intent(out) :: clds
-      real (kind=kind_phys), dimension(:),     intent(out) :: de_lgth
-      real (kind=kind_phys), dimension(:,:),   intent(out) :: alpha
-
-      integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
 !  ---  local variables:
       real (kind=kind_phys), dimension(IX,NLAY) :: cldtot, cldcnv,      &
@@ -3443,8 +3318,6 @@
 
       real (kind=kind_phys), dimension(NLAY) :: cldfra1d, qv1d,         &
      &                                 qc1d, qi1d, qs1d, dz1d, p1d, t1d
-
-      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1), rxlat(ix)
 
       real (kind=kind_phys) :: clwmin, tem1
       real (kind=kind_phys) :: corr, xland, snow_mass_factor
@@ -3478,23 +3351,6 @@
           rei   (i,k) = re_ice(i,k)
           rer   (i,k) = rrain_def            ! default rain radius to 1000 micron
           res   (i,k) = re_snow(i,K)
-        enddo
-      enddo
-
-!> - Find top pressure for each cloud domain for given latitude.
-!! ptopc(k,i): top presure of each cld domain (k=1-4 are sfc,L,m,h;
-!! i=1,2 are low-lat (<45 degree) and pole regions)
-
-      do i =1, IX
-        rxlat(i) = abs( xlat(i) / con_pi )      ! if xlat in pi/2 -> -pi/2 range
-!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)    ! if xlat in 0 -> pi range
-      enddo
-
-      do id = 1, 4
-        tem1 = ptopc(id,2) - ptopc(id,1)
-
-        do i =1, IX
-          ptop1(i,id) = ptopc(id,1) + tem1*max( 0.0, 4.0*rxlat(i)-1.0 )
         enddo
       enddo
 
@@ -3626,56 +3482,6 @@
          lwp_ex(i) = lwp_ex(i)*1.E-3
          iwp_ex(i) = iwp_ex(i)*1.E-3
       enddo
-
-      ! Compute cloud decorrelation length 
-      if (idcor == 1) then
-         call cmp_dcorr_lgth(ix, xlat, con_pi, de_lgth)
-      endif
-      if (idcor == 2) then
-        call cmp_dcorr_lgth(ix, latdeg, julian, yearlen, de_lgth)
-      endif
-      if (idcor == 0) then
-         de_lgth(:) = decorr_con
-      endif
-
-      ! Call subroutine get_alpha_exp to define alpha parameter for exponential cloud overlap options
-      if ( iovr == 3 .or. iovr == 4 .or. iovr == 5) then
-         call get_alpha_exp(ix, nLay, dzlay, de_lgth, alpha)
-      else
-         de_lgth(:) = 0.
-         alpha(:,:) = 0.
-      endif
-
-      ! Revise alpha for exponential-random cloud overlap
-      ! Decorrelate layers when a clear layer follows a cloudy layer to enforce
-      ! random correlation between non-adjacent blocks of cloudy layers
-      if (iovr == 5) then
-        do k = 2, nLay
-          do i = 1, ix
-            if (clouds(i,k,1) == 0.0 .and. clouds(i,k-1,1) > 0.0) then
-              alpha(i,k) = 0.0
-            endif
-          enddo
-        enddo
-      endif
-
-!> - Call gethml() to compute low,mid,high,total, and boundary layer
-!!    cloud fractions and clouds top/bottom layer indices for low, mid,
-!!    and high clouds.
-!  ---  compute low, mid, high, total, and boundary layer cloud fractions
-!       and clouds top/bottom layer indices for low, mid, and high clouds.
-!       The three cloud domain boundaries are defined by ptopc.  The cloud
-!       overlapping method is defined by control flag 'iovr', which may
-!       be different for lw and sw radiation programs.
-
-      call gethml                                                       &
-!  ---  inputs:
-     &     ( plyr, ptop1, cldtot, cldcnv, dz, de_lgth, alpha,           &
-     &       IX,NLAY,                                                   &
-!  ---  outputs:
-     &       clds, mtop, mbot                                           &
-     &     )
-
 !
       return
 
@@ -3709,9 +3515,6 @@
 !!\param effrs       (IX,NLAY), effective radius for snow water
 !!\param effr_in      logical - if .true. use input effective radii
 !!\param dzlay(ix,nlay) distance between model layer centers
-!!\param latdeg(ix)  latitude (in degrees 90 -> -90)
-!!\param julian      day of the year (fractional julian day)
-!!\param yearlen     current length of the year (365/366 days)
 !!\param clouds      (IX,NLAY,NF_CLDS), cloud profiles
 !!\n                 (:,:,1) - layer total cloud fraction
 !!\n                 (:,:,2) - layer cloud liq water path \f$(g/m^2)\f$
@@ -3722,19 +3525,14 @@
 !!\n                 (:,:,7) - mean eff radius for rain drop (micron)
 !!\n                 (:,:,8) - layer snow flake water path
 !!\n                 (:,:,9) - mean eff radius for snow flake (micron)
-!!\param clds       (IX,5), fraction of clouds for low, mid, hi, tot, bl
-!!\param mtop       (IX,3), vertical indices for low, mid, hi cloud tops
-!!\param mbot       (IX,3), vertical indices for low, mid, hi cloud bases
-!!\param de_lgth    (IX),   clouds decorrelation length (km)
-!!\param alpha       (IX,NLAY), alpha decorrelation parameter
 !>\section gen_progclduni progclduni General Algorithm
 !> @{
       subroutine progclduni                                             &
      &     ( plyr,plvl,tlyr,tvly,ccnd,ncnd,                             &    !  ---  inputs:
      &       xlat,xlon,slmsk,dz,delp, IX, NLAY, NLP1, cldtot,           &
      &       effrl,effri,effrr,effrs,effr_in,                           &
-     &       dzlay, latdeg, julian, yearlen,                            &
-     &       clouds,clds,mtop,mbot,de_lgth,alpha                        &    !  ---  outputs:
+     &       dzlay, cldtot1, cldcnv,                                     &
+     &       clouds                                                     &    !  ---  outputs:
      &      )
 
 ! =================   subprogram documentation block   ================ !
@@ -3783,9 +3581,6 @@
 !   dz    (ix,nlay)      : layer thickness (km)                              !
 !   delp  (ix,nlay)      : model layer pressure thickness in mb (100Pa)      !
 !   dzlay(ix,nlay)  : thickness between model layer centers (km)        !
-!   latdeg(ix)      : latitude (in degrees 90 -> -90)                   !
-!   julian          : day of the year (fractional julian day)           !
-!   yearlen         : current length of the year (365/366 days)         !
 !                                                                       !
 ! output variables:                                                     !
 !   clouds(IX,NLAY,NF_CLDS) : cloud profiles                            !
@@ -3834,27 +3629,14 @@
       real (kind=kind_phys), dimension(:),   intent(in) :: xlat, xlon,  &
      &       slmsk
 
-      real(kind=kind_phys), dimension(:), intent(in) :: latdeg
-      real(kind=kind_phys), intent(in) :: julian
-      integer, intent(in)              :: yearlen
-
+      real (kind=kind_phys), dimension(:,:), intent(inout) :: cldtot1
 !  ---  outputs
       real (kind=kind_phys), dimension(:,:,:), intent(out) :: clouds
-
-      real (kind=kind_phys), dimension(:,:),   intent(out) :: clds
-
-      real (kind=kind_phys), dimension(:),     intent(out) :: de_lgth
-
-      real (kind=kind_phys), dimension(:,:),   intent(out) :: alpha
-
-      integer,               dimension(:,:),   intent(out) :: mtop,mbot
 
 !  ---  local variables:
       real (kind=kind_phys), dimension(IX,NLAY) :: cldcnv, cwp, cip,    &
      &       crp, csp, rew, rei, res, rer
       real (kind=kind_phys), dimension(IX,NLAY,ncnd) :: cndf
-
-      real (kind=kind_phys) :: ptop1(IX,NK_CLDS+1), rxlat(ix)
 
       real (kind=kind_phys) :: tem1, tem2, tem3
 
@@ -3862,14 +3644,6 @@
 
 !
 !===> ... begin here
-!
-!     do nf=1,nf_clds
-!       do k=1,nlay
-!         do i=1,ix
-!           clouds(i,k,nf) = 0.0
-!         enddo
-!       enddo
-!     enddo
 !
       do k = 1, NLAY
         do i = 1, IX
@@ -4006,6 +3780,12 @@
           enddo
         enddo
       endif
+
+      do k = 1, NLAY
+        do i = 1, IX
+          cldtot1(i,k) = cldtot(i,k)
+        enddo
+      enddo
 !
       do k = 1, NLAY
         do i = 1, IX
@@ -4020,73 +3800,6 @@
           clouds(i,k,9) = res(i,k)
         enddo
       enddo
-
-!> -# Find top pressure for each cloud domain for given latitude.
-!     ptopc(k,i): top presure of each cld domain (k=1-4 are sfc,L,m,h;
-!  ---  i=1,2 are low-lat (<45 degree) and pole regions)
-
-      do i =1, IX
-        rxlat(i) = abs( xlat(i) / con_pi )     ! if xlat in pi/2 -> -pi/2 range
-!       rxlat(i) = abs(0.5 - xlat(i)/con_pi)   ! if xlat in 0    ->  pi   range
-      enddo
-
-      do id = 1, 4
-        tem1 = ptopc(id,2) - ptopc(id,1)
-        do i =1, IX
-          ptop1(i,id) = ptopc(id,1) + tem1*max( 0.0, 4.0*rxlat(i)-1.0 )
-        enddo
-      enddo
-
-      ! Compute cloud decorrelation length
-      if (idcor == 1) then
-        call cmp_dcorr_lgth(ix, xlat, con_pi, de_lgth)
-      endif
-      if (idcor == 2) then
-        call cmp_dcorr_lgth(ix, latdeg, julian, yearlen, de_lgth)
-      endif
-      if (idcor == 0) then
-         de_lgth(:) = decorr_con
-      endif
-
-      ! Call subroutine get_alpha_exp to define alpha parameter for exponential cloud overlap options
-      if (iovr == 3 .or. iovr == 4 .or. iovr == 5) then
-         call get_alpha_exp(ix, nLay, dzlay, de_lgth, alpha)
-      else
-         de_lgth(:) = 0.
-         alpha(:,:) = 0.
-      endif
-
-      ! Revise alpha for exponential-random cloud overlap
-      ! Decorrelate layers when a clear layer follows a cloudy layer to enforce
-      ! random correlation between non-adjacent blocks of cloudy layers
-      if (iovr == 5) then
-        do k = 2, nLay
-          do i = 1, ix
-            if (clouds(i,k,1) == 0.0 .and. clouds(i,k-1,1) > 0.0) then
-              alpha(i,k) = 0.0
-            endif
-          enddo
-        enddo
-      endif
-
-!> - Call gethml() to compute low,mid,high,total, and boundary layer
-!!    cloud fractions and clouds top/bottom layer indices for low, mid,
-!!    and high clouds.
-!  ---  compute low, mid, high, total, and boundary layer cloud fractions
-!       and clouds top/bottom layer indices for low, mid, and high clouds.
-!       The three cloud domain boundaries are defined by ptopc.  The cloud
-!       overlapping method is defined by control flag 'iovr', which may
-!       be different for lw and sw radiation programs.
-
-      call gethml                                                       &
-!  ---  inputs:
-     &     ( plyr, ptop1, cldtot, cldcnv, dz, de_lgth, alpha,           &
-     &       IX,NLAY,                                                   &
-!  ---  outputs:
-     &       clds, mtop, mbot                                           &
-     &     )
-
-
 !
       return
 !...................................
@@ -4118,7 +3831,8 @@
 !! @{
       subroutine gethml                                                 &
      &     ( plyr, ptop1, cldtot, cldcnv, dz, de_lgth, alpha,           &       !  ---  inputs:
-     &       IX, NLAY,                                                  &
+     &       IX, NLAY, iovr_rand, iovr_maxrand, iovr_max,               &
+     &       iovr_dcorr, iovr_exp, iovr_exprand,                        &
      &       clds, mtop, mbot                                           &       !  ---  outputs:
      &     )
 
@@ -4178,6 +3892,13 @@
 
 !  ---  inputs:
       integer, intent(in) :: IX, NLAY
+      integer, intent(in) ::                                            &
+     &     iovr_rand,                    ! Flag for random cloud overlap method
+     &     iovr_maxrand,                 ! Flag for maximum-random cloud overlap method
+     &     iovr_max,                     ! Flag for maximum cloud overlap method
+     &     iovr_dcorr,                   ! Flag for decorrelation-length cloud overlap method
+     &     iovr_exp,                     ! Flag for exponential cloud overlap method
+     &     iovr_exprand                  ! Flag for exponential-random cloud overlap method
 
       real (kind=kind_phys), dimension(:,:), intent(in) :: plyr, ptop1, &
      &       cldtot, cldcnv, dz
@@ -4222,7 +3943,7 @@
         kinc = 1
       endif                                     ! end_if_ivflip
 
-      if ( iovr == 0 ) then                     ! random overlap
+      if ( iovr == iovr_rand ) then                     ! random overlap
 
         do k = kstr, kend, kinc
           do i = 1, IX
@@ -4241,7 +3962,7 @@
           clds(i,4) = 1.0 - cl1(i)              ! save total cloud
         enddo
 
-      elseif ( iovr == 1 ) then                 ! max/ran overlap
+      elseif ( iovr == iovr_maxrand ) then                 ! max/ran overlap
 
         do k = kstr, kend, kinc
           do i = 1, IX
@@ -4265,7 +3986,7 @@
           clds(i,4) = 1.0 - cl1(i) * cl2(i)     ! save total cloud
         enddo
 
-      elseif ( iovr == 2 ) then                 ! maximum overlap all levels
+      elseif ( iovr == iovr_max ) then                 ! maximum overlap all levels
 
         cl1(:) = 0.0
 
@@ -4286,7 +4007,7 @@
           clds(i,4) = cl1(i)        ! save total cloud
         enddo
 
-      elseif ( iovr == 3 ) then                 ! random if clear-layer divided,
+      elseif ( iovr == iovr_dcorr ) then                 ! random if clear-layer divided,
                                                 ! otherwise de-corrlength method
         do i = 1, ix
           dz1(i) = - dz(i,kstr)
@@ -4318,7 +4039,7 @@
           clds(i,4) = 1.0 - cl1(i) * cl2(i)     ! save total cloud
         enddo
 
-      elseif ( iovr == 4 .or. iovr == 5 ) then  ! exponential overlap (iovr=4), or
+      elseif ( iovr == iovr_exp .or. iovr == iovr_exprand ) then  ! exponential overlap (iovr=4), or
                                                 ! exponential-random  (iovr=5);
                                                 ! distinction defined by alpha
 
@@ -4399,7 +4120,7 @@
               if (kth2(i) == 0) kbt2(i) = k
               kth2(i) = kth2(i) + 1
 
-              if ( iovr == 0 ) then
+              if ( iovr == iovr_rand ) then
                 cl2(i) = cl2(i) + ccur - cl2(i)*ccur
               else
                 cl2(i) = max( cl2(i), ccur )
@@ -4481,7 +4202,7 @@
               if (kth2(i) == 0) kbt2(i) = k
               kth2(i) = kth2(i) + 1
 
-              if ( iovr == 0 ) then
+              if ( iovr == iovr_rand ) then
                 cl2(i) = cl2(i) + ccur - cl2(i)*ccur
               else
                 cl2(i) = max( cl2(i), ccur )

--- a/physics/radlw_main.F90
+++ b/physics/radlw_main.F90
@@ -2082,7 +2082,7 @@
 !
 !       NOTE: The code below is identical for case (4) and (5) because the 
 !       distinction in the vertical correlation between EXP and ER is already 
-!       built into the specification of alpha (in subroutine get_alpha_exp). 
+!       built into the specification of alpha (in subroutine get_alpha_exper). 
 
 !  ---  setup 2 sets of random numbers
 

--- a/physics/radsw_main.F90
+++ b/physics/radsw_main.F90
@@ -2197,7 +2197,7 @@
 !
 !       NOTE: The code below is identical for case (4) and (5) because the 
 !       distinction in the vertical correlation between EXP and ER is already 
-!       built into the specification of alpha (in subroutine get_alpha_exp). 
+!       built into the specification of alpha (in subroutine get_alpha_exper). 
 
 !  ---  setup 2 sets of random numbers
 


### PR DESCRIPTION
A request has been made by many physics developers and users to  rewrite
the cloud computation routines (progcldXXX) in the program
radiation_clouds.f. Each microphysics scheme has one subroutine to
calculate the cloud radiation properties, and those similar subroutines
have many lines of common code. In the new code, we wrapped the calculation
of cloud radiation properties in one single module “radiation_clouds.f” and
moved all the common code from subroutines progcldXXX to the new subroutine
“radiation_clouds_prop”. This subroutine can be called by RRTMG and RRTMGP.
A single call to the subroutine “radiation_clouds_prop” can connect to the
calculations of the cloud radiation properties for all the microphysics
schemes. There are also many other changes in the following listed program
based on the reviewer’s suggestions/comments.

See https://docs.google.com/document/d/1y-0K3GS6ZwwKipwNNfBWE-k-TQaN3NwrgIbxRkdInYY/edit for more details.