### PR TITLE
Add logic to reduce optimization for host-model provided GFS_typedefs.F90

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ else(TYPEDEFS)
   include(${CMAKE_CURRENT_BINARY_DIR}/CCPP_TYPEDEFS.cmake)
   message(STATUS "Got CCPP TYPEDEFS from cmakefile include file")
 endif(TYPEDEFS)
+list(REMOVE_DUPLICATES TYPEDEFS)
 
 # Generate list of Fortran modules from the CCPP type
 # definitions that need need to be installed
@@ -58,6 +59,7 @@ else(SCHEMES)
   include(${CMAKE_CURRENT_BINARY_DIR}/CCPP_SCHEMES.cmake)
   message(STATUS "Got CCPP SCHEMES from cmakefile include file")
 endif(SCHEMES)
+list(REMOVE_DUPLICATES SCHEMES)
 
 # Set the sources: physics scheme caps
 set(CAPS $ENV{CCPP_CAPS})
@@ -67,6 +69,7 @@ else(CAPS)
   include(${CMAKE_CURRENT_BINARY_DIR}/CCPP_CAPS.cmake)
   message(STATUS "Got CCPP CAPS from cmakefile include file")
 endif(CAPS)
+list(REMOVE_DUPLICATES CAPS)
 
 # Schemes and caps from the CCPP code generator use full paths with symlinks
 # resolved, we need to do the same here for the below logic to work
@@ -141,12 +144,19 @@ endif()
 SET_PROPERTY(SOURCE ${SCHEMES} ${CAPS}
              APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_PHYSICS} ${OpenMP_Fortran_FLAGS}")
 
-# Reduce optimization for module_sf_mynn.F90 (to avoid an apparent compiler bug with Intel 18 on Hera)
-if(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_sf_mynn.F90 IN_LIST SCHEMES AND
-    (CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "Bitforbit") AND
+# Lower optimization for certain schemes when compiling with Intel in Release mode
+if((CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "Bitforbit") AND
     ${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
-  SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/module_sf_mynn.F90
-                              APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_PHYSICS} ${OpenMP_Fortran_FLAGS} -O1")
+  # Define a list of schemes that need lower optimization with Intel in Release mode
+  set(SCHEME_NAMES_LOWER_OPTIMIZATION GFS_typedefs.F90
+                                      module_sf_mynn.F90)
+  foreach(SCHEME_NAME IN LISTS SCHEME_NAMES_LOWER_OPTIMIZATION)
+    set(SCHEMES_TMP ${SCHEMES})
+    # Need to determine the name of the scheme with its path
+    list(FILTER SCHEMES_TMP INCLUDE REGEX ".*${SCHEME_NAME}$")
+    SET_SOURCE_FILES_PROPERTIES(${SCHEMES_TMP}
+                                APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_PHYSICS} ${OpenMP_Fortran_FLAGS} -O1")
+  endforeach()
 endif()
 
 # Reduce optimization for mo_gas_optics_kernels.F90 (to avoid an apparent compiler bug with Intel 19+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,14 +148,27 @@ SET_PROPERTY(SOURCE ${SCHEMES} ${CAPS}
 if((CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "Bitforbit") AND
     ${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
   # Define a list of schemes that need lower optimization with Intel in Release mode
-  set(SCHEME_NAMES_LOWER_OPTIMIZATION GFS_typedefs.F90
-                                      module_sf_mynn.F90)
+  set(SCHEME_NAMES_LOWER_OPTIMIZATION module_sf_mynn.F90)
   foreach(SCHEME_NAME IN LISTS SCHEME_NAMES_LOWER_OPTIMIZATION)
     set(SCHEMES_TMP ${SCHEMES})
     # Need to determine the name of the scheme with its path
     list(FILTER SCHEMES_TMP INCLUDE REGEX ".*${SCHEME_NAME}$")
     SET_SOURCE_FILES_PROPERTIES(${SCHEMES_TMP}
                                 APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_PHYSICS} ${OpenMP_Fortran_FLAGS} -O1")
+  endforeach()
+endif()
+
+# No optimization for certain schemes when compiling with Intel in Release mode
+if((CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "Bitforbit") AND
+    ${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
+  # Define a list of schemes that can't be optimized with Intel in Release mode
+  set(SCHEME_NAMES_NO_OPTIMIZATION GFS_typedefs.F90)
+  foreach(SCHEME_NAME IN LISTS SCHEME_NAMES_NO_OPTIMIZATION)
+    set(SCHEMES_TMP ${SCHEMES})
+    # Need to determine the name of the scheme with its path
+    list(FILTER SCHEMES_TMP INCLUDE REGEX ".*${SCHEME_NAME}$")
+    SET_SOURCE_FILES_PROPERTIES(${SCHEMES_TMP}
+                                APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_PHYSICS} ${OpenMP_Fortran_FLAGS} -O0")
   endforeach()
 endif()
 


### PR DESCRIPTION
Add logic to reduce optimization for multiple files, independent of their preceding paths, including the host-model provided `GFS_typedefs.F90`.

For `GFS_typedefs.F90`, this is slightly more complicated because the relative path to the file depends on the host model. The solution presented here will add `-O1` to any `GFS_typedefs.F90` when using Intel in release (PROD), regardless of the host model. We definitely do not want host-model specific code in `CMakeLists.txt`.

Duplicates for the auto-generated cmake include files need to be removed. This can also be done in the framework before writing the files, but even if that gets done having a second check here doesn't hurt.

This should fix the problem that @junwang-noaa reported (exceeding memory on wcoss_dell_p3 in compile jobs).

Tested to compile (and do the right thing) on Hera with Intel in PROD mode.
