### PR TITLE
Address Issue #863 (setting surface-related interstitial variables for SCM prescribed-surface-flux mode)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,125 +4,125 @@
 
 # Default codeowners for files that don't have specific owners:
 
-*           @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+*           @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
 
 # The following lines are from the CCPP Primary Schemes Points of Contact
 #   https://docs.google.com/spreadsheets/d/14y0Th_sSpCqlssEMNfSZ_Ni9wrpPqfpPY0kRG7jCZB8/edit#gid=0
 # (Internal NOAA document.)
 
-physics/cs_conv_aw_adj.*                       @AnningCheng-NOAA                    @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/cs_conv.*                              @AnningCheng-NOAA                    @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/cu_gf*                                 @hannahcbarnes @haiqinli             @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/sascnvn.*                              @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/cs_conv_aw_adj.*                       @AnningCheng-NOAA                    @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/cs_conv.*                              @AnningCheng-NOAA                    @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/cu_gf*                                 @hannahcbarnes @haiqinli             @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/sascnvn.*                              @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 physics/cu_ntiedtke*                           @ChunxiZhang-NOAA                    @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/rascnv.*                               @SMoorthi-emc                        @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/rascnv.*                               @SMoorthi-emc                        @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/samfdeepcnv.*                          @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/samfshalcnv.*                          @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/samfaerosols.*                         @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/samfdeepcnv.*                          @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/samfshalcnv.*                          @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/samfaerosols.*                         @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/shalcnv.*                              @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/unified_ugwp*                          @mdtoyNOAA                           @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/ugwp_driver_v0.F                       @mdtoyNOAA                           @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/cires_ugwp*                            @mdtoyNOAA @ValeryYudin-NOAA         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/drag_suite.*                           @mdtoyNOAA                           @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/shalcnv.*                              @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/unified_ugwp*                          @mdtoyNOAA                           @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/ugwp_driver_v0.F                       @mdtoyNOAA                           @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/cires_ugwp*                            @mdtoyNOAA @ValeryYudin-NOAA         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/drag_suite.*                           @mdtoyNOAA                           @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/gwdc.*                                 @Songyou184                          @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/gwdps.*                                @Songyou184                          @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/gwdc.*                                 @Songyou184                          @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/gwdps.*                                @Songyou184                          @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/gfdl_fv_sat_adj.*                      @RuiyuSun                            @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/gfdl_cloud_microphys.*                 @RuiyuSun                            @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/gfdl_fv_sat_adj.*                      @RuiyuSun                            @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/gfdl_cloud_microphys.*                 @RuiyuSun                            @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/module_gfdl_cloud_microphys.*          @RuiyuSun                            @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/multi_gases.F90                        @RuiyuSun                            @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/module_gfdl_cloud_microphys.*          @RuiyuSun                            @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/multi_gases.F90                        @RuiyuSun                            @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/mp_fer_hires.*                         @ericaligo-NOAA                      @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/module_MP_FER_HIRES.*                  @ericaligo-NOAA                      @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/mp_fer_hires.*                         @ericaligo-NOAA                      @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/module_MP_FER_HIRES.*                  @ericaligo-NOAA                      @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/module_mp_thompson*                    @gthompsnWRF @RuiyuSun               @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/module_mp_radar.*                      @gthompsnWRF @RuiyuSun               @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/mp_thompson*                           @gthompsnWRF @RuiyuSun               @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/module_mp_thompson*                    @gthompsnWRF @RuiyuSun               @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/module_mp_radar.*                      @gthompsnWRF @RuiyuSun               @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/mp_thompson*                           @gthompsnWRF @RuiyuSun               @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/precpd.*                               @RuiyuSun                            @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/gscond.*                               @RuiyuSun                            @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/precpd.*                               @RuiyuSun                            @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/gscond.*                               @RuiyuSun                            @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/m_micro*                               @AnningCheng-NOAA @andrewgettelman   @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/aer_cloud.F                            @AnningCheng-NOAA @andrewgettelman   @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/aerclm_def.F                           @AnningCheng-NOAA @andrewgettelman   @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/cldmacro.F                             @AnningCheng-NOAA @andrewgettelman   @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/cldwat2m_micro.F                       @AnningCheng-NOAA @andrewgettelman   @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/wv_saturation.F                        @AnningCheng-NOAA @andrewgettelman   @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/micro_mg*                              @AnningCheng-NOAA @andrewgettelman   @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/m_micro*                               @AnningCheng-NOAA @andrewgettelman   @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/aer_cloud.F                            @AnningCheng-NOAA @andrewgettelman   @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/aerclm_def.F                           @AnningCheng-NOAA @andrewgettelman   @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/cldmacro.F                             @AnningCheng-NOAA @andrewgettelman   @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/cldwat2m_micro.F                       @AnningCheng-NOAA @andrewgettelman   @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/wv_saturation.F                        @AnningCheng-NOAA @andrewgettelman   @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/micro_mg*                              @AnningCheng-NOAA @andrewgettelman   @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/ozphys*                                @AlexBelochitski-NOAA                @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/ozphys*                                @AlexBelochitski-NOAA                @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/satmedmfvdif.*                         @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/satmedmfvdifq.*                        @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/mfpbl.f                                @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/mfscu.f                                @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/mfpbltq.f                              @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/mfscuq.f                               @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/satmedmfvdif.*                         @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/satmedmfvdifq.*                        @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/mfpbl.f                                @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/mfscu.f                                @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/mfpbltq.f                              @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/mfscuq.f                               @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
 physics/shinhongvdif.*                         @ChunxiZhang-NOAA                    @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
 physics/ysuvdif.*                              @ChunxiZhang-NOAA                    @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
 
 physics/tridi.f                                @JongilHan66 @ChunxiZhang-NOAA @JongilHan66 @WeiguoWang-NOAA @AlexBelochitski-NOAA       @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
 
-physics/moninedmf.*                            @JongilHan66 @WeiguoWang-NOAA        @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/moninedmf.*                            @JongilHan66 @WeiguoWang-NOAA        @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/module_BL_MYJPBL.*                     @Qingfu-Liu                          @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/module_MYJPBL_wrapper.*                @Qingfu-Liu                          @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/module_BL_MYJPBL.*                     @Qingfu-Liu                          @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/module_MYJPBL_wrapper.*                @Qingfu-Liu                          @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/module_bl_mynn.*                       @joeolson42                          @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/module_MYNNPBL_wrapper.*               @joeolson42                          @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/module_bl_mynn.*                       @joeolson42                          @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/module_MYNNPBL_wrapper.*               @joeolson42                          @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/gcm_shoc.*                             @AlexBelochitski-NOAA                @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/moninshoc.*                            @AlexBelochitski-NOAA                @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/gcm_shoc.*                             @AlexBelochitski-NOAA                @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/moninshoc.*                            @AlexBelochitski-NOAA                @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/rte-rrtmgp                             @dustinswales @Qingfu-Liu            @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/radiation_tools.*                      @dustinswales @Qingfu-Liu            @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/rrtmgp_lw_rte.met*                     @dustinswales @Qingfu-Liu            @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/rrtmgp_sw_rte.met*                     @dustinswales @Qingfu-Liu            @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/rte-rrtmgp                             @dustinswales @Qingfu-Liu            @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/radiation_tools.*                      @dustinswales @Qingfu-Liu            @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/rrtmgp_lw_rte.met*                     @dustinswales @Qingfu-Liu            @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/rrtmgp_sw_rte.met*                     @dustinswales @Qingfu-Liu            @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/radlw_main.*                           @mjiacono @Qingfu-Liu                @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/HWRF_mcica_random_numbers.F90          @mjiacono @Qingfu-Liu                @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/HWRF_mersenne_twister.F90              @mjiacono @Qingfu-Liu                @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/radlw_datatb.f                         @mjiacono @Qingfu-Liu                @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/radsw_datatb.*                         @mjiacono @Qingfu-Liu                @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/radsw_main.*                           @mjiacono @Qingfu-Liu                @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/radlw_main.*                           @mjiacono @Qingfu-Liu                @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/HWRF_mcica_random_numbers.F90          @mjiacono @Qingfu-Liu                @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/HWRF_mersenne_twister.F90              @mjiacono @Qingfu-Liu                @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/radlw_datatb.f                         @mjiacono @Qingfu-Liu                @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/radsw_datatb.*                         @mjiacono @Qingfu-Liu                @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/radsw_main.*                           @mjiacono @Qingfu-Liu                @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/radsw_param.f                          @dustinswales @Qingfu-Liu @mjiacono  @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/radsw_param.f                          @dustinswales @Qingfu-Liu @mjiacono  @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/rayleigh_damp.*                        @yangfanglin                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/GFS_stochastics.*                      @pjpegion @lisa-bengtsson            @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/flake*                                 @YihuaWu-NOAA                        @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/rayleigh_damp.*                        @yangfanglin                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/GFS_stochastics.*                      @pjpegion @lisa-bengtsson            @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/flake*                                 @YihuaWu-NOAA                        @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/sfc_drv.*                              @HelinWei-NOAA                       @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/sflx.f                                 @HelinWei-NOAA                       @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/surface_perturbation.*                 @HelinWei-NOAA                       @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/sfc_drv.*                              @HelinWei-NOAA                       @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/sflx.f                                 @HelinWei-NOAA                       @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/surface_perturbation.*                 @HelinWei-NOAA                       @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/*noahmp*                               @barlage @cenlinhe                   @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/*noahmp*                               @barlage @cenlinhe                   @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/set_soilveg.*                          @HelinWei-NOAA @barlage @cenlinhe    @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/namelist_soilveg.*                     @HelinWei-NOAA @barlage @cenlinhe    @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/set_soilveg.*                          @HelinWei-NOAA @barlage @cenlinhe    @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/namelist_soilveg.*                     @HelinWei-NOAA @barlage @cenlinhe    @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/namelist_soilveg_ruc.*                 @tanyasmirnova                       @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/set_soilveg_ruc.*                      @tanyasmirnova                       @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/module_sf_ruclsm.*                     @tanyasmirnova                       @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/module_soil_pre.*                      @tanyasmirnova                       @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/sfc_drv_ruc.*                          @tanyasmirnova                       @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/namelist_soilveg_ruc.*                 @tanyasmirnova                       @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/set_soilveg_ruc.*                      @tanyasmirnova                       @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/module_sf_ruclsm.*                     @tanyasmirnova                       @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/module_soil_pre.*                      @tanyasmirnova                       @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/sfc_drv_ruc.*                          @tanyasmirnova                       @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/date_def.f                             @XuLi-NOAA                           @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/*nst*                                  @XuLi-NOAA                           @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/date_def.f                             @XuLi-NOAA                           @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/*nst*                                  @XuLi-NOAA                           @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/sfc_ocean.*                            @HelinWei-NOAA                       @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/sfc_diff.*                             @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/sfc_ocean.*                            @HelinWei-NOAA                       @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/sfc_diff.*                             @JongilHan66                         @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/h2ophys.*                              @AlexBelochitski-NOAA                @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/h2ophys.*                              @AlexBelochitski-NOAA                @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
-physics/sfc_sice.*                             @wd20xw                              @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
-physics/sfc_cice.*                             @wd20xw                              @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich
+physics/sfc_sice.*                             @wd20xw                              @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
+physics/sfc_cice.*                             @wd20xw                              @climbfuji @SamuelTrahanNOAA @grantfirl @mzhangw @panll @mkavulich @ChunxiZhang-NOAA
 
 ########################################################################
 

--- a/physics/scm_sfc_flux_spec.F90
+++ b/physics/scm_sfc_flux_spec.F90
@@ -60,15 +60,15 @@ module scm_sfc_flux_spec
 
     use machine,             only: kind_phys
     
-    integer, intent(in) :: im, lkm
+    integer, intent(in)    :: im, lkm
     integer, intent(inout) :: islmsk(:)
-    logical, intent(in) :: cplflx, cplice
+    logical, intent(in)    :: cplflx, cplice
     logical, intent(inout) :: dry(:), icy(:), flag_cice(:), wet(:), use_flake(:)
-    real(kind=kind_phys), intent(in) :: u1(:), v1(:), z1(:), t1(:), q1(:), p1(:), roughness_length(:), &
+    real(kind=kind_phys), intent(in)    :: cp, grav, hvap, rd, fvirt, vonKarman, min_seaice, tgice, min_lakeice
+    real(kind=kind_phys), intent(in)    :: u1(:), v1(:), z1(:), t1(:), q1(:), p1(:), roughness_length(:), &
       spec_sh_flux(:), spec_lh_flux(:), exner_inverse(:), T_surf(:), oceanfrac(:), lakefrac(:), lakedepth(:)
-    real(kind=kind_phys), intent(in) :: cp, grav, hvap, rd, fvirt, vonKarman, min_seaice, tgice, min_lakeice
     real(kind=kind_phys), intent(inout) :: cice(:), tisfc(:), tsfcl(:), tsfc_wat(:), slmsk(:)
-    real(kind=kind_phys), intent(out) :: sh_flux(:), lh_flux(:), u_star(:), sfc_stress(:), &
+    real(kind=kind_phys), intent(out)   :: sh_flux(:), lh_flux(:), u_star(:), sfc_stress(:), &
       cm(:), ch(:), fm(:), fh(:), rb(:), u10m(:), v10m(:), wind1(:), qss(:), t2m(:), q2m(:), &
       sh_flux_chs(:), frland(:)
 

--- a/physics/scm_sfc_flux_spec.F90
+++ b/physics/scm_sfc_flux_spec.F90
@@ -52,18 +52,25 @@ module scm_sfc_flux_spec
 !!  -# Calculate the Monin-Obukhov similarity function for heat and moisture from the bulk Richardson number and diagnosed similarity function for momentum.
 !!  -# Calculate the surface drag coefficient for heat and moisture.
 !!  -# Calculate the u and v wind at 10m.
-  subroutine scm_sfc_flux_spec_run (u1, v1, z1, t1, q1, p1, roughness_length, spec_sh_flux, spec_lh_flux, &
-    exner_inverse, T_surf, cp, grav, hvap, rd, fvirt, vonKarman, sh_flux, lh_flux, sh_flux_chs, u_star, sfc_stress, cm, ch, &
+  subroutine scm_sfc_flux_spec_run (im, u1, v1, z1, t1, q1, p1, roughness_length, spec_sh_flux, spec_lh_flux, &
+    exner_inverse, T_surf, cp, grav, hvap, rd, fvirt, vonKarman, tgice, islmsk, dry, frland, cice, icy, tisfc,&
+    oceanfrac, min_seaice, cplflx, cplice, flag_cice, wet, min_lakeice, tsfcl, tsfc_wat, slmsk, lakefrac, lkm,&
+    lakedepth, use_flake, sh_flux, lh_flux, sh_flux_chs, u_star, sfc_stress, cm, ch, &
     fm, fh, rb, u10m, v10m, wind1, qss, t2m, q2m, errmsg, errflg)
 
     use machine,             only: kind_phys
     
+    integer, intent(in) :: im, lkm
+    integer, intent(inout) :: islmsk(:)
+    logical, intent(in) :: cplflx, cplice
+    logical, intent(inout) :: dry(:), icy(:), flag_cice(:), wet(:), use_flake(:)
     real(kind=kind_phys), intent(in) :: u1(:), v1(:), z1(:), t1(:), q1(:), p1(:), roughness_length(:), &
-      spec_sh_flux(:), spec_lh_flux(:), exner_inverse(:), T_surf(:)
-    real(kind=kind_phys), intent(in) :: cp, grav, hvap, rd, fvirt, vonKarman
+      spec_sh_flux(:), spec_lh_flux(:), exner_inverse(:), T_surf(:), oceanfrac(:), lakefrac(:), lakedepth(:)
+    real(kind=kind_phys), intent(in) :: cp, grav, hvap, rd, fvirt, vonKarman, min_seaice, tgice, min_lakeice
+    real(kind=kind_phys), intent(inout) :: cice(:), tisfc(:), tsfcl(:), tsfc_wat(:), slmsk(:)
     real(kind=kind_phys), intent(out) :: sh_flux(:), lh_flux(:), u_star(:), sfc_stress(:), &
       cm(:), ch(:), fm(:), fh(:), rb(:), u10m(:), v10m(:), wind1(:), qss(:), t2m(:), q2m(:), &
-      sh_flux_chs(:)
+      sh_flux_chs(:), frland(:)
 
     character(len=*), intent(out) :: errmsg
     integer,          intent(out) :: errflg
@@ -72,6 +79,8 @@ module scm_sfc_flux_spec
 
     real(kind=kind_phys) :: rho, q1_non_neg, w_thv1, rho_cp_inverse, rho_hvap_inverse, Obukhov_length, thv1, tvs, &
       dtv, adtv, wind10m, u_fraction, roughness_length_m
+    
+    real(kind=kind_phys), parameter :: timin = 173.0_kind_phys  ! minimum temperature allowed for snow/ice
 
     ! Initialize CCPP error handling variables
     errmsg = ''
@@ -79,7 +88,7 @@ module scm_sfc_flux_spec
   
 !     !--- set control properties (including namelist read)
   !calculate u_star from wind profiles (need roughness length, and wind and height at lowest model level)
-  do i=1, size(z1)
+  do i=1, im
     sh_flux(i) = spec_sh_flux(i)
     lh_flux(i) = spec_lh_flux(i)
     sh_flux_chs(i) = sh_flux(i)
@@ -135,7 +144,82 @@ module scm_sfc_flux_spec
     t2m(i) = 0.0
     q2m(i) = 0.0
   end do
+  
+  !GJF: The following code is from GFS_surface_composites.F90; only statements that are used in physics schemes outside of surface schemes are kept
+  !GJF: Adding this code means that this scheme should be called before dcyc2t3
+  do i = 1, im
+    if (islmsk(i) == 1) then
+      dry(i)    = .true.
+      frland(i) = 1.0_kind_phys
+      cice(i)   = 0.0_kind_phys
+      icy(i)    = .false.
+      tsfcl(i)  = T_surf(i) !GJF
+    else
+      frland(i) = 0.0_kind_phys
+      if (oceanfrac(i) > 0.0_kind_phys) then
+        if (cice(i) >= min_seaice) then
+          icy(i)   = .true.
+          tisfc(i) = T_surf(i) !GJF
+          tisfc(i) = max(timin, min(tisfc(i), tgice))
+          ! This cplice namelist option was added to deal with the
+          ! situation of the FV3ATM-HYCOM coupling without an active sea
+          ! ice (e.g., CICE6) component. By default, the cplice is true
+          ! when cplflx is .true. (e.g., for the S2S application).
+          ! Whereas, for the HAFS FV3ATM-HYCOM coupling, cplice is set as
+          ! .false.. In the future HAFS FV3ATM-MOM6 coupling, the cplflx
+          ! could be .true., while cplice being .false..
+          if (cplice .and. cplflx)  then
+            flag_cice(i)   = .true.
+          else
+            flag_cice(i)   = .false.
+          endif
+          islmsk(i) = 2
+        else
+          cice(i)        = 0.0_kind_phys
+          flag_cice(i)   = .false.
+          islmsk(i)      = 0
+          icy(i)         = .false.
+        endif
+        if (cice(i) < 1.0_kind_phys) then
+          wet(i) = .true. ! some open ocean
+        endif
+      else
+        if (cice(i) >= min_lakeice) then
+          icy(i) = .true.
+          tisfc(i) = T_surf(i) !GJF
+          tisfc(i) = max(timin, min(tisfc(i), tgice))
+          islmsk(i) = 2
+        else
+          cice(i)   = 0.0_kind_phys
+          islmsk(i) = 0
+          icy(i)    = .false.
+        endif
+        flag_cice(i)   = .false.
+        if (cice(i) < 1.0_kind_phys) then
+          wet(i) = .true. ! some open lake
+        endif
+        if (wet(i)) then                   ! Water
+          tsfc_wat(i) = T_surf(i)
+        endif
+      endif
+    endif
+    if (nint(slmsk(i)) /= 1) slmsk(i)  = islmsk(i)
+  enddo
 
+! to prepare to separate lake from ocean under water category
+  do i = 1, im
+    if ((wet(i) .or. icy(i)) .and. lakefrac(i) > 0.0_kind_phys) then
+      if (lkm == 1 .and. lakefrac(i) >= 0.15 .and. lakedepth(i) > 1.0_kind_phys) then
+        use_flake(i) = .true.
+      else
+        use_flake(i) = .false.
+      endif
+    else
+      use_flake(i) = .false.
+    endif
+  enddo
+!
+  
   end subroutine scm_sfc_flux_spec_run
 
 end module scm_sfc_flux_spec

--- a/physics/scm_sfc_flux_spec.meta
+++ b/physics/scm_sfc_flux_spec.meta
@@ -34,6 +34,13 @@
 [ccpp-arg-table]
   name = scm_sfc_flux_spec_run
   type = scheme
+[im]
+  standard_name = horizontal_loop_extent
+  long_name = horizontal loop extent
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
 [u1]
   standard_name = x_wind_at_surface_adjacent_layer
   long_name = x component of 1st model layer wind
@@ -170,6 +177,165 @@
   type = real
   kind = kind_phys
   intent = in
+[tgice]
+  standard_name = freezing_point_temperature_of_seawater
+  long_name = freezing point temperature of seawater
+  units = K
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+[islmsk]
+  standard_name = sea_land_ice_mask
+  long_name = sea/land/ice mask (=0/1/2)
+  units = flag
+  dimensions = (horizontal_loop_extent)
+  type = integer
+  intent = inout
+[dry]
+  standard_name = flag_nonzero_land_surface_fraction
+  long_name = flag indicating presence of some land surface area fraction
+  units = flag
+  dimensions = (horizontal_loop_extent)
+  type = logical
+  intent = inout
+[frland]
+  standard_name = land_area_fraction_for_microphysics
+  long_name = land area fraction used in microphysics schemes
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+[cice]
+  standard_name = sea_ice_area_fraction_of_sea_area_fraction
+  long_name = ice fraction over open water
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[icy]
+  standard_name = flag_nonzero_sea_ice_surface_fraction
+  long_name = flag indicating presence of some sea ice surface area fraction
+  units = flag
+  dimensions = (horizontal_loop_extent)
+  type = logical
+  intent = inout
+[tisfc]
+  standard_name = surface_skin_temperature_over_ice
+  long_name = surface skin temperature over ice
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[oceanfrac]
+  standard_name = sea_area_fraction
+  long_name = fraction of horizontal grid area occupied by ocean
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+[min_seaice]
+  standard_name = min_sea_ice_area_fraction
+  long_name = minimum sea ice value
+  units = frac
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+[cplflx]
+  standard_name = flag_for_surface_flux_coupling
+  long_name = flag controlling cplflx collection (default off)
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+[cplice]
+  standard_name = flag_for_sea_ice_coupling
+  long_name = flag controlling cplice collection (default on)
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+[flag_cice]
+  standard_name = flag_for_cice
+  long_name = flag for cice
+  units = flag
+  dimensions = (horizontal_loop_extent)
+  type = logical
+  intent = inout
+[wet]
+  standard_name = flag_nonzero_wet_surface_fraction
+  long_name = flag indicating presence of some ocean or lake surface area fraction
+  units = flag
+  dimensions = (horizontal_loop_extent)
+  type = logical
+  intent = inout
+[min_lakeice]
+  standard_name = min_lake_ice_area_fraction
+  long_name = minimum lake ice value
+  units = frac
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
+[tsfcl]
+  standard_name = surface_skin_temperature_over_land
+  long_name = surface skin temperature over land
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[tsfc_wat]
+  standard_name = surface_skin_temperature_over_water
+  long_name = surface skin temperature over water
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[slmsk]
+  standard_name = area_type
+  long_name = landmask: sea/land/ice=0/1/2
+  units = flag
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[lakefrac]
+  standard_name = lake_area_fraction
+  long_name = fraction of horizontal grid area occupied by lake
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+[lkm]
+  standard_name = control_for_lake_surface_scheme
+  long_name = flag for lake surface model
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
+[lakedepth]
+  standard_name = lake_depth
+  long_name = lake depth
+  units = m
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+[use_flake]
+  standard_name = flag_for_using_flake
+  long_name = flag indicating lake points using flake model
+  units = flag
+  dimensions = (horizontal_loop_extent)
+  type = logical
+  intent = inout
 [sh_flux]
   standard_name = surface_upward_temperature_flux
   long_name = surface upward sensible heat flux


### PR DESCRIPTION
- Fixes #863
- Changes answer for prescribed-surface flux SCM cases
- Will not affect FV3/UFS at all
- Copy some of the code from GFS_surface_composites_pre_run into scm_sfc_flux_spec_run for setting some surface-related interstitial variables that are used in non-surface-related schemes after scm_sfc_flux_spec_run
- This requires executed scm_sfc_flux_spec_run prior to dcyc2 in the SDFs to work