### PR TITLE
Rectify total number of Thompson MP species for PBL mixing

### DIFF
--- a/physics/GFS_PBL_generic.F90
+++ b/physics/GFS_PBL_generic.F90
@@ -37,9 +37,9 @@
       elseif (imp_physics == imp_physics_thompson) then
 ! Thompson
         if(ltaerosol) then
-          kk = 10
+          kk = 12
         else
-          kk = 7
+          kk = 9
         endif
 ! MG
       elseif (imp_physics == imp_physics_mg) then


### PR DESCRIPTION
This update properly sets the total number of species to be diffused in the PBL for the Thompson microphysics scheme, addressing an issue occurring when coupling with prognostic aerosols.

Fixes: #880 