### PR TITLE
Minor cloud tunings to improve cloud fraction and radiation in UFS

### DIFF
--- a/physics/module_mp_thompson.F90
+++ b/physics/module_mp_thompson.F90
@@ -2162,7 +2162,7 @@ MODULE module_mp_thompson
             ni(k) = MAX(R2, ni1d(k)*rho(k))
             if (ni(k).le. R2) then
                lami = cie(2)/5.E-6
-               ni(k) = MIN(499.D3, cig(1)*oig2*ri(k)/am_i*lami**bm_i)
+               ni(k) = MIN(4999.D3, cig(1)*oig2*ri(k)/am_i*lami**bm_i)
             endif
             L_qi(k) = .true.
             lami = (am_i*cig(2)*oig1*ni(k)/ri(k))**obmi
@@ -2170,7 +2170,7 @@ MODULE module_mp_thompson
             xDi = (bm_i + mu_i + 1.) * ilami
             if (xDi.lt. 5.E-6) then
              lami = cie(2)/5.E-6
-             ni(k) = MIN(499.D3, cig(1)*oig2*ri(k)/am_i*lami**bm_i)
+             ni(k) = MIN(4999.D3, cig(1)*oig2*ri(k)/am_i*lami**bm_i)
             elseif (xDi.gt. 300.E-6) then
              lami = cie(2)/300.E-6
              ni(k) = cig(1)*oig2*ri(k)/am_i*lami**bm_i
@@ -2875,7 +2875,7 @@ MODULE module_mp_thompson
 
 !>  - Freezing of aqueous aerosols based on Koop et al (2001, Nature)
           xni = smo0(k)+ni(k) + (pni_rfz(k)+pni_wfz(k)+pni_inu(k))*dtsave
-          if (is_aerosol_aware .AND. homogIce .AND. (xni.le.499.E3)     &
+          if (is_aerosol_aware .AND. homogIce .AND. (xni.le.4999.E3)    &
      &                .AND.(temp(k).lt.238).AND.(ssati(k).ge.0.4) ) then
             xnc = iceKoop(temp(k),qv(k),qvs(k),nwfa(k), dtsave)
             pni_iha(k) = xnc*odts
@@ -3211,7 +3211,7 @@ MODULE module_mp_thompson
            xDi = (bm_i + mu_i + 1.) * ilami
            if (xDi.lt. 5.E-6) then
             lami = cie(2)/5.E-6
-            xni = MIN(499.D3, cig(1)*oig2*xri/am_i*lami**bm_i)
+            xni = MIN(4999.D3, cig(1)*oig2*xri/am_i*lami**bm_i)
             niten(k) = (xni-ni1d(k)*rho(k))*odts*orho
            elseif (xDi.gt. 300.E-6) then
             lami = cie(2)/300.E-6
@@ -3222,8 +3222,8 @@ MODULE module_mp_thompson
           niten(k) = -ni1d(k)*odts
          endif
          xni=MAX(0.,(ni1d(k) + niten(k)*dtsave)*rho(k))
-         if (xni.gt.499.E3) &
-                niten(k) = (499.E3-ni1d(k)*rho(k))*odts*orho
+         if (xni.gt.4999.E3) &
+                niten(k) = (4999.E3-ni1d(k)*rho(k))*odts*orho
 
 !>  - Rain tendency
          qrten(k) = qrten(k) + (prr_wau(k) + prr_rcw(k) &
@@ -3898,7 +3898,7 @@ MODULE module_mp_thompson
                                             *odzq*DT*onstep(1))
           enddo
 
-          if (rr(kts).gt.R1*10.) &
+          if (rr(kts).gt.R1*1000.) &
           pptrain = pptrain + sed_r(kts)*DT*onstep(1)
         enddo
       else !if(.not. sedi_semi)
@@ -3989,7 +3989,7 @@ MODULE module_mp_thompson
                                            *odzq*DT*onstep(2))
          enddo
 
-         if (ri(kts).gt.R1*10.) &
+         if (ri(kts).gt.R1*1000.) &
          pptice = pptice + sed_i(kts)*DT*onstep(2)
       enddo
       endif
@@ -4016,7 +4016,7 @@ MODULE module_mp_thompson
                                            *odzq*DT*onstep(3))
          enddo
 
-         if (rs(kts).gt.R1*10.) &
+         if (rs(kts).gt.R1*1000.) &
          pptsnow = pptsnow + sed_s(kts)*DT*onstep(3)
       enddo
       endif
@@ -4044,7 +4044,7 @@ MODULE module_mp_thompson
                                            *odzq*DT*onstep(4))
            enddo
 
-           if (rg(kts).gt.R1*10.) &
+           if (rg(kts).gt.R1*1000.) &
            pptgraul = pptgraul + sed_g(kts)*DT*onstep(4)
         enddo
       else ! if(.not. sedi_semi) then 
@@ -4168,7 +4168,7 @@ MODULE module_mp_thompson
             lami = cie(2)/300.E-6
            endif
            ni1d(k) = MIN(cig(1)*oig2*qi1d(k)/am_i*lami**bm_i,           &
-                         499.D3/rho(k))
+                         4999.D3/rho(k))
          endif
          qr1d(k) = qr1d(k) + qrten(k)*DT
          nr1d(k) = MAX(R2/rho(k), nr1d(k) + nrten(k)*DT)
@@ -5633,7 +5633,7 @@ MODULE module_mp_thompson
 
 !+---+-----------------------------------------------------------------+
 !>\ingroup aathompson
-!! Helper routine for Phillips et al (2008) ice nucleation.  Trude
+!! Helper routine for Phillips et al (2008) ice nucleation.
       REAL FUNCTION delta_p (yy, y1, y2, aa, bb)
       IMPLICIT NONE
 
@@ -5676,6 +5676,7 @@ MODULE module_mp_thompson
 !! schemes.  Since only the smallest snowflakes should impact
 !! radiation, compute from first portion of complicated Field number
 !! distribution, not the second part, which is the larger sizes.
+
       subroutine calc_effectRad (t1d, p1d, qv1d, qc1d, nc1d, qi1d, ni1d, qs1d,   &
      &                re_qc1d, re_qi1d, re_qs1d, kts, kte)
 
@@ -5791,6 +5792,7 @@ MODULE module_mp_thompson
 !! library of routines.  The meltwater fraction is simply the amount
 !! of frozen species remaining from what initially existed at the
 !! melting level interface.
+
       subroutine calc_refl10cm (qv1d, qc1d, qr1d, nr1d, qs1d, qg1d, &
                t1d, p1d, dBZ, rand1, kts, kte, ii, jj, melti,       &
                vt_dBZ, first_time_step)
@@ -6110,27 +6112,27 @@ MODULE module_mp_thompson
 
       end subroutine calc_refl10cm
 !
-!-------------------------------------------------------------------
+!+---+-----------------------------------------------------------------+
+!>\ingroup aathompson
+!! This routine is a semi-Lagrangain forward advection for hydrometeors
+!! with mass conservation and positive definite advection 2nd order
+!! interpolation with monotonic piecewise parabolic method is used.
+!! This routine is under assumption of decfl < 1 for semi_Lagrangian
+!!
+!! dzl    depth of model layer in meter
+!! wwl    terminal velocity at model layer m/s
+!! rql    dry air density*mixing ratio
+!! precip precipitation at surface 
+!! dt     time step
+!!
+!! author: hann-ming henry juang <henry.juang@noaa.gov>
+!!         implemented by song-you hong
+!! reference: Juang, H.-M., and S.-Y. Hong, 2010: Forward semi-Lagrangian
+!!         advection with mass conservation and positive definiteness for
+!!         falling hydrometeors. Mon. Wea.Rev., 138, 1778-1791.
+
       SUBROUTINE semi_lagrange_sedim(km,dzl,wwl,rql,precip,dt,R1)
-!-------------------------------------------------------------------
-!
-! This routine is a semi-Lagrangain forward advection for hydrometeors
-! with mass conservation and positive definite advection
-! 2nd order interpolation with monotonic piecewise parabolic method is used.
-! This routine is under assumption of decfl < 1 for semi_Lagrangian
-!
-! dzl    depth of model layer in meter
-! wwl    terminal velocity at model layer m/s
-! rql    dry air density*mixing ratio
-! precip precipitation at surface 
-! dt     time step
-!
-! author: hann-ming henry juang <henry.juang@noaa.gov>
-!         implemented by song-you hong
-! reference: Juang, H.-M., and S.-Y. Hong, 2010: Forward semi-Lagrangian advection
-!         with mass conservation and positive definiteness for falling
-!         hydrometeors. *Mon.  Wea. Rev.*, *138*, 1778-1791
-!
+
       implicit none
 
       integer, intent(in) :: km
@@ -6144,7 +6146,7 @@ MODULE module_mp_thompson
       real  zsum,qsum,dim,dip,con1,fa1,fa2
       real  allold, decfl
       real  dz(km), ww(km), qq(km)
-      real  wi(km+1), zi(km+1), za(km+2)    !hmhj
+      real  wi(km+1), zi(km+1), za(km+2)
       real  qn(km)
       real  dza(km+1), qa(km+1), qmi(km+1), qpi(km+1)
 !
@@ -6192,12 +6194,12 @@ MODULE module_mp_thompson
       enddo
       wi(km) = 0.5*(ww(km)+ww(km-1))
       wi(km+1) = ww(km)
-!
+
 ! terminate of top of raingroup
       do k=2,km
         if( ww(k).eq.0.0 ) wi(k)=ww(k-1)
       enddo
-!
+
 ! diffusivity of wi
       con1 = 0.05
       do k=km,1,-1
@@ -6210,18 +6212,18 @@ MODULE module_mp_thompson
       do k=1,km+1
         za(k) = zi(k) - wi(k)*dt
       enddo
-      za(km+2) = zi(km+1)   !hmhj
-!
-      do k=1,km+1  !hmhj
+      za(km+2) = zi(km+1)
+
+      do k=1,km+1
         dza(k) = za(k+1)-za(k)
       enddo
-!
+
 ! computer deformation at arrival point
       do k=1,km
         qa(k) = qq(k)*dz(k)/dza(k)
       enddo
       qa(km+1) = 0.0
-!
+
 ! estimate values at arrival cell interface with monotone
       do k=2,km
         dip=(qa(k+1)-qa(k))/(dza(k+1)+dza(k))
@@ -6242,7 +6244,7 @@ MODULE module_mp_thompson
       qmi(1)=qa(1)
       qmi(km+1)=qa(km+1)
       qpi(km+1)=qa(km+1)
-!
+
 ! interpolation to regular point
       qn = 0.0
       kb=1
@@ -6262,7 +6264,7 @@ MODULE module_mp_thompson
                            cycle find_kb
                          endif
                enddo find_kb
-               find_kt : do kk=kt,km+2    !hmhj
+               find_kt : do kk=kt,km+2
                          if( zi(k+1).le.za(kk) ) then
                            kt = kk
                            exit find_kt
@@ -6305,35 +6307,30 @@ MODULE module_mp_thompson
                endif
                cycle intp
              endif
-!
+
        enddo intp
-!
+
 ! rain out
       sum_precip: do k=1,km
                     if( za(k).lt.0.0 .and. za(k+1).le.0.0 ) then
-!hmhj
                       precip = precip + qa(k)*dza(k)
                       cycle sum_precip
                     else if ( za(k).lt.0.0 .and. za(k+1).gt.0.0 ) then
-!hmhj
-!hmhj                 precip(i) = precip(i) + qa(k)*(0.0-za(k))
-                      th = (0.0-za(k))/dza(k)               !hmhj
-                      th2 = th*th                           !hmhj
-                      qqd = 0.5*(qpi(k)-qmi(k))             !hmhj
-                      qqh = qqd*th2+qmi(k)*th               !hmhj
-                      precip = precip + qqh*dza(k)    !hmhj
+                      th = (0.0-za(k))/dza(k)
+                      th2 = th*th
+                      qqd = 0.5*(qpi(k)-qmi(k))
+                      qqh = qqd*th2+qmi(k)*th
+                      precip = precip + qqh*dza(k)
                       exit sum_precip
                     endif
                     exit sum_precip
       enddo sum_precip
-!
+
 ! replace the new values
       rql(:) = max(qn(:),R1)
-!
-! ----------------------------------
-!
+
   END SUBROUTINE semi_lagrange_sedim
-!+---+-----------------------------------------------------------------+
+
 !+---+-----------------------------------------------------------------+
 !+---+-----------------------------------------------------------------+
 END MODULE module_mp_thompson

--- a/physics/module_mp_thompson.F90
+++ b/physics/module_mp_thompson.F90
@@ -2376,7 +2376,7 @@ MODULE module_mp_thompson
 !+---+-----------------------------------------------------------------+
       do k = kte, kts, -1
          ygra1 = alog10(max(1.E-9, rg(k)))
-         zans1 = 3.0 + 2./7.*(ygra1+8.) + rand1
+         zans1 = 3.2 + 2./7.*(ygra1+8.) + rand1
          N0_exp = 10.**(zans1)
          N0_exp = MAX(DBLE(gonv_min), MIN(N0_exp, DBLE(gonv_max)))
          lam_exp = (N0_exp*am_g*cgg(1)/rg(k))**oge1
@@ -2404,12 +2404,9 @@ MODULE module_mp_thompson
       do k = kts, kte
 
 !>  - Rain self-collection follows Seifert, 1994 and drop break-up
-!! follows Verlinde and Cotton, 1993.                                        RAIN2M
+!! follows Verlinde and Cotton, 1993. Updated after Saleeby et al 2022.      RAIN2M
          if (L_qr(k) .and. mvd_r(k).gt. D0r) then
-!-GT      Ef_rr = 1.0
-!-GT      if (mvd_r(k) .gt. 1500.0E-6) then
-             Ef_rr = 1.0 - EXP(2300.0*(mvd_r(k)-1950.0E-6))
-!-GT      endif
+          Ef_rr = MAX(-0.1, 1.0 - EXP(2300.0*(mvd_r(k)-1950.0E-6)))
           pnr_rcr(k) = Ef_rr * 2.0*nr(k)*rr(k)
          endif
 
@@ -3452,7 +3449,7 @@ MODULE module_mp_thompson
 !+---+-----------------------------------------------------------------+
       do k = kte, kts, -1
          ygra1 = alog10(max(1.E-9, rg(k)))
-         zans1 = 3.0 + 2./7.*(ygra1+8.) + rand1
+         zans1 = 3.2 + 2./7.*(ygra1+8.) + rand1
          N0_exp = 10.**(zans1)
          N0_exp = MAX(DBLE(gonv_min), MIN(N0_exp, DBLE(gonv_max)))
          lam_exp = (N0_exp*am_g*cgg(1)/rg(k))**oge1
@@ -4068,7 +4065,7 @@ MODULE module_mp_thompson
              vtg = 0.
              if (rg(k).gt. R1) then
               ygra1 = alog10(max(1.E-9, rg(k)))
-              zans1 = 3.0 + 2./7.*(ygra1+8.) + rand1
+              zans1 = 3.2 + 2./7.*(ygra1+8.) + rand1
               N0_exp = 10.**(zans1)
               N0_exp = MAX(DBLE(gonv_min), MIN(N0_exp, DBLE(gonv_max)))
               lam_exp = (N0_exp*am_g*cgg(1)/rg(k))**oge1
@@ -5825,7 +5822,7 @@ MODULE module_mp_thompson
       REAL, DIMENSION(kts:kte):: ze_rain, ze_snow, ze_graupel
 
       DOUBLE PRECISION:: N0_exp, N0_min, lam_exp, lamr, lamg
-      REAL:: a_, b_, loga_, tc0
+      REAL:: a_, b_, loga_, tc0, SR
       DOUBLE PRECISION:: fmelt_s, fmelt_g
 
       INTEGER:: i, k, k_0, kbot, n
@@ -5848,7 +5845,7 @@ MODULE module_mp_thompson
       else
          do_vt_dBZ = .false.
          allow_wet_snow = .true.
-         allow_wet_graupel = .true.
+         allow_wet_graupel = .false.
       endif
 
       do k = kts, kte
@@ -5964,7 +5961,7 @@ MODULE module_mp_thompson
       if (ANY(L_qg .eqv. .true.)) then
       do k = kte, kts, -1
          ygra1 = alog10(max(1.E-9, rg(k)))
-         zans1 = 3.0 + 2./7.*(ygra1+8.) + rand1
+         zans1 = 3.2 + 2./7.*(ygra1+8.) + rand1
          N0_exp = 10.**(zans1)
          N0_exp = MAX(DBLE(gonv_min), MIN(N0_exp, DBLE(gonv_max)))
          lam_exp = (N0_exp*am_g*cgg(1)/rg(k))**oge1
@@ -6018,7 +6015,8 @@ MODULE module_mp_thompson
 
 !..Reflectivity contributed by melting snow
           if (allow_wet_snow .and. L_qs(k) .and. L_qs(k_0) ) then
-           fmelt_s = MAX(0.05d0, MIN(1.0d0-rs(k)/rs(k_0), 0.99d0))
+           SR = MAX(0.01, MIN(1.0 - rs(k)/(rs(k) + rr(k)), 0.99))
+           fmelt_s = DBLE(SR*SR)
            eta = 0.d0
            oM3 = 1./smoc(k)
            M0 = (smob(k)*oM3)
@@ -6041,7 +6039,8 @@ MODULE module_mp_thompson
 
 !..Reflectivity contributed by melting graupel
           if (allow_wet_graupel .and. L_qg(k) .and. L_qg(k_0) ) then
-           fmelt_g = MAX(0.05d0, MIN(1.0d0-rg(k)/rg(k_0), 0.99d0))
+           SR = MAX(0.01, MIN(1.0 - rg(k)/(rg(k) + rr(k)), 0.99))
+           fmelt_g = DBLE(SR*SR)
            eta = 0.d0
            lamg = 1./ilamg(k)
            do n = 1, nrbins

--- a/physics/module_mp_thompson.F90
+++ b/physics/module_mp_thompson.F90
@@ -2376,7 +2376,7 @@ MODULE module_mp_thompson
 !+---+-----------------------------------------------------------------+
       do k = kte, kts, -1
          ygra1 = alog10(max(1.E-9, rg(k)))
-         zans1 = 3.2 + 2./7.*(ygra1+8.) + rand1
+         zans1 = 3.3 + 2./7.*(ygra1+8.) + rand1
          N0_exp = 10.**(zans1)
          N0_exp = MAX(DBLE(gonv_min), MIN(N0_exp, DBLE(gonv_max)))
          lam_exp = (N0_exp*am_g*cgg(1)/rg(k))**oge1
@@ -3449,7 +3449,7 @@ MODULE module_mp_thompson
 !+---+-----------------------------------------------------------------+
       do k = kte, kts, -1
          ygra1 = alog10(max(1.E-9, rg(k)))
-         zans1 = 3.2 + 2./7.*(ygra1+8.) + rand1
+         zans1 = 3.3 + 2./7.*(ygra1+8.) + rand1
          N0_exp = 10.**(zans1)
          N0_exp = MAX(DBLE(gonv_min), MIN(N0_exp, DBLE(gonv_max)))
          lam_exp = (N0_exp*am_g*cgg(1)/rg(k))**oge1
@@ -4065,7 +4065,7 @@ MODULE module_mp_thompson
              vtg = 0.
              if (rg(k).gt. R1) then
               ygra1 = alog10(max(1.E-9, rg(k)))
-              zans1 = 3.2 + 2./7.*(ygra1+8.) + rand1
+              zans1 = 3.3 + 2./7.*(ygra1+8.) + rand1
               N0_exp = 10.**(zans1)
               N0_exp = MAX(DBLE(gonv_min), MIN(N0_exp, DBLE(gonv_max)))
               lam_exp = (N0_exp*am_g*cgg(1)/rg(k))**oge1
@@ -5961,7 +5961,7 @@ MODULE module_mp_thompson
       if (ANY(L_qg .eqv. .true.)) then
       do k = kte, kts, -1
          ygra1 = alog10(max(1.E-9, rg(k)))
-         zans1 = 3.2 + 2./7.*(ygra1+8.) + rand1
+         zans1 = 3.3 + 2./7.*(ygra1+8.) + rand1
          N0_exp = 10.**(zans1)
          N0_exp = MAX(DBLE(gonv_min), MIN(N0_exp, DBLE(gonv_max)))
          lam_exp = (N0_exp*am_g*cgg(1)/rg(k))**oge1

--- a/physics/module_mp_thompson.F90
+++ b/physics/module_mp_thompson.F90
@@ -2376,7 +2376,7 @@ MODULE module_mp_thompson
 !+---+-----------------------------------------------------------------+
       do k = kte, kts, -1
          ygra1 = alog10(max(1.E-9, rg(k)))
-         zans1 = 3.3 + 2./7.*(ygra1+8.) + rand1
+         zans1 = 3.4 + 2./7.*(ygra1+8.) + rand1
          N0_exp = 10.**(zans1)
          N0_exp = MAX(DBLE(gonv_min), MIN(N0_exp, DBLE(gonv_max)))
          lam_exp = (N0_exp*am_g*cgg(1)/rg(k))**oge1
@@ -3449,7 +3449,7 @@ MODULE module_mp_thompson
 !+---+-----------------------------------------------------------------+
       do k = kte, kts, -1
          ygra1 = alog10(max(1.E-9, rg(k)))
-         zans1 = 3.3 + 2./7.*(ygra1+8.) + rand1
+         zans1 = 3.4 + 2./7.*(ygra1+8.) + rand1
          N0_exp = 10.**(zans1)
          N0_exp = MAX(DBLE(gonv_min), MIN(N0_exp, DBLE(gonv_max)))
          lam_exp = (N0_exp*am_g*cgg(1)/rg(k))**oge1
@@ -4065,7 +4065,7 @@ MODULE module_mp_thompson
              vtg = 0.
              if (rg(k).gt. R1) then
               ygra1 = alog10(max(1.E-9, rg(k)))
-              zans1 = 3.3 + 2./7.*(ygra1+8.) + rand1
+              zans1 = 3.4 + 2./7.*(ygra1+8.) + rand1
               N0_exp = 10.**(zans1)
               N0_exp = MAX(DBLE(gonv_min), MIN(N0_exp, DBLE(gonv_max)))
               lam_exp = (N0_exp*am_g*cgg(1)/rg(k))**oge1
@@ -5961,7 +5961,7 @@ MODULE module_mp_thompson
       if (ANY(L_qg .eqv. .true.)) then
       do k = kte, kts, -1
          ygra1 = alog10(max(1.E-9, rg(k)))
-         zans1 = 3.3 + 2./7.*(ygra1+8.) + rand1
+         zans1 = 3.4 + 2./7.*(ygra1+8.) + rand1
          N0_exp = 10.**(zans1)
          N0_exp = MAX(DBLE(gonv_min), MIN(N0_exp, DBLE(gonv_max)))
          lam_exp = (N0_exp*am_g*cgg(1)/rg(k))**oge1

--- a/physics/radiation_clouds.f
+++ b/physics/radiation_clouds.f
@@ -3406,7 +3406,7 @@
       REAL:: RH_00L, RH_00O, RH_00
       REAL:: entrmnt=0.5
       INTEGER:: k
-      REAL:: TC, qvsi, qvsw, RHUM, delz
+      REAL:: TC, qvsi, qvsw, RHUM, delz, var_temp
       REAL, DIMENSION(kts:kte):: qvs, rh, rhoa
       integer:: ndebug = 0
 
@@ -3466,7 +3466,8 @@
             CLDFRA(K) = 1.0
          elseif (((qc(k)+qi(k)).gt.1.E-10) .and.                        &
      &                                    ((qc(k)+qi(k)).lt.1.E-6)) then
-            CLDFRA(K) = MIN(0.99, 0.1*(11.0 + log10(qc(k)+qi(k))))
+            var_temp = MIN(0.99, 0.1*(11.0 + log10(qc(k)+qi(k))))
+            CLDFRA(K) = var_temp*var_temp
          else
 
             IF ((XLAND-1.5).GT.0.) THEN                                  !--- Ocean

--- a/physics/radiation_clouds.f
+++ b/physics/radiation_clouds.f
@@ -2509,7 +2509,7 @@
         do i = 1, IX
           cwp(i,k) = max(0.0, clw(i,k,ntcw) * dz(i,k)*1.E6)
           crp(i,k) = 0.0
-          snow_mass_factor = 0.99
+          snow_mass_factor = 0.90
           cip(i,k) = max(0.0, (clw(i,k,ntiw)                            &
      &             + (1.0-snow_mass_factor)*clw(i,k,ntsw))*dz(i,k)*1.E6)
           if (re_snow(i,k) .gt. snow_max_radius)then
@@ -3476,24 +3476,24 @@
             ENDIF
 
             tc = MAX(-80.0, t(k) - 273.15)
-            if (tc .lt. -12.0) RH_00 = RH_00L
+            if (tc .lt. -24.0) RH_00 = RH_00L
 
             if (tc .gt. 20.0) then
                CLDFRA(K) = 0.0
-            elseif (tc .ge. -12.0) then
+            elseif (tc .ge. -24.0) then
                RHUM = MIN(rh(k), 1.0)
-               CLDFRA(K) = MAX(0., 1.0-SQRT((1.001-RHUM)/(1.001-RH_00)))
+               CLDFRA(K) = MAX(0., 1.0-SQRT(SQRT((1.001-RHUM)/(1.001-RH_00))))
             else
                if (max_relh.gt.1.12 .or. (.NOT.(modify_qvapor)) ) then
 !..For HRRR model, the following look OK.
                   RHUM = MIN(rh(k), 1.45)
-                  RH_00 = RH_00 + (1.45-RH_00)*(-12.0-tc)/(-12.0+85.)
-                  CLDFRA(K) = MAX(0.,1.0-SQRT((1.46-RHUM)/(1.46-RH_00)))
+                  RH_00 = RH_00 + (1.45-RH_00)*(-24.0-tc)/(-24.0+85.)
+                  CLDFRA(K) = MAX(0.,1.0-SQRT(SQRT((1.46-RHUM)/(1.46-RH_00))))
                else
 !..but for the GFS model, RH is way lower.
                   RHUM = MIN(rh(k), 1.05)
-                  RH_00 = RH_00 + (1.05-RH_00)*(-12.0-tc)/(-12.0+85.)
-                  CLDFRA(K) = MAX(0.,1.0-SQRT((1.06-RHUM)/(1.06-RH_00)))
+                  RH_00 = RH_00 + (1.05-RH_00)*(-24.0-tc)/(-24.0+85.)
+                  CLDFRA(K) = MAX(0.,1.0-SQRT(SQRT((1.06-RHUM)/(1.06-RH_00))))
                endif
             endif
             if (CLDFRA(K).gt.0.) CLDFRA(K)=MAX(0.01,MIN(CLDFRA(K),0.99))
@@ -3812,6 +3812,8 @@
 
       END SUBROUTINE adjust_cloudFinal
 
+!+---+-----------------------------------------------------------------+
+
       subroutine cloud_fraction_XuRandall                               &
      &     ( IX, NLAY, plyr, clwf, rhly, qstl,                          & !  ---  inputs
      &       cldtot )                                                   & !  ---  outputs
@@ -3836,7 +3838,6 @@
         do k = 1, NLAY
         do i = 1, IX
           clwt = 1.0e-6 * (plyr(i,k)*0.001)
-!         clwt = 2.0e-6 * (plyr(i,k)*0.001)
 
           if (clwf(i,k) > clwt) then
 
@@ -3845,8 +3846,6 @@
 
             tem1  = min(max(sqrt(sqrt(onemrh*qstl(i,k))),0.0001),1.0)
             tem1  = 2000.0 / tem1
-
-!           tem1  = 1000.0 / tem1
 
             value = max( min( tem1*(clwf(i,k)-clwm), 50.0 ), 0.0 )
             tem2  = sqrt( sqrt(rhly(i,k)) )
@@ -3857,6 +3856,8 @@
         enddo
 
       end subroutine cloud_fraction_XuRandall
+ 
+!+---+-----------------------------------------------------------------+
  
       subroutine cloud_fraction_mass_flx_1                              &
      &     ( IX, NLAY, lmfdeep2, xrc3, plyr, clwf, rhly, qstl,          & !  ---  inputs
@@ -3906,6 +3907,8 @@
         enddo
 
       end subroutine cloud_fraction_mass_flx_1
+ 
+!+---+-----------------------------------------------------------------+
  
       subroutine cloud_fraction_mass_flx_2                              &
      &     ( IX, NLAY, lmfdeep2, xrc3, plyr, clwf, rhly, qstl,          & !  ---  inputs

--- a/physics/radiation_clouds.f
+++ b/physics/radiation_clouds.f
@@ -3483,18 +3483,21 @@
                CLDFRA(K) = 0.0
             elseif (tc .ge. -24.0) then
                RHUM = MIN(rh(k), 1.0)
-               CLDFRA(K) = MAX(0., 1.0-SQRT(SQRT((1.001-RHUM)/(1.001-RH_00))))
+               var_temp = SQRT(SQRT((1.001-RHUM)/(1.001-RH_00)))
+               CLDFRA(K) = MAX(0., 1.0-var_temp)
             else
                if (max_relh.gt.1.12 .or. (.NOT.(modify_qvapor)) ) then
 !..For HRRR model, the following look OK.
                   RHUM = MIN(rh(k), 1.45)
                   RH_00 = RH_00 + (1.45-RH_00)*(-24.0-tc)/(-24.0+85.)
-                  CLDFRA(K) = MAX(0.,1.0-SQRT(SQRT((1.46-RHUM)/(1.46-RH_00))))
+                  var_temp = SQRT(SQRT((1.46-RHUM)/(1.46-RH_00)))
+                  CLDFRA(K) = MAX(0., 1.0-var_temp)
                else
 !..but for the GFS model, RH is way lower.
                   RHUM = MIN(rh(k), 1.05)
                   RH_00 = RH_00 + (1.05-RH_00)*(-24.0-tc)/(-24.0+85.)
-                  CLDFRA(K) = MAX(0.,1.0-SQRT(SQRT((1.06-RHUM)/(1.06-RH_00))))
+                  var_temp = SQRT(SQRT((1.06-RHUM)/(1.06-RH_00)))
+                  CLDFRA(K) = MAX(0., 1.0-var_temp)
                endif
             endif
             if (CLDFRA(K).gt.0.) CLDFRA(K)=MAX(0.01,MIN(CLDFRA(K),0.99))


### PR DESCRIPTION
This PR is attempting to increase some cloud ice aloft explicitly in the Thompson microphysics by permitting a larger number of ice crystals (as a maximum) and by overall decreasing the fractional cloudiness in the Thompson cloud fraction scheme (```subroutine cal_cldfra3```).  The following list of 4 items describes the changes introduced by this PR:

1.  permit maximum of 5000 ice crystals per Liter (previously 500).
2.  return to using 10% of snow mass assumed as cloud ice in radiation scheme.
3.  alter the equation for cloud fraction to use ```SQRT(SQRT(expression))``` in place of a single square root (see graphic below for how that affects the outcome).
4.  for readability purposes, I added a blank line around some subroutines and removed authors initials ```hnhj``` because this author was already credited in a comment block and having initials on many lines is pointless.

The first two items listed above are intended to improve explicitly-created clouds by the microphysics whether or not the ```icloud = 3``` option is attempted.  The third item is an attempt to reduce what was seen as too much high-altitude ice cloud causing outgoing longwave radiation to be too low compared to the 240 W/m2 target value.

The graphic below represents the cloud fraction diagnosed as a function of relative humidity for a sample condition of approximately 13km horizontal grid spacing and 250m vertical level spacing to arrive at the Critical RH values of 0.82 over land (red) and 0.90 over ocean (blue).  Dashed lines are the older diagnosis and solid lines with dots are the outcome of the new code.

![CF_versus_RH](https://user-images.githubusercontent.com/35609171/163230038-b58015c3-7e7f-484e-8782-b404521201fb.png)

