### PR TITLE
Add prognostic cumulus closure description in saSAS

### DIFF
--- a/physics/GFS_DCNV_generic.F90
+++ b/physics/GFS_DCNV_generic.F90
@@ -18,8 +18,8 @@
     subroutine GFS_DCNV_generic_pre_run (im, levs, ldiag3d, qdiag3d, do_cnvgwd, cplchm,  &
                                          gu0, gv0, gt0, gq0, nsamftrac, ntqv,            &
                                          save_u, save_v, save_t, save_q, clw,            &
-                                         ntcw,ntiw,ntclamt,ntrw,ntsw,ntrnc,ntsnc,ntgl,   &
-                                         ntgnc, nthl, nthnc, nthv, ntgv,                 &
+                                         ntcw,ntiw,ntclamt,ntsigma,ntrw,ntsw,ntrnc,ntsnc,&
+                                         ntgl,ntgnc, nthl, nthnc, nthv, ntgv,            &
                                          cscnv, satmedmf, trans_trac, ras, ntrac,        &
                                          dtidx, index_of_process_dcnv, errmsg, errflg)
 
@@ -28,7 +28,7 @@
       implicit none
 
       integer, intent(in) :: im, levs, nsamftrac, ntqv, index_of_process_dcnv, dtidx(:,:), &
-           ntcw,ntiw,ntclamt,ntrw,ntsw,ntrnc,ntsnc,ntgl,ntrac,ntgnc,nthl,nthnc,nthv,ntgv
+           ntcw,ntiw,ntclamt,ntrw,ntsw,ntrnc,ntsnc,ntgl,ntrac,ntgnc,nthl,nthnc,nthv,ntgv,ntsigma
       logical, intent(in) :: ldiag3d, qdiag3d, do_cnvgwd, cplchm
       real(kind=kind_phys), dimension(:,:),   intent(in)    :: gu0
       real(kind=kind_phys), dimension(:,:),   intent(in)    :: gv0
@@ -74,7 +74,7 @@
                     n /= ntrw  .and. n /= ntsw  .and. n /= ntrnc   .and. &
                     n /= ntsnc .and. n /= ntgl  .and. n /= ntgnc   .and. &
                     n /= nthl  .and. n /= nthnc .and. n /= nthv    .and. &
-                    n /= ntgv ) then
+                    n /= ntgv .and. n /= ntsigma) then
                   tracers = tracers + 1
                   if(dtidx(100+n,index_of_process_dcnv)>0) then
                      save_q(:,:,n) = clw(:,:,tracers)
@@ -114,7 +114,7 @@
       rainc, cldwrk, upd_mf, dwn_mf, det_mf, dtend, dtidx, index_of_process_dcnv, &
       index_of_temperature, index_of_x_wind, index_of_y_wind, ntqv, gq0, save_q,  &
       cnvw, cnvc, cnvw_phy_f3d, cnvc_phy_f3d, flag_for_dcnv_generic_tend,         &
-      ntcw,ntiw,ntclamt,ntrw,ntsw,ntrnc,ntsnc,ntgl,                               &
+      ntcw,ntiw,ntclamt,ntsigma,ntrw,ntsw,ntrnc,ntsnc,ntgl,                       &
       ntgnc, nthl, nthnc, nthv, ntgv, ntrac,clw,                                  &
       satmedmf, trans_trac, errmsg, errflg)
 
@@ -145,7 +145,7 @@
       integer, intent(in) :: dtidx(:,:), index_of_process_dcnv, index_of_temperature, &
            index_of_x_wind, index_of_y_wind, ntqv
       integer, intent(in) :: ntcw,ntiw,ntclamt,ntrw,ntsw,ntrnc,ntsnc,ntgl,   &
-                             ntgnc, nthl, nthnc, nthv, ntgv, ntrac
+                             ntgnc, nthl, nthnc, nthv, ntgv, ntsigma, ntrac
       real(kind=kind_phys), dimension(:,:,:), intent(in) :: clw
 
 
@@ -212,7 +212,7 @@
                      n /= ntrw  .and. n /= ntsw  .and. n /= ntrnc   .and. &
                      n /= ntsnc .and. n /= ntgl  .and. n /= ntgnc   .and. &
                      n /= nthl  .and. n /= nthnc .and. n /= nthv    .and. &
-                     n /= ntgv ) then
+                     n /= ntgv .and. n /= ntsigma) then
                    tracers = tracers + 1
                    idtend = dtidx(100+n,index_of_process_dcnv)
                    if(idtend>0) then

--- a/physics/GFS_DCNV_generic.meta
+++ b/physics/GFS_DCNV_generic.meta
@@ -190,6 +190,13 @@
   dimensions = ()
   type = integer
   intent = in
+[ntsigma]
+  standard_name = index_of_updraft_area_fraction_in_tracer_concentration_array
+  long_name = tracer index of updraft_area_fraction
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
 [ntrw]
   standard_name = index_of_rain_mixing_ratio_in_tracer_concentration_array
   long_name = tracer index for rain water
@@ -666,6 +673,13 @@
 [ntclamt]
   standard_name = index_of_cloud_area_fraction_in_atmosphere_layer_in_tracer_concentration_array
   long_name = tracer index for cloud amount integer
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+[ntsigma]
+  standard_name = index_of_updraft_area_fraction_in_tracer_concentration_array
+  long_name = tracer index of updraft_area_fraction
   units = index
   dimensions = ()
   type = integer

--- a/physics/GFS_MP_generic.F90
+++ b/physics/GFS_MP_generic.F90
@@ -88,14 +88,15 @@
 !> @{
       subroutine GFS_MP_generic_post_run(                                                                                 &
         im, levs, kdt, nrcm, nncl, ntcw, ntrac, imp_physics, imp_physics_gfdl, imp_physics_thompson, imp_physics_nssl,    &
-        imp_physics_mg, imp_physics_fer_hires, cal_pre, cplflx, cplchm, con_g, rainmin, dtf, frain, rainc,                &
+        imp_physics_mg, imp_physics_fer_hires, cal_pre, cplflx, cplchm, progsigma, con_g, rainmin, dtf, frain, rainc,     &
         rain1, rann, xlat, xlon, gt0, gq0, prsl, prsi, phii, tsfc, ice, snow, graupel, save_t, save_q, rain0, ice0, snow0,&
         graupel0, del, rain, domr_diag, domzr_diag, domip_diag, doms_diag, tprcp, srflag, sr, cnvprcp, totprcp, totice,   &
         totsnw, totgrp, cnvprcpb, totprcpb, toticeb, totsnwb, totgrpb, rain_cpl, rainc_cpl, snow_cpl, pwat,               &
         drain_cpl, dsnow_cpl, lsm, lsm_ruc, lsm_noahmp, raincprv, rainncprv, iceprv, snowprv,                             &
         graupelprv, draincprv, drainncprv, diceprv, dsnowprv, dgraupelprv, dtp, dfi_radar_max_intervals,                  &
-        dtend, dtidx, index_of_temperature, index_of_process_mp,ldiag3d, qdiag3d, lssav, num_dfi_radar, fh_dfi_radar,     &
-        index_of_process_dfi_radar, ix_dfi_radar, dfi_radar_tten, radar_tten_limits, fhour, errmsg, errflg)
+        dtend, dtidx, index_of_temperature, index_of_process_mp,ldiag3d, qdiag3d,dqdt_qmicro, lssav, num_dfi_radar,       &
+        fh_dfi_radar,index_of_process_dfi_radar, ix_dfi_radar, dfi_radar_tten, radar_tten_limits, fhour, qgrs_dsave,      &
+        errmsg, errflg)
 !
       use machine, only: kind_phys
 
@@ -104,7 +105,7 @@
       integer, intent(in) :: im, levs, kdt, nrcm, nncl, ntcw, ntrac, num_dfi_radar, index_of_process_dfi_radar
       integer, intent(in) :: imp_physics, imp_physics_gfdl, imp_physics_thompson, imp_physics_mg, imp_physics_fer_hires
       integer, intent(in) :: imp_physics_nssl
-      logical, intent(in) :: cal_pre, lssav, ldiag3d, qdiag3d, cplflx, cplchm
+      logical, intent(in) :: cal_pre, lssav, ldiag3d, qdiag3d, cplflx, cplchm, progsigma
       integer, intent(in) :: index_of_temperature,index_of_process_mp
 
       integer                                                :: dfi_radar_max_intervals
@@ -148,7 +149,8 @@
       real(kind=kind_phys), dimension(:),      intent(inout) :: diceprv
       real(kind=kind_phys), dimension(:),      intent(inout) :: dsnowprv
       real(kind=kind_phys), dimension(:),      intent(inout) :: dgraupelprv
-
+      real(kind=kind_phys), dimension(:,:),    intent(out)   :: dqdt_qmicro
+      real(kind=kind_phys), dimension(:,:),    intent(out)   :: qgrs_dsave
       real(kind=kind_phys),                    intent(in)    :: dtp
 
       ! CCPP error handling
@@ -420,6 +422,15 @@
         endif if_tendency_diagnostics
       endif if_save_fields
 
+      !If prognostic updraft area fraction is used in saSAS
+      if(progsigma)then
+         do k=1,levs
+            do i=1,im
+               dqdt_qmicro(i,k)=(gq0(i,k,1)-save_q(i,k,1))/dtp
+            enddo
+         enddo
+      endif
+
       if (cplflx .or. cplchm) then
         do i = 1, im
           dsnow_cpl(i)= max(zero, rain(i) * srflag(i))
@@ -455,6 +466,11 @@
         pwat(i) = pwat(i) * onebg
       enddo
 
+      do k = 1, levs
+        do i=1, im
+           qgrs_dsave(i,k) = gq0(i,k,1)
+        enddo
+       enddo
 
       end subroutine GFS_MP_generic_post_run
 !> @}

--- a/physics/GFS_MP_generic.meta
+++ b/physics/GFS_MP_generic.meta
@@ -852,7 +852,7 @@
   type = logical
   intent = in
 [dqdt_qmicro]
-  standard_name = instantanious_moisture_tendency_due_to_microphysics
+  standard_name = instantaneous_moisture_tendency_due_to_microphysics
   long_name = moisture tendency due to microphysics
   units = kg kg-1 s-1
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)

--- a/physics/GFS_MP_generic.meta
+++ b/physics/GFS_MP_generic.meta
@@ -248,6 +248,13 @@
   dimensions = ()
   type = logical
   intent = in
+[progsigma]
+  standard_name = flag_for_prognostic_sigma
+  long_name = flag for prognostic sigma
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
 [con_g]
   standard_name = gravitational_acceleration
   long_name = gravitational acceleration
@@ -844,6 +851,22 @@
   dimensions = ()
   type = logical
   intent = in
+[dqdt_qmicro]
+  standard_name = instantanious_moisture_tendency_due_to_microphysics
+  long_name = moisture tendency due to microphysics
+  units = kg kg-1 s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = out
+[qgrs_dsave]
+  standard_name = tracer_concentration_dsave
+  long_name = model layer mean tracer concentration dsave
+  units = kg kg-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = out
 [lssav]
   standard_name = flag_for_diagnostics
   long_name = logical flag for storing diagnostics

--- a/physics/GFS_SCNV_generic.F90
+++ b/physics/GFS_SCNV_generic.F90
@@ -17,14 +17,14 @@
       subroutine GFS_SCNV_generic_pre_run (im, levs, ldiag3d, qdiag3d, gu0, gv0, gt0, gq0, &
         save_u, save_v, save_t, save_q, ntqv, nsamftrac, flag_for_scnv_generic_tend,       &
         dtidx, index_of_process_scnv, ntcw,ntiw,ntclamt,ntrw,ntsw,ntrnc,ntsnc,ntgl,ntgnc,  &
-        cscnv, satmedmf, trans_trac, ras, ntrac, clw, errmsg, errflg)
+        ntsigma, cscnv, satmedmf, trans_trac, ras, ntrac, clw, errmsg, errflg)
 
         use machine,               only: kind_phys
 
         implicit none
 
         integer, intent(in) :: im, levs, ntqv, nsamftrac, index_of_process_scnv, dtidx(:,:)
-        integer, intent(in) :: ntcw,ntiw,ntclamt,ntrw,ntsw,ntrnc,ntsnc,ntgl,ntgnc,ntrac
+        integer, intent(in) :: ntcw,ntiw,ntclamt,ntsigma,ntrw,ntsw,ntrnc,ntsnc,ntgl,ntgnc,ntrac
         logical, intent(in) :: ldiag3d, qdiag3d, flag_for_scnv_generic_tend
         real(kind=kind_phys), dimension(:,:),   intent(in) :: gu0, gv0, gt0
         real(kind=kind_phys), dimension(:,:,:), intent(in) :: gq0
@@ -55,7 +55,7 @@
                 do n=2,ntrac
                    if ( n /= ntcw  .and. n /= ntiw  .and. n /= ntclamt .and. &
                         n /= ntrw  .and. n /= ntsw  .and. n /= ntrnc   .and. &
-                        n /= ntsnc .and. n /= ntgl  .and. n /= ntgnc) then
+                        n /= ntsnc .and. n /= ntgl  .and. n /= ntgnc .and. n /= ntsigma) then
                       tracers = tracers + 1
                       if(dtidx(100+n,index_of_process_scnv)>0) then
                          save_q(:,:,n) = clw(:,:,tracers)
@@ -97,7 +97,7 @@
         rainc, cnvprcp, cnvprcpb, cnvw_phy_f3d, cnvc_phy_f3d,                      &
         dtend, dtidx, index_of_temperature, index_of_x_wind, index_of_y_wind,      &
         index_of_process_scnv, ntqv, flag_for_scnv_generic_tend,                   &
-        ntcw,ntiw,ntclamt,ntrw,ntsw,ntrnc,ntsnc,ntgl,ntgnc,                        &
+        ntcw,ntiw,ntclamt,ntsigma,ntrw,ntsw,ntrnc,ntsnc,ntgl,ntgnc,                &
         imfshalcnv, imfshalcnv_sas, imfshalcnv_samf, ntrac,                        &
         cscnv, satmedmf, trans_trac, ras, errmsg, errflg)
 
@@ -106,7 +106,7 @@
       implicit none
 
       integer, intent(in) :: im, levs, nn, ntqv, nsamftrac
-      integer, intent(in) :: ntcw,ntiw,ntclamt,ntrw,ntsw,ntrnc,ntsnc,ntgl,ntgnc,ntrac
+      integer, intent(in) :: ntcw,ntiw,ntclamt,ntsigma,ntrw,ntsw,ntrnc,ntsnc,ntgl,ntgnc,ntrac
       logical, intent(in) :: lssav, ldiag3d, qdiag3d, flag_for_scnv_generic_tend
       real(kind=kind_phys),                     intent(in) :: frain
       real(kind=kind_phys), dimension(:,:), intent(in) :: gu0, gv0, gt0
@@ -186,7 +186,7 @@
              do n=2,ntrac
                 if ( n /= ntcw  .and. n /= ntiw  .and. n /= ntclamt .and. &
                      n /= ntrw  .and. n /= ntsw  .and. n /= ntrnc   .and. &
-                     n /= ntsnc .and. n /= ntgl  .and. n /= ntgnc) then
+                     n /= ntsnc .and. n /= ntgl  .and. n /= ntgnc .and. n/= ntsigma) then
                    tracers = tracers + 1
                    idtend = dtidx(100+n,index_of_process_scnv)
                    if(idtend>0) then

--- a/physics/GFS_SCNV_generic.meta
+++ b/physics/GFS_SCNV_generic.meta
@@ -183,6 +183,13 @@
   dimensions = ()
   type = integer
   intent = in
+[ntsigma]
+  standard_name = index_of_updraft_area_fraction_in_tracer_concentration_array
+  long_name = tracer index of updraft_area_fraction
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
 [ntrw]
   standard_name = index_of_rain_mixing_ratio_in_tracer_concentration_array
   long_name = tracer index for rain water
@@ -610,6 +617,13 @@
 [ntclamt]
   standard_name = index_of_cloud_area_fraction_in_atmosphere_layer_in_tracer_concentration_array
   long_name = tracer index for cloud amount integer
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+[ntsigma]
+  standard_name = index_of_updraft_area_fraction_in_tracer_concentration_array
+  long_name = tracer index of updraft_area_fraction
   units = index
   dimensions = ()
   type = integer

--- a/physics/progsigma_calc.f90
+++ b/physics/progsigma_calc.f90
@@ -12,12 +12,11 @@
 !!\section progsigma General Algorithm 
 !> @{ 
 
-      subroutine progsigma_calc (im,km,flag_init,flag_restart,flag_deep, &
+      subroutine progsigma_calc (im,km,flag_init,flag_restart,           &
            del,tmf,qmicro,dbyo1,zdqca,omega_u,zeta,hvap,delt,            &
            qgrs_dsave,q,kbcon1,ktcon,cnvflg,gdx,                         &
            do_ca, ca_closure, ca_entr, ca_trigger, nthresh, ca_deep,     &
-           ca_turb,ca_micro,ca_shal,ca_rad,convcount,ca1,ca2,ca3,ca4,    &
-           sigmain,sigmaout,sigmab,errmsg,errflg)
+           ca_micro,sigmain,sigmaout,sigmab,errmsg,errflg)
 !                                                           
 !                                                                                                                                             
       use machine,  only : kind_phys
@@ -31,12 +30,10 @@
       real,    intent(in)  :: qgrs_dsave(im,km), q(im,km),del(im,km),    &
            qmicro(im,km),tmf(im,km),dbyo1(im,km),zdqca(im,km),           &
            omega_u(im,km),zeta(im,km),gdx(im)
-      logical, intent(in)  :: flag_init,flag_restart,flag_deep,cnvflg(im)
+      logical, intent(in)  :: flag_init,flag_restart,cnvflg(im)
       real(kind=kind_phys), intent(in) :: nthresh
       real(kind=kind_phys), intent(in) :: ca_deep(im)
-      real(kind=kind_phys), intent(out):: ca_turb(im),                   &
-           ca_micro(im),ca_rad(im),ca_shal(im),convcount(im),ca1(im),    &
-           ca2(im),ca3(im),ca4(im)
+      real(kind=kind_phys), intent(out):: ca_micro(im)
       logical, intent(in)  :: do_ca,ca_closure,ca_entr,ca_trigger
 
       real(kind=kind_phys), intent(in) :: sigmain(im,km)
@@ -86,19 +83,6 @@
          zfdqa(i)=0.
          mcons(i)=0.
       enddo
-
-      !Temporary Initialization output:
-       do i = 1,im
-         if(flag_deep)then
-            !ca_turb(i)=0.
-            ca_shal(i)=0.
-         endif
-         if(.not. flag_deep)then
-            ca_rad(i)=0.
-            convcount(i)=0.
-            ca1(i)=0.
-         endif
-       enddo
 
       !Initial computations, place maximum sigmain in sigmab
 
@@ -232,15 +216,6 @@
                 sigmab(i)=MAX(sigmab(i),0.01)
              endif
              
-             if(flag_deep)then
-                !ca_turb(i)=ZCVG
-                ca_shal(i)=termC(i)
-             else
-                ca_rad(i)=ZCVG
-                ca1(i)=termC(i)
-             endif
-             !ca3(i)=sigmab(i)
-
           endif!cnvflg
        enddo
 

--- a/physics/progsigma_calc.f90
+++ b/physics/progsigma_calc.f90
@@ -16,7 +16,7 @@
       subroutine progsigma_calc (im,km,flag_init,flag_restart,           &
            flag_shallow,del,tmf,qmicro,dbyo1,zdqca,omega_u,zeta,hvap,    &
            delt,qgrs_dsave,q,kbcon1,ktcon,cnvflg,gdx,                    &
-           ca_micro,sigmain,sigmaout,sigmab,errmsg,errflg)
+           sigmain,sigmaout,sigmab,errmsg,errflg)
 !                                                           
 !                                                                                                                                             
       use machine,  only : kind_phys
@@ -31,7 +31,6 @@
            qmicro(im,km),tmf(im,km),dbyo1(im,km),zdqca(im,km),           &
            omega_u(im,km),zeta(im,km),gdx(im)
       logical, intent(in)  :: flag_init,flag_restart,cnvflg(im),flag_shallow
-      real(kind=kind_phys), intent(out):: ca_micro(im)
       real(kind=kind_phys), intent(in) :: sigmain(im,km)
 
 !     intent out
@@ -79,7 +78,6 @@
          termD(i)=0.
          fdqa(i)=0.
          mcons(i)=0.
-         ca_micro(i)=0.
       enddo
 
       !Initial computations, place maximum sigmain in sigmab
@@ -207,7 +205,6 @@
                 sigmab(i)=MIN(sigmab(i),sigmamax(i))  
                 sigmab(i)=MAX(sigmab(i),0.01)
              endif
-             ca_micro(i)=sigmab(i)
           endif!cnvflg
        enddo
 

--- a/physics/progsigma_calc.f90
+++ b/physics/progsigma_calc.f90
@@ -1,0 +1,260 @@
+!>\file progsigma
+!! This file contains the subroutine that calculates the prognostic
+!! updraft area fraction that is used for closure computations in 
+!! saSAS deep and shallow convection.
+
+!>\ingroup samfdeepcnv
+!! This subroutine computes a prognostic updraft area fraction
+!! used in the closure computations in the samfdeepcnv.f scheme
+!>\ingroup samfshalcnv
+!! This subroutine computes a prognostic updraft area fracftion
+!! used in the closure computations in the samfshalcnv. scheme
+!!\section progsigma General Algorithm 
+!> @{ 
+
+      subroutine progsigma_calc (im,km,flag_init,flag_restart,flag_deep, &
+           del,tmf,qmicro,dbyo1,zdqca,omega_u,zeta,hvap,delt,            &
+           qgrs_dsave,q,kbcon1,ktcon,cnvflg,gdx,                         &
+           do_ca, ca_closure, ca_entr, ca_trigger, nthresh, ca_deep,     &
+           ca_turb,ca_micro,ca_shal,ca_rad,convcount,ca1,ca2,ca3,ca4,    &
+           sigmain,sigmaout,sigmab,errmsg,errflg)
+!                                                           
+!                                                                                                                                             
+      use machine,  only : kind_phys
+      use funcphys, only : fpvs
+
+      implicit none
+
+!     intent in
+      integer, intent(in)  :: im,km,kbcon1(im),ktcon(im)
+      real,    intent(in)  :: hvap,delt
+      real,    intent(in)  :: qgrs_dsave(im,km), q(im,km),del(im,km),    &
+           qmicro(im,km),tmf(im,km),dbyo1(im,km),zdqca(im,km),           &
+           omega_u(im,km),zeta(im,km),gdx(im)
+      logical, intent(in)  :: flag_init,flag_restart,flag_deep,cnvflg(im)
+      real(kind=kind_phys), intent(in) :: nthresh
+      real(kind=kind_phys), intent(in) :: ca_deep(im)
+      real(kind=kind_phys), intent(out):: ca_turb(im),                   &
+           ca_micro(im),ca_rad(im),ca_shal(im),convcount(im),ca1(im),    &
+           ca2(im),ca3(im),ca4(im)
+      logical, intent(in)  :: do_ca,ca_closure,ca_entr,ca_trigger
+
+      real(kind=kind_phys), intent(in) :: sigmain(im,km)
+
+!     intent out
+      real(kind=kind_phys), intent(out) :: sigmaout(im,km)
+      real(kind=kind_phys), intent(out) :: sigmab(im)
+      character(len=*),     intent(out) :: errmsg
+      integer,              intent(out) :: errflg
+
+!     Local variables
+      integer              :: i,k,km1
+      real(kind=kind_phys) :: termA(im),termB(im),termC(im),termD(im),   &
+                          mcons(im),zfdqa(im),zform(im,km),              &
+                          qadv(im,km),sigmamax(im)                         
+                          
+
+      real(kind=kind_phys) :: gcvalmx,ZEPS7,ZZ,ZCVG,mcon,buy2,   &
+                          zfdqb,dtdyn,dxlim,rmulacvg,dp,tem,     &
+                          alpha,DEN
+      integer :: inbu(im,km)  
+
+     !Parameters
+     gcvalmx = 0.1
+     rmulacvg=10.
+     ZEPS7=1.E-11
+     km1=km-1
+     alpha=7000.
+
+     !Initialization 2D
+     do k = 1,km
+        do i = 1,im
+           sigmaout(i,k)=0.
+           inbu(i,k)=0
+           zform(i,k)=0. 
+        enddo
+     enddo
+     
+     !Initialization 1D
+     do i=1,im
+         sigmab(i)=0.
+         sigmamax(i)=0.95
+         termA(i)=0.
+         termB(i)=0.
+         termC(i)=0.
+         termD(i)=0.
+         zfdqa(i)=0.
+         mcons(i)=0.
+      enddo
+
+      !Temporary Initialization output:
+       do i = 1,im
+         if(flag_deep)then
+            !ca_turb(i)=0.
+            ca_shal(i)=0.
+         endif
+         if(.not. flag_deep)then
+            ca_rad(i)=0.
+            convcount(i)=0.
+            ca1(i)=0.
+         endif
+       enddo
+
+      !Initial computations, place maximum sigmain in sigmab
+
+      do k=2,km
+       do i=1,im
+          if(flag_init .and. .not. flag_restart)then
+             if(cnvflg(i))then
+                sigmab(i)=0.03
+             endif
+          else
+             if(cnvflg(i))then
+                !if(sigmain(i,k)<1.E-5)then
+                !   sigmain(i,k)=0.
+                !endif
+               if(sigmain(i,k)>sigmab(i))then
+                   sigmab(i)=sigmain(i,k)
+               endif
+             endif
+          endif
+       enddo
+      enddo
+
+      do i=1,im
+         if(sigmab(i) < 1.E-5)then !after advection
+            sigmab(i)=0.                                                                                                             
+         endif
+      enddo
+           
+      !Initial computations, sigmamax
+      do i=1,im
+         sigmamax(i)=alpha/gdx(i)
+         sigmamax(i)=MIN(0.95,sigmamax(i))
+      enddo
+
+      !Initial computations, dynamic q-tendency
+      do k = 1,km
+         do i = 1,im
+            if(flag_init .and. .not.flag_restart)then
+               qadv(i,k)=0.
+            else
+               qadv(i,k)=(q(i,k) - qgrs_dsave(i,k))/delt
+            endif
+         enddo
+      enddo
+      
+      !compute termD "The vertical integral of the latent heat convergence is limited to the                                        
+      !buoyant layers with positive moisture convergence (accumulated from the surface).                                                       
+      !Lowest level:                                                                                                               
+       do i = 1,im
+          dp = 1000. * del(i,1)
+          mcons(i)=(hvap*(qadv(i,1)+tmf(i,1)+qmicro(i,1))*dp)
+       enddo
+      !Levels above:
+       do k = 2,km1
+          do i = 1,im
+             dp = 1000. * del(i,k)
+             if(cnvflg(i))then
+                mcon = (hvap*(qadv(i,k)+tmf(i,k)+qmicro(i,k))*dp)
+                buy2 = termD(i)+mcon+mcons(i)
+!               Do the integral over buoyant layers with positive mcon acc from surface
+                if(k > kbcon1(i) .and. k < ktcon(i) .and. buy2 > 0.)then
+                   inbu(i,k)=1
+                endif
+                inbu(i,k-1)=MAX(inbu(i,k-1),inbu(i,k))
+                termD(i) = termD(i) + float(inbu(i,k-1))*mcons(i)
+                mcons(i)=mcon
+             endif
+          enddo
+       enddo
+
+       !termA
+       do k = 2,km1
+          do i = 1,im
+             dp = 1000. * del(i,k)
+             if(cnvflg(i))then
+                tem=(sigmab(i)*zeta(i,k)*float(inbu(i,k))*dbyo1(i,k))*dp
+                termA(i)=termA(i)+tem
+             endif
+          enddo
+       enddo
+
+       !termB                                                                                                             
+       do k = 2,km1
+          do i = 1,im
+             dp = 1000. * del(i,k)
+             if(cnvflg(i))then
+                tem=(dbyo1(i,k)*float(inbu(i,k)))*dp
+                termB(i)=termB(i)+tem
+             endif
+          enddo
+       enddo
+       
+      !termC
+       do k = 2,km1
+          do i = 1,im
+             if(cnvflg(i))then
+                dp = 1000. * del(i,k)
+                zform(i,k)=-1.0*float(inbu(i,k))*(omega_u(i,k)*delt)
+                zfdqb=0.5*((zform(i,k)*zdqca(i,k)))
+                termC(i)=termC(i)+(float(inbu(i,k))*   &
+                     (zfdqb+zfdqa(i))*hvap*zeta(i,k))
+                zfdqa(i)=zfdqb
+             endif
+         enddo
+      enddo
+
+      !sigmab
+       do i = 1,im                                                                                                                           
+          if(cnvflg(i))then
+
+             DEN=MIN(termC(i)+termB(i),1.E8) !1.E8
+             !DEN=MAX(termC(i)+termB(i),1.E7) !1.E7
+
+             ZCVG=termD(i)*delt
+
+             ZZ=MAX(0.0,SIGN(1.0,termA(i)))            &
+                  *MAX(0.0,SIGN(1.0,termB(i)))         &
+                  *MAX(0.0,SIGN(1.0,termC(i)-ZEPS7))   
+
+
+             ZCVG=MAX(0.0,ZCVG)
+             
+             if(flag_init)then
+                sigmab(i)=0.03
+             else
+                sigmab(i)=(ZZ*(termA(i)+ZCVG))/(DEN+(1.0-ZZ))
+             endif
+
+             if(sigmab(i)>0.)then
+                sigmab(i)=MIN(sigmab(i),sigmamax(i))  
+                sigmab(i)=MAX(sigmab(i),0.01)
+             endif
+             
+             if(flag_deep)then
+                !ca_turb(i)=ZCVG
+                ca_shal(i)=termC(i)
+             else
+                ca_rad(i)=ZCVG
+                ca1(i)=termC(i)
+             endif
+             !ca3(i)=sigmab(i)
+
+          endif!cnvflg
+       enddo
+
+       do k=1,km
+          do i=1,im
+             if(cnvflg(i))then
+                sigmaout(i,k)=sigmab(i)
+             endif
+          enddo
+       enddo
+     
+     end subroutine progsigma_calc
+!> @}                            
+!! @} 
+
+
+

--- a/physics/samfdeepcnv.f
+++ b/physics/samfdeepcnv.f
@@ -86,7 +86,7 @@
      &    CNV_DQLDT,CLCN,CNV_FICE,CNV_NDROP,CNV_NICE,mp_phys,mp_phys_mg,&
      &    clam,c0s,c1,betal,betas,evef,pgcon,asolfac,                   &
      &    do_ca, ca_closure, ca_entr, ca_trigger, nthresh, ca_deep,     &
-     &    rainevap, sigmain, sigmaout, ca_micro,                        &
+     &    rainevap, sigmain, sigmaout,                                  &
      &    errmsg,errflg)
 !
       use machine , only : kind_phys
@@ -108,7 +108,7 @@
       real(kind=kind_phys), intent(in) :: ca_deep(:)
       real(kind=kind_phys), intent(in) :: sigmain(:,:),qmicro(:,:),     &
      &     tmf(:,:),q(:,:), qgrs_dsave(:,:)
-      real(kind=kind_phys), intent(out) :: rainevap(:),ca_micro(:)
+      real(kind=kind_phys), intent(out) :: rainevap(:)
       real(kind=kind_phys), intent(out) :: sigmaout(:,:)
       logical, intent(in)  :: do_ca,ca_closure,ca_entr,ca_trigger
 
@@ -919,8 +919,6 @@ c
       enddo
       if(totflg) return
 !!
-!
-!Lisa: at this point only trigger criteria is set
 
 ! turbulent entrainment rate assumed to be proportional
 !   to subcloud mean TKE
@@ -2895,7 +2893,7 @@ c
          call progsigma_calc(im,km,first_time_step,restart,flag_shallow,
      &        del,tmf,qmicro,dbyo1,zdqca,omega_u,zeta,hvap,delt,
      &        qgrs_dsave,q,kbcon1,ktcon,cnvflg,gdx,
-     &        ca_micro,sigmain,sigmaout,sigmab,errmsg,errflg)
+     &        sigmain,sigmaout,sigmab,errmsg,errflg)
       endif
 
 !> - From Han et al.'s (2017) \cite han_et_al_2017 equation 6, calculate cloud base mass flux as a function of the mean updraft velcoity for the grid sizes where the quasi-equilibrium assumption of Arakawa-Schubert is not valid any longer.

--- a/physics/samfdeepcnv.f
+++ b/physics/samfdeepcnv.f
@@ -216,7 +216,7 @@ cj
 !  parameters for prognostic sigma closure                                                                                                                                                      
       real(kind=kind_phys) omega_u(im,km),zdqca(im,km),qlks(im,km),
      &                    omegac(im),zeta(im,km),dbyo1(im,km),sigmab(im)
-
+      logical flag_shallow
 c  physical parameters
 !     parameter(grav=grav,asolfac=0.958)
 !     parameter(elocp=hvap/cp,el2orc=hvap*hvap/(rv*cp))
@@ -1729,7 +1729,7 @@ c
         enddo
       enddo
 
-      if(progsigma)then                                                                                                                                                                         
+      if(progsigma)then                                                                                                                                                                   
           do k = 2, km1
             do i = 1, im
                if (cnvflg(i)) then
@@ -1776,8 +1776,7 @@ c
 c
 
 !> - Calculate the mean updraft velocity within the cloud (wc),cast in pressure coordinates.                                                                                                                                  
-      if(progsigma)then 
-                                                                                                                                                                        
+      if(progsigma)then                                                                                                                                                            
          do i = 1, im
             omegac(i) = 0.
             sumx(i) = 0.
@@ -1861,17 +1860,19 @@ c
 c
 
 c store term needed for "termC" in prognostic area fraction closure
-      do k = 2, km1
-         do i = 1, im
-            dp = 1000. * del(i,k)
-            if (cnvflg(i)) then
-               if(k > kbcon(i) .and. k < ktcon(i)) then
-                  zdqca(i,k)=((qlks(i,k)-qlks(i,k-1)) +
-     &                 pwo(i,k)+dellal(i,k))
+      if(progsigma)then
+         do k = 2, km1
+            do i = 1, im
+               dp = 1000. * del(i,k)
+               if (cnvflg(i)) then
+                  if(k > kbcon(i) .and. k < ktcon(i)) then
+                     zdqca(i,k)=((qlks(i,k)-qlks(i,k-1)) +
+     &                    pwo(i,k)+dellal(i,k))
+                  endif
                endif
-            endif
+            enddo
          enddo
-      enddo
+      endif
 
 ccccc if(lat.==.latd.and.lon.==.lond.and.cnvflg(i)) then
 ccccc   print *, ' aa1(i) before dwndrft =', aa1(i)
@@ -2890,10 +2891,10 @@ c
 
 !> - From Bengtsson et al. (2022) Prognostic closure scheme, equation 8, compute updraft area fraction based on a moisture budget
       if(progsigma)then
-         call progsigma_calc(im,km,first_time_step,restart,
+         flag_shallow = .false.
+         call progsigma_calc(im,km,first_time_step,restart,flag_shallow,
      &        del,tmf,qmicro,dbyo1,zdqca,omega_u,zeta,hvap,delt,
      &        qgrs_dsave,q,kbcon1,ktcon,cnvflg,gdx,
-     &        do_ca, ca_closure, ca_entr, ca_trigger, nthresh, ca_deep,
      &        ca_micro,sigmain,sigmaout,sigmab,errmsg,errflg)
       endif
 

--- a/physics/samfdeepcnv.meta
+++ b/physics/samfdeepcnv.meta
@@ -326,14 +326,6 @@
   dimensions = ()
   type = logical
   intent = in
-[ca_micro]
-  standard_name = output_prognostic_sigma_two
-  long_name = output of prognostic area fraction two
-  units = frac
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = out
 [cldwrk]
   standard_name = cloud_work_function
   long_name = cloud work function

--- a/physics/samfdeepcnv.meta
+++ b/physics/samfdeepcnv.meta
@@ -70,15 +70,15 @@
   type = logical
   intent = in
 [tmf]
-  standard_name = turbulence_moisture_flux
-  long_name = turbulence_moisture_flux
+  standard_name = turbulence_moisture_flux_for_coupling_to_convection
+  long_name = turbulence_moisture_flux_for_coupling_to_convection
   units = kg kg-1 s-1
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = in
 [qmicro]
-  standard_name = instantanious_moisture_tendency_due_to_microphysics
+  standard_name = instantaneous_moisture_tendency_due_to_microphysics
   long_name = moisture tendency due to microphysics
   units = kg kg-1 s-1
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
@@ -450,13 +450,13 @@
   kind = kind_phys
   intent = inout
 [sigmain]
-  standard_name = updraft_area_fraction
+  standard_name = prognostic_updraft_area_fraction_in_convection
   long_name = convective updraft area fraction
   units = frac
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  intent = inout
+  intent = in
 [sigmaout]
   standard_name = updraft_area_fraction_updated_by_physics
   long_name = convective updraft area fraction updated by physics

--- a/physics/samfdeepcnv.meta
+++ b/physics/samfdeepcnv.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = samfdeepcnv
   type = scheme
-  dependencies = funcphys.f90,machine.F,samfaerosols.F
+  dependencies = funcphys.f90,machine.F,samfaerosols.F,progsigma_calc.f90
 
 ########################################################################
 [ccpp-arg-table]
@@ -54,6 +54,36 @@
   units = count
   dimensions = ()
   type = integer
+  intent = in
+[first_time_step]
+  standard_name = flag_for_first_timestep
+  long_name = flag for first time step for time integration loop (cold/warmstart)
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+[restart]
+  standard_name = flag_for_restart
+  long_name = flag for restart (warmstart) or coldstart
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+[tmf]
+  standard_name = turbulence_moisture_flux
+  long_name = turbulence_moisture_flux
+  units = kg kg-1 s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[qmicro]
+  standard_name = instantanious_moisture_tendency_due_to_microphysics
+  long_name = moisture tendency due to microphysics
+  units = kg kg-1 s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
   intent = in
 [itc]
   standard_name = index_of_first_chemical_tracer_for_convection
@@ -219,6 +249,22 @@
   type = real
   kind = kind_phys
   intent = inout
+[qgrs_dsave]
+  standard_name = tracer_concentration_dsave
+  long_name = model layer mean tracer concentration dsave
+  units = kg kg-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[q]
+  standard_name = specific_humidity
+  long_name = water vapor specific humidity
+  units = kg kg-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
 [q1]
   standard_name = specific_humidity_of_new_state
   long_name = updated vapor specific humidity
@@ -266,6 +312,28 @@
   dimensions = ()
   type = logical
   intent = in
+[wclosureflg]
+  standard_name = flag_for_wclosure
+  long_name = flag for vertical velocity closure
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+[progsigma]
+  standard_name = flag_for_prognostic_sigma
+  long_name = flag for prognostic sigma
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+[ca_micro]
+  standard_name = output_prognostic_sigma_two
+  long_name = output of prognostic area fraction two
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
 [cldwrk]
   standard_name = cloud_work_function
   long_name = cloud work function
@@ -381,6 +449,22 @@
   type = real
   kind = kind_phys
   intent = inout
+[sigmain]
+  standard_name = updraft_area_fraction
+  long_name = convective updraft area fraction
+  units = frac
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[sigmaout]
+  standard_name = updraft_area_fraction_updated_by_physics
+  long_name = convective updraft area fraction updated by physics
+  units = frac
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = out
 [qlcn]
   standard_name = mass_fraction_of_convective_cloud_liquid_water
   long_name = mass fraction of convective cloud liquid water

--- a/physics/samfshalcnv.f
+++ b/physics/samfshalcnv.f
@@ -63,7 +63,7 @@
      &     rn,kbot,ktop,kcnv,islimsk,garea,                             &
      &     dot,ncloud,hpbl,ud_mf,dt_mf,cnvw,cnvc,                       &
      &     clam,c0s,c1,evef,pgcon,asolfac,hwrf_samfshal,
-     &     ca_micro,sigmain,sigmaout,errmsg,errflg)
+     &     sigmain,sigmaout,errmsg,errflg)
 !
       use machine , only : kind_phys
       use funcphys , only : fpvs
@@ -86,7 +86,7 @@
      &   q1(:,:), t1(:,:), u1(:,:), v1(:,:)
 !
       integer, intent(out) :: kbot(:), ktop(:)
-      real(kind=kind_phys), intent(out) :: rn(:), ca_micro(:),          &
+      real(kind=kind_phys), intent(out) :: rn(:),                       &
      &   cnvw(:,:), cnvc(:,:), ud_mf(:,:), dt_mf(:,:), sigmaout(:,:)
 !
       real(kind=kind_phys), intent(in) :: clam,    c0s,     c1,         &
@@ -334,7 +334,6 @@ c
 !       vshear(i) = 0.
         gdx(i) = sqrt(garea(i))
         xmb(i) = 0.
-        ca_micro(i) = 0.
        enddo
       endif
 !!
@@ -1932,7 +1931,7 @@ c Prognostic closure
          call progsigma_calc(im,km,first_time_step,restart,flag_shallow,
      &        del,tmf,qmicro,dbyo1,zdqca,omega_u,zeta,hvap,delt,
      &        qgrs_dsave,q,kbcon1,ktcon,cnvflg,gdx,
-     &        ca_micro,sigmain,sigmaout,sigmab,errmsg,errflg)
+     &        sigmain,sigmaout,sigmab,errmsg,errflg)
       endif
 
 !> - From Han et al.'s (2017) \cite han_et_al_2017 equation 6, calculate cloud base mass flux as a function of the mean updraft velcoity.

--- a/physics/samfshalcnv.meta
+++ b/physics/samfshalcnv.meta
@@ -466,14 +466,6 @@
   dimensions = ()
   type = logical
   intent = in
-[ca_micro]
-  standard_name = output_prognostic_sigma_two
-  long_name = output of prognostic area fraction two
-  units = frac
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = out
 [sigmain]
   standard_name = prognostic_updraft_area_fraction_in_convection
   long_name = convective updraft area fraction

--- a/physics/samfshalcnv.meta
+++ b/physics/samfshalcnv.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = samfshalcnv
   type = scheme
-  dependencies = funcphys.f90,machine.F,samfaerosols.F
+  dependencies = funcphys.f90,machine.F,samfaerosols.F,progsigma_calc.f90
 
 ########################################################################
 [ccpp-arg-table]
@@ -54,6 +54,36 @@
   units = count
   dimensions = ()
   type = integer
+  intent = in
+[first_time_step]
+  standard_name = flag_for_first_timestep
+  long_name = flag for first time step for time integration loop (cold/warmstart)
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+[restart]
+  standard_name = flag_for_restart
+  long_name = flag for restart (warmstart) or coldstart
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+[tmf]
+  standard_name = turbulence_moisture_flux_for_coupling_to_convection
+  long_name = turbulence_moisture_flux_for_coupling_to_convection
+  units = kg kg-1 s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[qmicro]
+  standard_name = instantaneous_moisture_tendency_due_to_microphysics
+  long_name = moisture tendency due to microphysics
+  units = kg kg-1 s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
   intent = in
 [itc]
   standard_name = index_of_first_chemical_tracer_for_convection
@@ -219,6 +249,22 @@
   type = real
   kind = kind_phys
   intent = inout
+[qgrs_dsave]
+  standard_name = tracer_concentration_dsave
+  long_name = model layer mean tracer concentration dsave
+  units = kg kg-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[q]
+  standard_name = specific_humidity
+  long_name = water vapor specific humidity
+  units = kg kg-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
 [q1]
   standard_name = specific_humidity_of_new_state
   long_name = updated vapor specific humidity
@@ -413,6 +459,37 @@
   dimensions = ()
   type = logical
   intent = in
+[progsigma]
+  standard_name = flag_for_prognostic_sigma
+  long_name = flag for prognostic sigma
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+[ca_micro]
+  standard_name = output_prognostic_sigma_two
+  long_name = output of prognostic area fraction two
+  units = frac
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+[sigmain]
+  standard_name = prognostic_updraft_area_fraction_in_convection
+  long_name = convective updraft area fraction
+  units = frac
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[sigmaout]
+  standard_name = updraft_area_fraction_updated_by_physics
+  long_name = convective updraft area fraction updated by physics
+  units = frac
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = out
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP

--- a/physics/satmedmfvdifq.F
+++ b/physics/satmedmfvdifq.F
@@ -121,9 +121,9 @@
       real(kind=kind_phys), intent(out) ::                              &
      &                     dusfc(:),     dvsfc(:),                      &
      &                     dtsfc(:),     dqsfc(:),                      &
-     &                     hpbl(:),      tmf(:,:)
+     &                     hpbl(:)
       real(kind=kind_phys), intent(out) ::                              &
-     &                     dkt(:,:), dku(:,:)
+     &                     dkt(:,:), dku(:,:), tmf(:,:)
 !
       logical, intent(in)  :: dspheat
       character(len=*), intent(out) :: errmsg
@@ -299,6 +299,7 @@
           xmfd(i,k) = 0.
           buou(i,k) = 0.
           buod(i,k) = 0.
+          tmf(i,k) = 0.
           ckz(i,k) = ck1
           chz(i,k) = ch1
           rlmnz(i,k) = rlmn0

--- a/physics/satmedmfvdifq.F
+++ b/physics/satmedmfvdifq.F
@@ -69,7 +69,7 @@
 !! @{
       subroutine satmedmfvdifq_run(im,km,ntrac,ntcw,ntrw,ntiw,ntke,     &
      &     grav,rd,cp,rv,hvap,hfus,fv,eps,epsm1,                        &
-     &     dv,du,tdt,rtg,u1,v1,t1,q1,swh,hlw,xmu,garea,zvfun,           &
+     &     dv,du,tdt,rtg,tmf,u1,v1,t1,q1,swh,hlw,xmu,garea,zvfun,       &
      &     psk,rbsoil,zorl,u10m,v10m,fm,fh,                             &
      &     tsea,heat,evap,stress,spd1,kpbl,                             &
      &     prsi,del,prsl,prslk,phii,phil,delt,                          &
@@ -121,7 +121,7 @@
       real(kind=kind_phys), intent(out) ::                              &
      &                     dusfc(:),     dvsfc(:),                      &
      &                     dtsfc(:),     dqsfc(:),                      &
-     &                     hpbl(:)
+     &                     hpbl(:),      tmf(:,:)
       real(kind=kind_phys), intent(out) ::                              &
      &                     dkt(:,:), dku(:,:)
 !
@@ -2114,6 +2114,7 @@ c
             qtend      = (f2(i,k)-q1(i,k,1))*rdt
             tdt(i,k)   = tdt(i,k)+ttend
             rtg(i,k,1) = rtg(i,k,1)+qtend
+            tmf(i,k)   = qtend
 !           dtsfc(i)   = dtsfc(i)+cont*del(i,k)*ttend
 !           dqsfc(i)   = dqsfc(i)+conq*del(i,k)*qtend
          enddo

--- a/physics/satmedmfvdifq.meta
+++ b/physics/satmedmfvdifq.meta
@@ -201,6 +201,14 @@
   type = real
   kind = kind_phys
   intent = inout
+[tmf]
+  standard_name = turbulence_moisture_flux
+  long_name = turbulence_moisture_flux
+  units = kg kg-1 s-1
+  dimensions = (horizontal_dimension,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = out
 [u1]
   standard_name = x_wind
   long_name = x component of layer wind

--- a/physics/satmedmfvdifq.meta
+++ b/physics/satmedmfvdifq.meta
@@ -202,10 +202,10 @@
   kind = kind_phys
   intent = inout
 [tmf]
-  standard_name = turbulence_moisture_flux
-  long_name = turbulence_moisture_flux
+  standard_name = turbulence_moisture_flux_for_coupling_to_convection
+  long_name = turbulence_moisture_flux_for_coupling_to_convection
   units = kg kg-1 s-1
-  dimensions = (horizontal_dimension,vertical_layer_dimension)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = out


### PR DESCRIPTION
This PR introduces an optional closure assumption to the Arakawa-Schubert cloud work function in saSAS cumulus convection, in where the mass-flux at cloud base is described as the product between updraft area fraction and updraft velocity. The updraft area fraction is given by a prognostic moisture budget equation. 

The update is not aimed for UFS coupled prototype 8, but is an option to be explored beyond P8. 

In addition to updates in the ccpp/physics submodule, new field_table, and namelist parameters are added in ufs-weather-model. 

Issue: https://github.com/NCAR/ccpp-physics/issues/890
