### PR TITLE
Addition of total flux calculation for wet deposition in Thompson

### DIFF
--- a/physics/mp_thompson.F90
+++ b/physics/mp_thompson.F90
@@ -300,7 +300,7 @@ module mp_thompson
                               con_eps, convert_dry_rho,            &
                               spechum, qc, qr, qi, qs, qg, ni, nr, &
                               is_aerosol_aware, nc, nwfa, nifa,    &
-                              nwfa2d, nifa2d, aero_ind_fdb,        &
+                              nwfa2d, nifa2d,                      &
                               tgrs, prsl, phii, omega,             &
                               sedi_semi, decfl, dtp, dt_inner,     & 
                               first_time_step, istep, nsteps,      &
@@ -308,9 +308,8 @@ module mp_thompson
                               refl_10cm, reset_dBZ, do_radar_ref,  &
                               mpicomm, mpirank, mpiroot, blkno,    &
                               ext_diag, diag3d, reset_diag3d,      &
-                              spp_wts_mp, spp_mp, n_var_spp,       &
-                              spp_prt_list, spp_var_list,          &
-                              spp_stddev_cutoff,                   &
+                              spp_wts_mp, spp_mp,                  &
+                              pfi_lsan, pfl_lsan,                  &
                               errmsg, errflg)
 
          implicit none
@@ -341,7 +340,6 @@ module mp_thompson
          real(kind_phys), optional, intent(inout) :: nifa(:,:)
          real(kind_phys), optional, intent(in   ) :: nwfa2d(:)
          real(kind_phys), optional, intent(in   ) :: nifa2d(:)
-         logical,         optional, intent(in   ) :: aero_ind_fdb
          ! State variables and timestep information
          real(kind_phys),           intent(inout) :: tgrs(:,:)
          real(kind_phys),           intent(in   ) :: prsl(:,:)
@@ -379,11 +377,8 @@ module mp_thompson
          
          ! SPP
          integer,                   intent(in) :: spp_mp
-         integer,                   intent(in) :: n_var_spp
          real(kind_phys),           intent(in) :: spp_wts_mp(:,:)
-         real(kind_phys),           intent(in) :: spp_prt_list(:)
-         character(len=3),          intent(in) :: spp_var_list(:)
-         real(kind_phys),           intent(in) :: spp_stddev_cutoff(:)
+         real(kind=kind_phys), intent(inout), dimension(:,:) :: pfi_lsan, pfl_lsan
 
          ! Local variables
 
@@ -589,6 +584,10 @@ module mp_thompson
          kde = nlev
          kme = nlev
          kte = nlev
+         if (reset_diag3d) then
+           pfi_lsan = 0.0
+           pfl_lsan = 0.0
+         end if
 
          ! Set pointers for extended diagnostics
          set_extended_diagnostic_pointers: if (ext_diag) then
@@ -641,7 +640,6 @@ module mp_thompson
          if (is_aerosol_aware) then
             call mp_gt_driver(qv=qv, qc=qc, qr=qr, qi=qi, qs=qs, qg=qg, ni=ni, nr=nr,        &
                               nc=nc, nwfa=nwfa, nifa=nifa, nwfa2d=nwfa2d, nifa2d=nifa2d,     &
-                              aero_ind_fdb=aero_ind_fdb,                                     &
                               tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtstep, dt_inner=dt_inner,  &
                               sedi_semi=sedi_semi, decfl=decfl,                              &
                               rainnc=rain_mp, rainncv=delta_rain_mp,                         &
@@ -652,9 +650,7 @@ module mp_thompson
                               diagflag=diagflag, do_radar_ref=do_radar_ref_mp,               &
                               has_reqc=has_reqc, has_reqi=has_reqi, has_reqs=has_reqs,       &
                               rand_perturb_on=spp_mp_opt, kme_stoch=kme_stoch,               &
-                              rand_pert=spp_wts_mp, spp_var_list=spp_var_list,               &
-                              spp_prt_list=spp_prt_list, n_var_spp=n_var_spp,                &
-                              spp_stddev_cutoff=spp_stddev_cutoff,                           &
+                              rand_pert=spp_wts_mp,                                          &
                               ids=ids, ide=ide, jds=jds, jde=jde, kds=kds, kde=kde,          &
                               ims=ims, ime=ime, jms=jms, jme=jme, kms=kms, kme=kme,          &
                               its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte,          &
@@ -678,7 +674,7 @@ module mp_thompson
                               tprv_rev=tprv_rev, tten3=tten3,                                &
                               qvten3=qvten3, qrten3=qrten3, qsten3=qsten3, qgten3=qgten3,    &
                               qiten3=qiten3, niten3=niten3, nrten3=nrten3, ncten3=ncten3,    &
-                              qcten3=qcten3)
+                              qcten3=qcten3,  pfi_lsan=pfi_lsan, pfl_lsan=pfl_lsan)
          else
             call mp_gt_driver(qv=qv, qc=qc, qr=qr, qi=qi, qs=qs, qg=qg, ni=ni, nr=nr,        &
                               tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtstep, dt_inner=dt_inner,  &
@@ -691,9 +687,7 @@ module mp_thompson
                               diagflag=diagflag, do_radar_ref=do_radar_ref_mp,               &
                               has_reqc=has_reqc, has_reqi=has_reqi, has_reqs=has_reqs,       &
                               rand_perturb_on=spp_mp_opt, kme_stoch=kme_stoch,               &
-                              rand_pert=spp_wts_mp, spp_var_list=spp_var_list,               &
-                              spp_prt_list=spp_prt_list, n_var_spp=n_var_spp,                &
-                              spp_stddev_cutoff=spp_stddev_cutoff,                           &
+                              rand_pert=spp_wts_mp,                                          &
                               ids=ids, ide=ide, jds=jds, jde=jde, kds=kds, kde=kde,          &
                               ims=ims, ime=ime, jms=jms, jme=jme, kms=kms, kme=kme,          &
                               its=its, ite=ite, jts=jts, jte=jte, kts=kts, kte=kte,          &
@@ -717,7 +711,7 @@ module mp_thompson
                               tprv_rev=tprv_rev, tten3=tten3,                                &
                               qvten3=qvten3, qrten3=qrten3, qsten3=qsten3, qgten3=qgten3,    &
                               qiten3=qiten3, niten3=niten3, nrten3=nrten3, ncten3=ncten3,    &
-                              qcten3=qcten3)
+                              qcten3=qcten3, pfi_lsan=pfi_lsan, pfl_lsan=pfl_lsan)
          end if
          if (errflg/=0) return
 

--- a/physics/mp_thompson.meta
+++ b/physics/mp_thompson.meta
@@ -435,13 +435,6 @@
   type = real
   kind = kind_phys
   intent = in
-[aero_ind_fdb]
-  standard_name = do_smoke_aerosol_indirect_feedback
-  long_name = flag for wfa ifa emission indirect feedback
-  units = flag
-  dimensions = ()
-  type = logical
-  intent = in
 [tgrs]
   standard_name = air_temperature_of_new_state
   long_name = model layer mean temperature
@@ -651,6 +644,7 @@
   units = 1
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
+  kind = kind_phys
   intent = in
 [spp_mp]
   standard_name = control_for_microphysics_spp_perturbations
@@ -659,37 +653,22 @@
   dimensions = ()
   type = integer
   intent = in
-[n_var_spp]
-  standard_name = number_of_perturbed_spp_schemes
-  long_name = number of perturbed spp schemes
-  units = count
-  dimensions = ()
-  type = integer
-  intent = in
-[spp_prt_list]
-  standard_name = magnitude_of_spp_perturbations
-  long_name = magnitude of spp perturbations
-  units = 1
-  dimensions = (number_of_perturbed_spp_schemes)
+[pfi_lsan]
+  standard_name = ice_flux_due_to_large_scale_precipitation
+  long_name = instantaneous 3D flux of ice from nonconvective precipitation
+  units = kg m-2 s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  intent = in
-[spp_stddev_cutoff]
-  standard_name = magnitude_of_spp_standard_deviation_cutoff
-  long_name = magnitude of spp standard deviation cutoff
-  units = 1
-  dimensions = (number_of_perturbed_spp_schemes)
+  intent = inout
+[pfl_lsan]
+  standard_name = liquid_flux_due_to_large_scale_precipitation
+  long_name = instantaneous 3D flux of liquid water from nonconvective precipitation
+  units = kg m-2 s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  intent = in
-[spp_var_list]
-  standard_name = perturbed_spp_schemes
-  long_name = perturbed spp schemes
-  units = none
-  dimensions = (number_of_perturbed_spp_schemes)
-  type = character
-  kind = len=3
-  intent = in
+  intent = inout
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP

--- a/physics/mp_thompson_pre.F90
+++ b/physics/mp_thompson_pre.F90
@@ -41,7 +41,6 @@ module mp_thompson_pre
 
          ! Save current air temperature for tendency limiters in mp_thompson_post
          tgrs_save = tgrs
-
       end subroutine mp_thompson_pre_run
 
       subroutine mp_thompson_pre_finalize()


### PR DESCRIPTION
 When switching to to Thompson in P8b with the coupled aerosols the values were not calculated by default and therefore zeros were passed to the GOCART  model through the NUOPC layer causing no large scale wet deposition. This PR adds back in the capability that was added to the GFDL MP for the coupled GOCART model for the calculation of the large scale wet deposition. Here we use the instantaneous tendency to calculate the flux. This has no impact on the meteorology and only adds in the needed variables for the GOCART model. 

For comparison see here: https://docs.google.com/presentation/d/1DzPGs85respsvhLe64rZm3I8V4MxM0q3/edit?usp=sharing&ouid=111407383710090576995&rtpof=true&sd=true

Particularly look at the v7 (this fix) and in comparison with the GFDL MP.  They should not be identical because of different model physics but it is in the right ballpark. 

@zhanglikate @yangfanglin @AnningCheng-NOAA 