### PR TITLE
Fix RAP (Grell Freitas) decomp b4b issues

### DIFF
--- a/physics/cu_gf_driver.F90
+++ b/physics/cu_gf_driver.F90
@@ -7,7 +7,7 @@ module cu_gf_driver
    ! DH* TODO: replace constants with arguments to cu_gf_driver_run
    !use physcons  , g => con_g, cp => con_cp, xlv => con_hvap, r_v => con_rv
    use machine   , only: kind_phys
-   use cu_gf_deep, only: cu_gf_deep_run,neg_check,autoconv,aeroevap,fct1d3
+   use cu_gf_deep, only: cu_gf_deep_run,neg_check,fct1d3
    use cu_gf_sh  , only: cu_gf_sh_run
 
    implicit none


### PR DESCRIPTION
Bug fixes in `physics/cu_gf_deep.F90` and `physics/cu_gf_driver.F90` for bit-for-bit identical results with GF when changing the MPI decomposition. Instead of using the `pefc` value of last column (`pefc` was a scalar), which is incorrect, turn `pefc` into a vector of length `horizontal_loop_extent` and use the correct value in GF deep convection.

Minor formatting cleanup in removal of unused symbols/code.

Associated PRs:

https://github.com/NOAA-EMC/fv3atm/pull/543
https://github.com/ufs-community/ufs-weather-model/pull/1243

For regression testing, see https://github.com/ufs-community/ufs-weather-model/pull/1243
