### PR TITLE
Removed references to rrtmg_lw_init and rrtmg_sw_init

### DIFF
--- a/physics/radlw_main.F90
+++ b/physics/radlw_main.F90
@@ -383,7 +383,7 @@
 
 !  ---  public accessable subprograms
 
-      public rrtmg_lw_init, rrtmg_lw_run, rrtmg_lw_finalize, rlwinit
+      public rrtmg_lw_run, rrtmg_lw_finalize, rlwinit
 
 
 ! ================

--- a/physics/radsw_main.F90
+++ b/physics/radsw_main.F90
@@ -404,7 +404,7 @@
 
 !  ---  public accessable subprograms
 
-      public rrtmg_sw_init, rrtmg_sw_run, rrtmg_sw_finalize, rswinit
+      public rrtmg_sw_run, rrtmg_sw_finalize, rswinit
 
 ! =================
       contains


### PR DESCRIPTION
Removed undefined references for use with ufs-weather-model release/public-v3 branch used by SRW release/public-v2.

Fixes issue #938 