### PR TITLE
update w3nco with w3emc 2.9.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,7 @@ set_target_properties(ccpp_physics PROPERTIES VERSION ${PROJECT_VERSION}
 target_include_directories(ccpp_physics PUBLIC
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
-target_link_libraries(ccpp_physics PUBLIC w3nco::w3nco_d NetCDF::NetCDF_Fortran)
+target_link_libraries(ccpp_physics PUBLIC w3emc::w3emc_d NetCDF::NetCDF_Fortran)
 
 # Define where to install the library
 install(TARGETS ccpp_physics


### PR DESCRIPTION
w3nco has been merged with w3emc. w3emc/2.9.2 contains identical code as w3nco with the exception of gblevents.
The ufs wm and its subcomponents will be updated to use w3emc/2.9.2.

Related PRs:
https://github.com/ufs-community/ufs-weather-model/pull/1328
https://github.com/NOAA-EMC/fv3atm/pull/561