### PR TITLE
Fixed a bug related to sensible/latent heat fluxes for AQM coupling (Issue#945)

### DIFF
--- a/physics/GFS_PBL_generic_post.F90
+++ b/physics/GFS_PBL_generic_post.F90
@@ -369,13 +369,8 @@
         do i=1,im
           if (oceanfrac(i) > zero) then      ! Ocean only, NO LAKES
             if ( .not. wet(i)) then ! no open water
-              if (kdt > 1) then              !use results from CICE
-                dtsfci_cpl(i) = dtsfc_cice(i)
-                dqsfci_cpl(i) = dqsfc_cice(i)
-              else                           !use PBL fluxes when CICE fluxes is unavailable
-                dtsfci_cpl(i) = dtsfc1(i)*hffac(i)
-                dqsfci_cpl(i) = dqsfc1(i)
-              end if
+              dtsfci_cpl(i) = dtsfc1(i)*hffac(i)
+              dqsfci_cpl(i) = dqsfc1(i)
             elseif (icy(i) .or. dry(i)) then ! use stress_ocean from sfc_diff for opw component at mixed point
               rho = prsl(i,1) / (rd*t1(i)*(one+fvirt*max(q1(i), qmin)))
               dtsfci_cpl(i) = cp   * rho * hflx_wat(i) ! sensible heat flux over open ocean


### PR DESCRIPTION
A bug is fixed which is described in Issue#[945](https://github.com/NCAR/ccpp-physics/issues/945). 
Currently, this PR only fixed the bug that caused model crashes due to the unallocated variables dtsfc_cice and dqsfc_cice which are only allocated when cplflx=.true. in GFS_typedefs.F90. 
There are potential other issues. For instance, when (cplaqm .and. .not.cplflx) is ture, dtsfci_cpl and dqsfci_cpl are only assigned values over ocean (e.g., oceanfrac > 0). 