### PR TITLE
Miscellaneous Bugfixes from NRL

### DIFF
--- a/physics/GFS_rad_time_vary.fv3.F90
+++ b/physics/GFS_rad_time_vary.fv3.F90
@@ -16,7 +16,7 @@
 !> \section arg_table_GFS_rad_time_vary_timestep_init Argument Table
 !! \htmlinclude GFS_rad_time_vary_timestep_init.html
 !!
-      subroutine GFS_rad_time_vary_timestep_init (                                     &
+      subroutine GFS_rad_time_vary_timestep_init (lrseeds, rseeds,                     &
               lslwr, lsswr, isubc_lw, isubc_sw, icsdsw, icsdlw, cnx, cny, isc, jsc,    &
               imap, jmap, sec, kdt, imp_physics, imp_physics_zhao_carr, ps_2delt,      &
               ps_1delt, t_2delt, t_1delt, qv_2delt, qv_1delt, t, qv, ps, errmsg, errflg)
@@ -29,6 +29,8 @@
          implicit none
 
          ! Interface variables
+         logical,                intent(in)    :: lrseeds
+         integer,                intent(in)    :: rseeds(:,:)
          integer,                intent(in)    :: isubc_lw, isubc_sw, cnx, cny, isc, jsc, kdt
          integer,                intent(in)    :: imp_physics, imp_physics_zhao_carr
          logical,                intent(in)    :: lslwr, lsswr
@@ -47,7 +49,7 @@
 
          ! Local variables
          type (random_stat) :: stat
-         integer :: ix, j, i, nblks, ipseed
+         integer :: ix, j, i, ipseed
          integer :: numrdm(cnx*cny*2)
 
          ! Initialize CCPP error handling variables
@@ -60,18 +62,25 @@
 
            !--- set up random seed index in a reproducible way for entire cubed-sphere face (lat-lon grid)
            if ((isubc_lw==2) .or. (isubc_sw==2)) then
-             ipseed = mod(nint(con_100*sqrt(sec)), ipsdlim) + 1 + ipsd0
-             call random_setseed (ipseed, stat)
-             call random_index (ipsdlim, numrdm, stat)
+             !NRL If random seeds supplied by NEPTUNE
+             if(lrseeds) then
+               do ix=1,size(jmap)
+                 icsdsw(ix) = rseeds(ix,1)
+                 icsdlw(ix) = rseeds(ix,2)
+               enddo
+             else
+               ipseed = mod(nint(con_100*sqrt(sec)), ipsdlim) + 1 + ipsd0
+               call random_setseed (ipseed, stat)
+               call random_index (ipsdlim, numrdm, stat)
 
-             do ix=1,size(jmap)
-               j = jmap(ix)
-               i = imap(ix)
-               !--- for testing purposes, replace numrdm with '100'
-               icsdsw(ix) = numrdm(i+isc-1 + (j+jsc-2)*cnx)
-               icsdlw(ix) = numrdm(i+isc-1 + (j+jsc-2)*cnx + cnx*cny)
-             enddo
-
+               do ix=1,size(jmap)
+                 j = jmap(ix)
+                 i = imap(ix)
+                 !--- for testing purposes, replace numrdm with '100'
+                 icsdsw(ix) = numrdm(i+isc-1 + (j+jsc-2)*cnx)
+                 icsdlw(ix) = numrdm(i+isc-1 + (j+jsc-2)*cnx + cnx*cny)
+               enddo
+             end if !lrseeds
            endif  ! isubc_lw and isubc_sw
 
            if (imp_physics == imp_physics_zhao_carr) then

--- a/physics/GFS_rad_time_vary.fv3.meta
+++ b/physics/GFS_rad_time_vary.fv3.meta
@@ -7,6 +7,20 @@
 [ccpp-arg-table]
   name = GFS_rad_time_vary_timestep_init
   type = scheme
+[lrseeds]
+  standard_name = do_host_provided_random_seeds
+  long_name = flag to use host-provided random seeds
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+[rseeds]
+  standard_name = random_number_seeds_from_host
+  long_name = random number seeds from host
+  units = none
+  dimensions = (horizontal_dimension, number_of_host_provided_random_number_streams)
+  type = integer
+  intent = in
 [lslwr]
   standard_name = flag_for_calling_longwave_radiation
   long_name = logical flags for lw radiation calls

--- a/physics/GFS_rad_time_vary.scm.F90
+++ b/physics/GFS_rad_time_vary.scm.F90
@@ -11,11 +11,12 @@
       contains
 
 !>\defgroup mod_GFS_rad_time_vary GFS Radiation Time Update
+!! This module contains code related to GFS radiation setup.
 !> @{
 !> \section arg_table_GFS_rad_time_vary_timestep_init Argument Table
 !! \htmlinclude GFS_rad_time_vary_timestep_init.html
 !!
-      subroutine GFS_rad_time_vary_timestep_init (                                     &
+      subroutine GFS_rad_time_vary_timestep_init (lrseeds, rseeds,                     &
               lslwr, lsswr, isubc_lw, isubc_sw, icsdsw, icsdlw, cnx, cny, isc, jsc,    &
               imap, jmap, sec, kdt, imp_physics, imp_physics_zhao_carr, ps_2delt,      &
               ps_1delt, t_2delt, t_1delt, qv_2delt, qv_1delt, t, qv, ps, errmsg, errflg)
@@ -28,6 +29,8 @@
          implicit none
 
          ! Interface variables
+         logical,                intent(in)    :: lrseeds
+         integer,                intent(in)    :: rseeds(:,:)
          integer,                intent(in)    :: isubc_lw, isubc_sw, cnx, cny, isc, jsc, kdt
          integer,                intent(in)    :: imp_physics, imp_physics_zhao_carr
          logical,                intent(in)    :: lslwr, lsswr
@@ -59,26 +62,33 @@
 
            !--- set up random seed index in a reproducible way for entire cubed-sphere face (lat-lon grid)
            if ((isubc_lw==2) .or. (isubc_sw==2)) then
-             ipseed = mod(nint(con_100*sqrt(sec)), ipsdlim) + 1 + ipsd0
-             call random_setseed (ipseed, stat)
-             call random_index (ipsdlim, numrdm, stat)
+             !NRL If random seeds supplied by NEPTUNE
+             if(lrseeds) then
+               do ix=1,size(jmap)
+                 icsdsw(ix) = rseeds(ix,1)
+                 icsdlw(ix) = rseeds(ix,2)
+               enddo
+             else
+               ipseed = mod(nint(con_100*sqrt(sec)), ipsdlim) + 1 + ipsd0
+               call random_setseed (ipseed, stat)
+               call random_index (ipsdlim, numrdm, stat)
 
-             do ix=1,size(jmap)
-               j = jmap(ix)
-               i = imap(ix)
-               !--- for testing purposes, replace numrdm with '100'
-               icsdsw(ix) = numrdm(i+isc-1 + (j+jsc-2)*cnx)
-               icsdlw(ix) = numrdm(i+isc-1 + (j+jsc-2)*cnx + cnx*cny)
-             enddo
-
+               do ix=1,size(jmap)
+                 j = jmap(ix)
+                 i = imap(ix)
+                 !--- for testing purposes, replace numrdm with '100'
+                 icsdsw(ix) = numrdm(i+isc-1 + (j+jsc-2)*cnx)
+                 icsdlw(ix) = numrdm(i+isc-1 + (j+jsc-2)*cnx + cnx*cny)
+               enddo
+             end if !lrseeds
            endif  ! isubc_lw and isubc_sw
 
            if (imp_physics == imp_physics_zhao_carr) then
              if (kdt == 1) then
                t_2delt  = t
                t_1delt  = t
-               qv_2delt = max(qmin,qv)
-               qv_1delt = max(qmin,qv)
+               qv_2delt = qv
+               qv_1delt = qv
                ps_2delt = ps
                ps_1delt = ps
              endif

--- a/physics/GFS_rad_time_vary.scm.meta
+++ b/physics/GFS_rad_time_vary.scm.meta
@@ -7,6 +7,20 @@
 [ccpp-arg-table]
   name = GFS_rad_time_vary_timestep_init
   type = scheme
+[lrseeds]
+  standard_name = do_host_provided_random_seeds
+  long_name = flag to use host-provided random seeds
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+[rseeds]
+  standard_name = random_number_seeds_from_host
+  long_name = random number seeds from host
+  units = none
+  dimensions = (horizontal_dimension, number_of_host_provided_random_number_streams)
+  type = integer
+  intent = in
 [lslwr]
   standard_name = flag_for_calling_longwave_radiation
   long_name = logical flags for lw radiation calls

--- a/physics/GFS_rrtmg_post.meta
+++ b/physics/GFS_rrtmg_post.meta
@@ -38,7 +38,7 @@
 [ltp]
   standard_name = extra_top_layer
   long_name = extra top layers
-  units = none
+  units = count
   dimensions = ()
   type = integer
   intent = in

--- a/physics/GFS_rrtmg_pre.F90
+++ b/physics/GFS_rrtmg_pre.F90
@@ -17,9 +17,9 @@
 !! \htmlinclude GFS_rrtmg_pre_run.html
 !!    
 !>\section rrtmg_pre_gen General Algorithm
-      subroutine GFS_rrtmg_pre_run (im, levs, lm, lmk, lmp, n_var_lndp,        &
-        imfdeepcnv, imfdeepcnv_gf, me, ncnd, ntrac, num_p3d, npdf3d, ncnvcld3d,&
-        ntqv, ntcw,ntiw, ntlnc, ntinc, ntrnc, ntsnc, ntccn,                    &
+      subroutine GFS_rrtmg_pre_run (im, levs, lm, lmk, lmp, lextop, ltp,       &
+        n_var_lndp, imfdeepcnv, imfdeepcnv_gf, me, ncnd, ntrac, num_p3d,       &
+        npdf3d, ncnvcld3d, ntqv, ntcw,ntiw, ntlnc, ntinc, ntrnc, ntsnc, ntccn, &
         ntrw, ntsw, ntgl, nthl, ntwa, ntoz,                                    &
         ntclamt, nleffr, nieffr, nseffr, lndp_type, kdt,                       &
         ntdu1, ntdu2, ntdu3, ntdu4, ntdu5, ntss1, ntss2,                       &
@@ -50,7 +50,7 @@
 
       use physparam
 
-      use radcons,                   only: itsfc,ltp, lextop, qmin,  &
+      use radcons,                   only: itsfc, qmin,  &
                                            qme5, qme6, epsq, prsmin
       use funcphys,                  only: fpvs
 
@@ -84,8 +84,8 @@
       use physparam,              only : iaermdl
       implicit none
 
-      integer,              intent(in)  :: im, levs, lm, lmk, lmp, n_var_lndp, &
-                                           imfdeepcnv,                         &
+      integer,              intent(in)  :: im, levs, lm, lmk, lmp, ltp,        &
+                                           n_var_lndp, imfdeepcnv,             &
                                            imfdeepcnv_gf, me, ncnd, ntrac,     &
                                            num_p3d, npdf3d, ncnvcld3d, ntqv,   &
                                            ntcw, ntiw, ntlnc, ntinc,           &
@@ -120,8 +120,8 @@
 
       character(len=3), dimension(:), intent(in) :: lndp_var_list
 
-      logical,              intent(in) :: lsswr, lslwr, ltaerosol, lgfdlmprad, &
-                                          uni_cld, effr_in, do_mynnedmf,       &
+      logical,              intent(in) :: lextop, lsswr, lslwr, ltaerosol, lgfdlmprad, &
+                                          uni_cld, effr_in, do_mynnedmf,               &
                                           lmfshal, lmfdeep2, pert_clds
       logical,              intent(in) :: aero_dir_fdb
       real(kind=kind_phys), dimension(:,:), intent(in) :: smoke_ext, dust_ext
@@ -346,7 +346,9 @@
           plyr(i,k1)    = prsl(i,k2)    * 0.01   ! pa to mb (hpa)
           tlyr(i,k1)    = tgrs(i,k2)
           prslk1(i,k1)  = prslk(i,k2)
-
+          rho(i,k1)     = prsl(i,k2)/(con_rd*tlyr(i,k1))
+          orho(i,k1)    = 1.0/rho(i,k1)
+          
 !> - Compute relative humidity.
           es  = min( prsl(i,k2),  fpvs( tgrs(i,k2) ) )  ! fpvs and prsl in pa
           qs  = max( QMIN, con_eps * es / (prsl(i,k2) + epsm1*es) )
@@ -402,6 +404,8 @@
           plyr(i,lyb)   = 0.5 * plvl(i,lla)
           tlyr(i,lyb)   = tlyr(i,lya)
           prslk1(i,lyb) = (plyr(i,lyb)*0.001) ** rocp ! plyr in hPa
+          rho(i,lyb)    = plyr(i,lyb) *100.0/(con_rd*tlyr(i,lyb))
+          orho(i,lyb)   = 1.0/rho(i,lyb)
           rhly(i,lyb)   = rhly(i,lya)
           qstl(i,lyb)   = qstl(i,lya)
         enddo

--- a/physics/GFS_rrtmg_pre.meta
+++ b/physics/GFS_rrtmg_pre.meta
@@ -44,6 +44,20 @@
   dimensions = ()
   type = integer
   intent = in
+[lextop]
+  standard_name = do_extra_top_layer_for_radiation
+  long_name = use an extra top layer for radiation
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+[ltp]
+  standard_name = extra_top_layer
+  long_name = extra top layer for radiation
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
 [n_var_lndp]
   standard_name = number_of_perturbed_land_surface_variables
   long_name = number of land surface variables perturbed

--- a/physics/GFS_rrtmg_setup.F90
+++ b/physics/GFS_rrtmg_setup.F90
@@ -13,8 +13,6 @@ module GFS_rrtmg_setup
    &             iswcliq,                                             &
    &             kind_phys
 
-   use radcons, only: ltp, lextop
-
    implicit none
 
    public GFS_rrtmg_setup_init, GFS_rrtmg_setup_timestep_init, GFS_rrtmg_setup_finalize
@@ -50,7 +48,7 @@ module GFS_rrtmg_setup
           icliq_sw, crick_proof, ccnorm,                      &
           imp_physics,                                        &
           norad_precip, idate, iflip,                         &
-          do_RRTMGP, me, errmsg, errflg)
+          do_RRTMGP, me, ltp, lextop, errmsg, errflg)
 ! =================   subprogram documentation block   ================ !
 !                                                                       !
 ! subprogram:   GFS_rrtmg_setup_init - a subprogram to initialize radiation !
@@ -141,6 +139,8 @@ module GFS_rrtmg_setup
 !                     =0: index from toa to surface                     !
 !                     =1: index from surface to toa                     !
 !   me               : print control flag                               !
+!   ltp              : number of radiation extra top layers             !
+!   lextop           : control flag to denote extra top layers are used !
 !                                                                       !
 !  subroutines called: radinit                                          !
 !                                                                       !
@@ -171,6 +171,8 @@ module GFS_rrtmg_setup
       integer, intent(in) :: iflip
       logical, intent(in) :: do_RRTMGP
       integer, intent(in) :: me
+      integer, intent(in) :: ltp
+      logical, intent(in) :: lextop
       character(len=*), intent(out) :: errmsg
       integer,          intent(out) :: errflg
 
@@ -243,7 +245,7 @@ module GFS_rrtmg_setup
 
       call radinit                                                      &
 !  ---  inputs:
-     &     ( si, levr, imp_physics, me )
+     &     ( si, levr, imp_physics, me, ltp, lextop )
 !  ---  outputs:
 !          ( none )
 
@@ -324,7 +326,7 @@ module GFS_rrtmg_setup
 ! Private functions
 
 
-   subroutine radinit( si, NLAY, imp_physics, me )
+   subroutine radinit( si, NLAY, imp_physics, me, ltp, lextop )
 !...................................
 
 !  ---  inputs:
@@ -437,7 +439,8 @@ module GFS_rrtmg_setup
       implicit none
 
 !  ---  inputs:
-      integer, intent(in) :: NLAY, me, imp_physics 
+      integer, intent(in) :: NLAY, me, imp_physics, ltp
+      logical, intent(in) :: lextop 
 
       real (kind=kind_phys), intent(in) :: si(:)
 

--- a/physics/GFS_rrtmg_setup.meta
+++ b/physics/GFS_rrtmg_setup.meta
@@ -163,6 +163,20 @@
   dimensions = ()
   type = integer
   intent = in
+[ltp]
+  standard_name = extra_top_layer
+  long_name = extra top layer for radiation
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
+[lextop]
+  standard_name = do_extra_top_layer_for_radiation
+  long_name = use an extra top layer for radiation
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP

--- a/physics/cu_gf_deep.F90
+++ b/physics/cu_gf_deep.F90
@@ -2908,12 +2908,12 @@ contains
 !$acc declare copyin(p,t,q)
      real(kind=kind_phys),    dimension (its:ite,kts:kte)                &
         ,intent (out  )                   ::             &
-        he,hes,qes
-!$acc declare copyout(he,hes,qes)
+        hes,qes
+!$acc declare copyout(hes,qes)
      real(kind=kind_phys),    dimension (its:ite,kts:kte)                &
         ,intent (inout)                   ::             &
-        z
-!$acc declare copy(z)
+        he,z
+!$acc declare copy(he,z)
      real(kind=kind_phys),    dimension (its:ite)                        &
         ,intent (in   )                   ::             &
         psur,z1

--- a/physics/h2ophys.f
+++ b/physics/h2ophys.f
@@ -122,7 +122,7 @@
           enddo
         endif
         do i=1,im
-          if (prsl(i,l) < prsmax) then
+          if (prsl(i,l) < prsmax .and. pltc(i,2) /= 0.0) then
             h2oib(i)  = h2o(i,l)            ! no filling
             tem       = 1.0 / pltc(i,2)     ! 1/teff
             h2o(i,l)  = (h2oib(i) + (pltc(i,1)+pltc(i,3)*tem)*dt)

--- a/physics/iounitdef.f
+++ b/physics/iounitdef.f
@@ -57,7 +57,7 @@
       integer, parameter :: NISIGI2 = 12
       integer, parameter :: NISFCI  = 14
       integer, parameter :: NICO2TR = 15
-      integer, parameter :: NICO2CN = 102
+      integer, parameter :: NICO2CN = 112 ! CCE (Cray) forbids 100-102 20211112 JM
       integer, parameter :: NIMTNVR = 24
       integer, parameter :: NIDTBTH = 27
       integer, parameter :: NIO3PRD = 28
@@ -66,9 +66,9 @@
       integer, parameter :: NICLTUN = 43
       integer, parameter :: NIO3CLM = 48
       integer, parameter :: NIMICPH = 1
-      integer, parameter :: NISFCYC = 101
-      integer, parameter :: NIAERCM = 102
-      integer, parameter :: NIRADSF = 102
+      integer, parameter :: NISFCYC = 111 ! CCE (Cray) forbids 100-102 20210701 JM
+      integer, parameter :: NIAERCM = 112 ! CCE (Cray) forbids 100-102 20210701 JM
+      integer, parameter :: NIRADSF = 112 ! CCE (Cray) forbids 100-102 20210701 JM
 
 !  --- ... output units
 

--- a/physics/radcons.f90
+++ b/physics/radcons.f90
@@ -47,16 +47,6 @@
 !! control parameter ioznflg=0)
       logical :: loz1st =.true.
 
-! DH* THIS MUST GO BUT NEED IT RIGHT NOW TO DEFINE LEXTOP
-!> optional extra top layer on top of low ceiling models
-!!\n LTP=0: no extra top layer
-      integer, parameter :: LTP = 0   ! no extra top layer
-!     integer, parameter :: LTP = 1   ! add an extra top layer
-! *DH
-
-!> control flag for extra top layer
-      logical, parameter :: lextop = (LTP > 0)
-
 !----------------------------
 ! Module variable definitions
 !----------------------------

--- a/physics/radiation_astronomy.f
+++ b/physics/radiation_astronomy.f
@@ -887,7 +887,9 @@
 
       do i = 1, IM
         coszdg(i) = coszen(i) * rstp
-        if (istsun(i) > 0) coszen(i) = coszen(i) / istsun(i)
+        if (istsun(i) > 0 .and. coszen(i) /= 0.0_kind_phys) then
+          coszen(i) = coszen(i) / istsun(i)
+        endif 
       enddo
 !
       return

--- a/physics/rrtmg_lw_post.meta
+++ b/physics/rrtmg_lw_post.meta
@@ -24,7 +24,7 @@
 [ltp]
   standard_name = extra_top_layer
   long_name = extra top layers
-  units = none
+  units = count
   dimensions = ()
   type = integer
   intent = in

--- a/physics/rrtmg_sw_post.meta
+++ b/physics/rrtmg_sw_post.meta
@@ -31,7 +31,7 @@
 [ltp]
   standard_name = extra_top_layer
   long_name = extra top layers
-  units = none
+  units = count
   dimensions = ()
   type = integer
   intent = in

--- a/physics/samfdeepcnv.f
+++ b/physics/samfdeepcnv.f
@@ -1637,15 +1637,11 @@ c
 !             aa2(i) = aa2(i) +
 !!   &                 dz1 * eta(i,k) * grav * fv *
 !    &                 dz1 * grav * fv *
-!    &                 max(val,(qeso(i,k) - qo(i,k)))
-              if(aa2(i) < 0.) then
-                ktcon1(i) = k
-                flg(i) = .false.
-              endif
-!NRL MNM: Limit overshooting not to be deeper than the actual cloud              
-              tem  = zi(i,ktcon(i))-zi(i,kbcon(i))
-              tem1 = zi(i,ktcon1(i))-zi(i,ktcon(i))
-              if(tem1.ge.tem) then
+!    &                 max(val,(qeso(i,k) - qo(i,k)))        
+!NRL MNM: Limit overshooting not to be deeper than half the actual cloud              
+              tem  = 0.5 * (zi(i,ktcon(i))-zi(i,kbcon(i)))
+              tem1 = zi(i,k)-zi(i,ktcon(i))
+              if(aa2(i) < 0. .or. tem1 >= tem) then
                 ktcon1(i) = k
                 flg(i) = .false.
               endif

--- a/physics/samfdeepcnv.f
+++ b/physics/samfdeepcnv.f
@@ -1642,6 +1642,13 @@ c
                 ktcon1(i) = k
                 flg(i) = .false.
               endif
+!NRL MNM: Limit overshooting not to be deeper than the actual cloud              
+              tem  = zi(i,ktcon(i))-zi(i,kbcon(i))
+              tem1 = zi(i,ktcon1(i))-zi(i,ktcon(i))
+              if(tem1.ge.tem) then
+                ktcon1(i) = k
+                flg(i) = .false.
+              endif
             endif
           endif
         enddo
@@ -3049,6 +3056,9 @@ c
               dellat = (dellah(i,k) - hvap * dellaq(i,k)) / cp
               t1(i,k) = t1(i,k) + tem2 * dellat
               q1(i,k) = q1(i,k) + tem2 * dellaq(i,k)
+! NRL MNM: Limit q1
+              val = epsilon(1.0_kind_phys)
+              q1(i,k) = max(q1(i,k), val  )
 !             tem = tem2 / rcs(i)
 !             u1(i,k) = u1(i,k) + dellau(i,k) * tem
 !             v1(i,k) = v1(i,k) + dellav(i,k) * tem

--- a/physics/samfdeepcnv.f
+++ b/physics/samfdeepcnv.f
@@ -1618,7 +1618,7 @@ c
 c
       do i = 1, im
         flg(i) = cnvflg(i)
-        ktcon1(i) = kmax(i)
+        ktcon1(i) = ktcon(i)
       enddo
       do k = 2, km1
         do i = 1, im
@@ -3056,9 +3056,6 @@ c
               dellat = (dellah(i,k) - hvap * dellaq(i,k)) / cp
               t1(i,k) = t1(i,k) + tem2 * dellat
               q1(i,k) = q1(i,k) + tem2 * dellaq(i,k)
-! NRL MNM: Limit q1
-              val = epsilon(1.0_kind_phys)
-              q1(i,k) = max(q1(i,k), val  )
 !             tem = tem2 / rcs(i)
 !             u1(i,k) = u1(i,k) + dellau(i,k) * tem
 !             v1(i,k) = v1(i,k) + dellav(i,k) * tem

--- a/physics/sascnvn.F
+++ b/physics/sascnvn.F
@@ -1000,18 +1000,14 @@
               aa2(i) = aa2(i) +
      &                 dz1 * (g / (cp * to(i,k)))
      &                 * dbyo(i,k) / (1. + gamma)
-     &                 * rfact
-              if(aa2(i).lt.0.) then
-                ktcon1(i) = k
-                flg(i) = .false.
-              endif
+     &                 * rfact            
 !NRL MNM: Limit overshooting not to be deeper than the actual cloud
-              tem  = zi(i,ktcon(i))-zi(i,kbcon(i))
-              tem1 = zi(i,ktcon1(i))-zi(i,ktcon(i))
-              if(tem1.ge.tem) then
+              tem  = 0.5 * (zi(i,ktcon(i))-zi(i,kbcon(i)))
+              tem1 = zi(i,k)-zi(i,ktcon(i))
+              if(aa2(i) < 0. .or. tem1 >= tem) then
                 ktcon1(i) = k
                 flg(i) = .false.
-              endif
+              endif        
             endif
           endif
         enddo

--- a/physics/sascnvn.F
+++ b/physics/sascnvn.F
@@ -1005,6 +1005,13 @@
                 ktcon1(i) = k
                 flg(i) = .false.
               endif
+!NRL MNM: Limit overshooting not to be deeper than the actual cloud
+              tem  = zi(i,ktcon(i))-zi(i,kbcon(i))
+              tem1 = zi(i,ktcon1(i))-zi(i,ktcon(i))
+              if(tem1.ge.tem) then
+                ktcon1(i) = k
+                flg(i) = .false.
+              endif
             endif
           endif
         enddo
@@ -1871,6 +1878,9 @@
               dellat = (dellah(i,k) - hvap * dellaq(i,k)) / cp
               t1(i,k) = t1(i,k) + dellat * xmb(i) * dt2
               q1(i,k) = q1(i,k) + dellaq(i,k) * xmb(i) * dt2
+! NRL MNM: Limit q1
+              val = epsilon(1.0_kind_phys)
+              q1(i,k) = max(q1(i,k), val  )
 !             tem = 1./rcs(i)
 !             u1(i,k) = u1(i,k) + dellau(i,k) * xmb(i) * dt2 * tem
 !             v1(i,k) = v1(i,k) + dellav(i,k) * xmb(i) * dt2 * tem

--- a/physics/sascnvn.F
+++ b/physics/sascnvn.F
@@ -987,7 +987,7 @@
 !
       do i = 1, im
         flg(i) = cnvflg(i)
-        ktcon1(i) = kmax(i) - 1
+        ktcon1(i) = ktcon(i)
       enddo
       do k = 2, km1
         do i = 1, im
@@ -1878,9 +1878,6 @@
               dellat = (dellah(i,k) - hvap * dellaq(i,k)) / cp
               t1(i,k) = t1(i,k) + dellat * xmb(i) * dt2
               q1(i,k) = q1(i,k) + dellaq(i,k) * xmb(i) * dt2
-! NRL MNM: Limit q1
-              val = epsilon(1.0_kind_phys)
-              q1(i,k) = max(q1(i,k), val  )
 !             tem = 1./rcs(i)
 !             u1(i,k) = u1(i,k) + dellau(i,k) * xmb(i) * dt2 * tem
 !             v1(i,k) = v1(i,k) + dellav(i,k) * xmb(i) * dt2 * tem

--- a/physics/sflx.f
+++ b/physics/sflx.f
@@ -906,15 +906,11 @@
         eta = etp
       endif
 
-#ifdef SINGLE_PREC
-      IF (ETP == 0.0) THEN
-        BETA = 0.0
-      ELSE
-        BETA = ETA/ETP
-      ENDIF
-#else
-      beta = eta / etp
-#endif
+      if (etp == 0.0) then
+        beta = 0.0
+      else
+        beta = eta/etp
+      endif
 
 !>  - Convert the sign of soil heat flux so that:
 !!   -  ssoil>0: warm the surface  (night time)

--- a/physics/ugwp_driver_v0.F
+++ b/physics/ugwp_driver_v0.F
@@ -1343,7 +1343,7 @@
               else
                 kzw2 = zero
               endif
-              if ( kzw2 > zero ) then
+              if ( kzw2 > zero .and. cdf2 > zero) then
                 v_kzw = sqrt(kzw2)
 !	       
 !linsatdis:  kzw2, kzw3, kdsat, c2f2,  cdf2, cdf1


### PR DESCRIPTION
All of these changes originally came from https://github.com/NCAR/ccpp-physics/pull/772. These changes were split from the single precision work since they were unrelated, but they're still relevant and should be merged since they fix several bugs. @michalakes, @areinecke, and @matusmartini deserve the credit. My work was only to update it to the latest main and test it in FV3/SCM.

The first 4 commits do not change any UFS RT results. They represent the following:

1. variable intent change and division by zero avoidance
2. changes to LUNs to avoid errors with the Cray CCE compiler
3. fix the LTP or extra top radiation layer functionality
4. add capability to use host-provided random number seeds

The last commit introduces a change to SAS-based deep convection schemes to avoid negative qv. Any UFS RTs that use samfdeepcnv or sascnvn will need new baselines if this is merged. The following description is from @matusmartini:

> This was a while back but if I remember correctly, it was to prevent negative QV resulting from overly deep overshooting mostly for relatively shallow updrafts with extremely deep overshoots. This change was before the parameter aafac was reduced from 10% to 5%, which helped but did not eliminate all of the negative values.

> Digging through my notes with examples of updrafts with negative QV concentrations:
Cloud base at 1.4 km above ground, level of neutral buoyancy ~3.5 km, with overshooting top is at 18 km!
More points found with cloud base at ~0.6 km, level of neutral buoyancy ~2.5 km, with overshooting top at ~16 km!

> The reason for the negative QV’s because of the approximations made in SAS:

> First, the moisture content of the rising parcel if it was saturated (qrch) is approximated as the sum of saturated moisture (qeso) and a term that is directly proportional to buoyancy. Generally, overshooting layers are negatively buoyant, and so the sum of the two can < 0 if large buoyancies are present.
Second, the convective overshooting level is estimated as the level where (0.1 * A_ktcon) < 0, where A_ktcon is the cloud work function at the level of neutral buoyancy (ktcon). The 0.1 is a tunable parameter (aafac) independent of the first approximation.

> Moreover, there is no check that would stop this from happening in the overshooting layers. There is only a check on negative cloud mass flux (eta) in imfdeepcnv=2, but it only scans levels below the level of neutral buoyancy. There should strictly be a check for negative qrch also in overshooting layers in both options of imfdeepcnv 1 and 2. After playing around with both options 1 and 2 of SAS convection, I see several tuning knobs that can result in increased number of updrafts with negative qrch (all of them near the overshooting cloud top). The most important tuning parameter is the critical thickness of the calculated convection (cthk), which determines whether the convection is deep enough, otherwise it is inhibited. In option 1, this threshold is set to 150 hPa. In option 2, this threshold is increased to 200 hPa. Doing an experiment with the cthk increased to 200 hPa in option 1, eliminates most of the negatively moist parcels. And vice versa, decreasing cthk to 150 hPa in option 2, introduces a few negatively moist parcels. Similar result can be achieved by tuning the aafac parameter.