### PR TITLE
Add tests for ccpp_prebuild step

### DIFF
--- a/.github/workflows/ci_fv3_ccpp_prebuild.yml
+++ b/.github/workflows/ci_fv3_ccpp_prebuild.yml
@@ -14,6 +14,7 @@ jobs:
 
     - name: Checkout code
       run: |
+        pwd
         git clone https://github.com/NOAA-EMC/fv3atm.git
 
     - name: Initialize submodules

--- a/.github/workflows/ci_fv3_ccpp_prebuild.yml
+++ b/.github/workflows/ci_fv3_ccpp_prebuild.yml
@@ -12,7 +12,9 @@ jobs:
 
     steps:
     - name: Checkout current ccpp-physics code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Store remote-URL for current ccpp-physics code
       run: echo "GIT_REMOTE_URL=`git remote get-url origin`" >> $GITHUB_ENV

--- a/.github/workflows/ci_fv3_ccpp_prebuild.yml
+++ b/.github/workflows/ci_fv3_ccpp_prebuild.yml
@@ -1,4 +1,4 @@
-name: CI test to run FV3 ccpp_prebuild script
+name: CI test to run FV3 ccpp_prebuild step
 
 on: [push, pull_request]
 

--- a/.github/workflows/ci_fv3_ccpp_prebuild.yml
+++ b/.github/workflows/ci_fv3_ccpp_prebuild.yml
@@ -1,0 +1,38 @@
+name: CI test to run FV3 ccpp_prebuild script
+
+on: [push, pull_request]
+
+jobs:
+  build-linux:
+
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+
+    steps:
+
+    - name: Checkout code
+      run: |
+        git clone https://github.com/NOAA-EMC/fv3atm.git
+
+    - name: Initialize submodules
+      run: |
+        cd /home/runner/work/NOAA-EMC/NOAA-EMC/fv3atm
+        git submodule update --init --recursive
+    
+    - name: Set up Python 3.8.5
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.8.5
+
+    - name: Add conda to system path
+      run: |
+        # $CONDA is an environment variable pointing to the root of the miniconda directory
+        echo $CONDA/bin >> $GITHUB_PATH
+
+    - name: Run ccpp_prebuild.py
+      run: |
+        cd /home/runner/work/NOAA-EMC/NOAA-EMC/fv3atm/
+        mkdir -p /home/runner/work/NOAA-EMC/NOAA-EMC/fv3atm/bin/ccpp/physics/physics/
+        ./ccpp/framework/scripts/ccpp_prebuild.py --config ccpp/config/ccpp_prebuild_config.py

--- a/.github/workflows/ci_fv3_ccpp_prebuild.yml
+++ b/.github/workflows/ci_fv3_ccpp_prebuild.yml
@@ -1,6 +1,6 @@
 name: CI test to run FV3 ccpp_prebuild step
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build-linux:
@@ -34,6 +34,7 @@ jobs:
         git submodule update --init --recursive
 
     - name: Update ccpp-physics hash in fv3atm
+      if: github.event.pull_request == false
       run: |
         cd /home/runner/work/ccpp-physics/ccpp-physics/fv3atm/ccpp/physics
         git remote add remote_local $GIT_REMOTE_URL

--- a/.github/workflows/ci_fv3_ccpp_prebuild.yml
+++ b/.github/workflows/ci_fv3_ccpp_prebuild.yml
@@ -34,6 +34,6 @@ jobs:
 
     - name: Run ccpp_prebuild.py
       run: |
-        cd /home/runner/work/NOAA-EMC/NOAA-EMC/fv3atm/
+        cd /home/runner/work/ccpp-physics/ccpp-physics/fv3atm
         mkdir -p /home/runner/work/ccpp-physics/ccpp-physics/fv3atm/bin/ccpp/physics/physics/
         ./ccpp/framework/scripts/ccpp_prebuild.py --config ccpp/config/ccpp_prebuild_config.py

--- a/.github/workflows/ci_fv3_ccpp_prebuild.yml
+++ b/.github/workflows/ci_fv3_ccpp_prebuild.yml
@@ -34,6 +34,7 @@ jobs:
 
     - name: Run ccpp_prebuild.py
       run: |
+        setenv suites_dir /home/runner/work/ccpp-physics/ccpp-physics/fv3atm/ccpp/suites/
         cd /home/runner/work/ccpp-physics/ccpp-physics/fv3atm
         mkdir -p /home/runner/work/ccpp-physics/ccpp-physics/fv3atm/bin/ccpp/physics/physics/
         ./ccpp/framework/scripts/ccpp_prebuild.py --config ccpp/config/ccpp_prebuild_config.py

--- a/.github/workflows/ci_fv3_ccpp_prebuild.yml
+++ b/.github/workflows/ci_fv3_ccpp_prebuild.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Initialize submodules
       run: |
-        cd /home/runner/work/NOAA-EMC/NOAA-EMC/fv3atm
+        cd /home/runner/work/ccpp-physics/ccpp-physics/fv3atm
         git submodule update --init --recursive
     
     - name: Set up Python 3.8.5
@@ -35,5 +35,5 @@ jobs:
     - name: Run ccpp_prebuild.py
       run: |
         cd /home/runner/work/NOAA-EMC/NOAA-EMC/fv3atm/
-        mkdir -p /home/runner/work/NOAA-EMC/NOAA-EMC/fv3atm/bin/ccpp/physics/physics/
+        mkdir -p /home/runner/work/ccpp-physics/ccpp-physics/fv3atm/bin/ccpp/physics/physics/
         ./ccpp/framework/scripts/ccpp_prebuild.py --config ccpp/config/ccpp_prebuild_config.py

--- a/.github/workflows/ci_fv3_ccpp_prebuild.yml
+++ b/.github/workflows/ci_fv3_ccpp_prebuild.yml
@@ -1,6 +1,6 @@
 name: CI test to run FV3 ccpp_prebuild step
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build-linux:

--- a/.github/workflows/ci_fv3_ccpp_prebuild.yml
+++ b/.github/workflows/ci_fv3_ccpp_prebuild.yml
@@ -11,16 +11,32 @@ jobs:
       max-parallel: 5
 
     steps:
+    - name: Checkout current ccpp-physics code
+      uses: actions/checkout@v2
 
-    - name: Checkout code
-      run: |
-        pwd
-        git clone https://github.com/NOAA-EMC/fv3atm.git
+    - name: Store remote-URL for current ccpp-physics code
+      run: echo "GIT_REMOTE_URL=`git remote get-url origin`" >> $GITHUB_ENV
+
+    - name: Store branch name for current ccpp-physics code
+      run: echo "GIT_REMOTE_BRANCH=`git rev-parse --abbrev-ref HEAD`" >> $GITHUB_ENV
+
+    - name: Store hash for HEAD of current ccpp-physics code
+      run: echo "GIT_REMOTE_HASH=`git rev-parse HEAD`" >> $GITHUB_ENV
+
+    - name: Checkout latest fv3atm
+      run: git clone https://github.com/NOAA-EMC/fv3atm.git
 
     - name: Initialize submodules
       run: |
         cd /home/runner/work/ccpp-physics/ccpp-physics/fv3atm
         git submodule update --init --recursive
+
+    - name: Update ccpp-physics hash in fv3atm
+      run: |
+        cd /home/runner/work/ccpp-physics/ccpp-physics/fv3atm/ccpp/physics
+        git remote add remote_local $GIT_REMOTE_URL
+        git fetch remote_local $GIT_REMOTE_BRANCH
+        git checkout remote_local/$GIT_REMOTE_BRANCH
     
     - name: Set up Python 3.8.5
       uses: actions/setup-python@v3

--- a/.github/workflows/ci_fv3_ccpp_prebuild.yml
+++ b/.github/workflows/ci_fv3_ccpp_prebuild.yml
@@ -34,6 +34,6 @@ jobs:
 
     - name: Run ccpp_prebuild.py
       run: |
-        cd /home/runner/work/ccpp-physics/ccpp-physics/fv3atm
+        cd /home/runner/work/ccpp-physics/ccpp-physics/fv3atm/ccpp/
         mkdir -p /home/runner/work/ccpp-physics/ccpp-physics/fv3atm/bin/ccpp/physics/physics/
-        ./ccpp/framework/scripts/ccpp_prebuild.py --config ccpp/config/ccpp_prebuild_config.py
+        ./framework/scripts/ccpp_prebuild.py --config config/ccpp_prebuild_config.py

--- a/.github/workflows/ci_fv3_ccpp_prebuild.yml
+++ b/.github/workflows/ci_fv3_ccpp_prebuild.yml
@@ -34,7 +34,6 @@ jobs:
 
     - name: Run ccpp_prebuild.py
       run: |
-        setenv suites_dir /home/runner/work/ccpp-physics/ccpp-physics/fv3atm/ccpp/suites/
         cd /home/runner/work/ccpp-physics/ccpp-physics/fv3atm
         mkdir -p /home/runner/work/ccpp-physics/ccpp-physics/fv3atm/bin/ccpp/physics/physics/
         ./ccpp/framework/scripts/ccpp_prebuild.py --config ccpp/config/ccpp_prebuild_config.py

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -16,7 +16,7 @@ jobs:
       run: |
         pwd
         git clone https://github.com/NCAR/ccpp-scm.git
-        cd /home/runner/work/ccpp-scm/ccpp-scm/
+        cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/
 
     - name: Initialize submodules
       run: git submodule update --init --recursive

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -35,6 +35,8 @@ jobs:
     - name: Update ccpp-physics hash in ccpp-scm
       run: |
         cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/ccpp/physics
+        echo $GIT_REMOTE_URL
+        echo $GIT_REMOTE_BRANCH
         git remote add remote_local $GIT_REMOTE_URL
         git fetch remote_local $GIT_REMOTE_BRANCH
         git checkout remote_local/$GIT_REMOTE_BRANCH

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -14,6 +14,7 @@ jobs:
 
     - name: Checkout code
       run: |
+        pwd
         git clone https://github.com/NCAR/ccpp-scm.git
         cd /home/runner/work/ccpp-scm/ccpp-scm/
 

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -20,6 +20,7 @@ jobs:
 
     - name: Checkout current ccpp-physics code
       uses: actions/checkout@v2
+      run: echo "GIT_REMOTE=`git remote get-url origin` >> $GIT_REMOTE_URL
 
     - name: Checkout latest ccpp-scm code
       run: |

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Checkout code
       run: |
         git clone https://github.com/NCAR/ccpp-scm.git
-        cd ccpp-scm/
+        cd /home/runner/work/ccpp-scm/ccpp-scm/
 
     - name: Initialize submodules
       run: git submodule update --init --recursive

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -40,15 +40,19 @@ jobs:
     - name: Test GIT_REMOTE_HASH
       run: echo	$GIT_REMOTE_HASH
 
-    - name: Initialize submodules
+    - name: Update ccpp-physics hash in ccpp-scm
       run: |
         cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/ccpp/physics
         git remote add remote_local $GIT_REMOTE_URL
-        git fetch remote_local
+        git fetch remote_local $GIT_REMOTE_BRANCH
         git checkout remote_local/$GIT_REMOTE_BRANCH
+
+    - name: Initialize submodules
+      run: |
         cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm
         git submodule update --init --recursive
         git remote -v
+        git log
     
     - name: Set up Python 3.8.5
       uses: actions/setup-python@v3

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -45,7 +45,7 @@ jobs:
         cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/ccpp/physics
         git remote add remote_local $GIT_REMOTE_NAME
         git fetch $GIT_REMOTE_NAME
-        git checkout $GIT_REMOTE_NAME/$GIT_REMOTE_BRANCH
+        git checkout $GIT_REMOTE_NAME $GIT_REMOTE_BRANCH
         cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm
         git submodule update --init --recursive
         git remote -v

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -2,6 +2,12 @@ name: CI test to run SCM ccpp_prebuild script
 
 on: [push, pull_request]
 
+env:
+  GIT_REMOTE_URL: https://github.com/NCAR/ccpp-physics.git
+  GIT_REMOTE_HASH: 255035269760c1a6560317c400727d962cdc57f0
+  GIT_REMOTE_NAME: origin
+  GIT_REMOTE_BRANCH: main
+
 jobs:
   build-linux:
 
@@ -15,25 +21,16 @@ jobs:
     - name: Checkout current ccpp-physics code
       uses: actions/checkout@v2
 
-    - run: GIT_REMOTE=`git remote get-url origin` && export GIT_REMOTE
-    - run: GIT_REMOTE_HASH=`git rev-parse HEAD` && export GIT_REMOTE_HASH
-    - run: GIT_REMOTE_BRANCH=`git rev-parse --abbrev-ref HEAD` && export GIT_REMOTE_BRANCH
-
     - name: Checkout latest ccpp-scm code
       run: |
         git clone https://github.com/NCAR/ccpp-scm.git
-        cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/ccpp/physics
-        pwd
-        ls
-        git remote 
-        git remote -v
 
     - name: Initialize submodules
       run: |
         cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/ccpp/physics
-        git remote add remote_local $GIT_REMOTE
-        git fetch $GIT_REMOTE
-        git checkout $GIT_REMOTE/$GIT_BRANCH
+        git remote add remote_local $GIT_REMOTE_NAME
+        git fetch $GIT_REMOTE_NAME
+        git checkout $GIT_REMOTE_NAME/$GIT_REMOTE_BRANCH
         cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm
         git submodule update --init --recursive
         git remote -v

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -68,5 +68,6 @@ jobs:
       run: |
         cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/
         git status
+        ls
         mkdir -p /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/scm/bin/ccpp/physics/physics/
         ./ccpp/framework/scripts/ccpp_prebuild.py --config ccpp/config/ccpp_prebuild_config.py

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -31,7 +31,7 @@ jobs:
         ls
         git status
         git remote -v
-        echo $GIT_REMOTE
+        $GIT_REMOTE
 
     - name: Initialize submodules
       run: |

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -12,7 +12,18 @@ jobs:
 
     steps:
 
-    - name: Checkout code
+    - name: Checkout current ccpp-physics code
+      uses: actions/checkout@v2
+      run: |
+        pwd
+        ls
+        cd ccpp-physics
+        pwd
+        ls
+        git status
+        git remote -v
+
+    - name: Checkout latest ccpp-scm code
       run: |
         git clone https://github.com/NCAR/ccpp-scm.git
 

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -44,7 +44,7 @@ jobs:
       run: |
         cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/ccpp/physics
         git remote add remote_local $GIT_REMOTE_NAME
-        git fetch $GIT_REMOTE_NAME
+        git fetch remote_local
         git checkout $GIT_REMOTE_NAME $GIT_REMOTE_BRANCH
         cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm
         git submodule update --init --recursive

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -1,6 +1,6 @@
 name: CI test to run SCM ccpp_prebuild step
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build-linux:
@@ -13,7 +13,7 @@ jobs:
     steps:
 
     - name: Checkout current ccpp-physics code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v2
       with:
         ref: "refs/pull/${{ github.event.number }}/merge"
 

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -13,9 +13,7 @@ jobs:
     steps:
 
     - name: Checkout current ccpp-physics code
-      uses: actions/checkout@v2
-      with:
-        ref: "refs/pull/${{ github.event.number }}/merge"
+      uses: actions/checkout@v3
 
     - name: Store remote-URL for current ccpp-physics code
       run: echo "GIT_REMOTE_URL=`git remote get-url origin`" >> $GITHUB_ENV

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -19,9 +19,6 @@ jobs:
       run: |
         pwd
         ls
-        cd ccpp-physics
-        pwd
-        ls
         git status
         git remote -v
 

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -1,6 +1,6 @@
 name: CI test to run SCM ccpp_prebuild step
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build-linux:

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -1,0 +1,35 @@
+name: CI test to run SCM ccpp_prebuild script
+
+on: [push, pull_request]
+
+jobs:
+  build-linux:
+
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+
+    steps:
+
+    - name: Checkout code
+      run: |
+        git clone https://github.com/NCAR/ccpp-scm.git
+        cd ccpp-scm/
+
+    - name: Initialize submodules
+      run: git submodule update --init --recursive
+    
+    - name: Set up Python 3.8.5
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.8.5
+
+    - name: Add conda to system path
+      run: |
+        # $CONDA is an environment variable pointing to the root of the miniconda directory
+        echo $CONDA/bin >> $GITHUB_PATH
+    - name: Run ccpp_prebuild.py
+      run: |
+        mkdir -p /home/runner/work/ccpp-scm/ccpp-scm/scm/bin/ccpp/physics/physics/
+        ./ccpp/framework/scripts/ccpp_prebuild.py --config ccpp/config/ccpp_prebuild_config.py

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -18,12 +18,6 @@ jobs:
 
     steps:
 
-      env:
-        GIT_REMOTE_URL_local: https://github.com/NCAR/ccpp-physics.git
-        GIT_REMOTE_HASH_local: 255035269760c1a6560317c400727d962cdc57f0
-        GIT_REMOTE_NAME_local: origin
-        GIT_REMOTE_BRANCH_local: main
-
     - name: Checkout current ccpp-physics code
       uses: actions/checkout@v2
 

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -14,6 +14,8 @@ jobs:
 
     - name: Checkout current ccpp-physics code
       uses: actions/checkout@v2
+
+    - name: Update checkout
       run: |
         pwd
         ls

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -14,8 +14,6 @@ jobs:
 
     - name: Checkout current ccpp-physics code
       uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Store remote-URL for current ccpp-physics code
       run: echo "GIT_REMOTE_URL=`git remote get-url origin`" >> $GITHUB_ENV

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -1,4 +1,4 @@
-name: CI test to run SCM ccpp_prebuild script
+name: CI test to run SCM ccpp_prebuild step
 
 on: [push, pull_request]
 

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -14,6 +14,8 @@ jobs:
 
     - name: Checkout current ccpp-physics code
       uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Store remote-URL for current ccpp-physics code
       run: echo "GIT_REMOTE_URL=`git remote get-url origin`" >> $GITHUB_ENV

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -33,9 +33,11 @@ jobs:
     - name: Checkout latest ccpp-scm code
       run: git clone https://github.com/NCAR/ccpp-scm.git
 
-    - name: Test
+    - name: Test GIT_REMOTE_URL
       run: echo $GIT_REMOTE_URL
+    - name: Test GIT_REMOTE_BRANCH
       run: echo $GIT_REMOTE_BRANCH
+    - name: Test GIT_REMOTE_HASH
       run: echo	$GIT_REMOTE_HASH
 
     - name: Initialize submodules

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -30,7 +30,9 @@ jobs:
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory
         echo $CONDA/bin >> $GITHUB_PATH
+
     - name: Run ccpp_prebuild.py
       run: |
-        mkdir -p /home/runner/work/ccpp-scm/ccpp-scm/scm/bin/ccpp/physics/physics/
+        cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/
+        mkdir -p /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/scm/bin/ccpp/physics/physics/
         ./ccpp/framework/scripts/ccpp_prebuild.py --config ccpp/config/ccpp_prebuild_config.py

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -20,6 +20,8 @@ jobs:
 
     - name: Checkout current ccpp-physics code
       uses: actions/checkout@v2
+
+    - name: Get remote-URL for current ccpp-physics code
       run: echo "GIT_REMOTE_URL=`git remote get-url origin` >> $GITHUB_ENV
 
     - name: Checkout latest ccpp-scm code

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -13,7 +13,9 @@ jobs:
     steps:
 
     - name: Checkout current ccpp-physics code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Store remote-URL for current ccpp-physics code
       run: echo "GIT_REMOTE_URL=`git remote get-url origin`" >> $GITHUB_ENV

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -1,4 +1,4 @@
-name: CI test to run SCM ccpp_prebuild script
+B1;95;0cname: CI test to run SCM ccpp_prebuild script
 
 on: [push, pull_request]
 
@@ -15,13 +15,11 @@ jobs:
     - name: Checkout current ccpp-physics code
       uses: actions/checkout@v2
 
-    - name: Update checkout
+    - name: Get repository information from current ccpp-physics code
       run: |
-        pwd
-        ls
-        git status
-        git remote -v
         GIT_REMOTE=`git remote get-url origin` && export GIT_REMOTE
+        GIT_REMOTE_HASH=`git rev-parse HEAD` && export GIT_REMOTE_HASH
+        GIT_REMOTE_BRANCH=`git rev-parse --abbrev-ref HEAD` && export GIT_REMOTE_BRANCH
 
     - name: Checkout latest ccpp-scm code
       run: |
@@ -29,7 +27,7 @@ jobs:
         cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/ccpp/physics
         pwd
         ls
-        git status
+        git remote 
         git remote -v
         $GIT_REMOTE
 

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -43,9 +43,9 @@ jobs:
     - name: Initialize submodules
       run: |
         cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/ccpp/physics
-        git remote add remote_local $GIT_REMOTE_NAME
+        git remote add remote_local $GIT_REMOTE_URL
         git fetch remote_local
-        git checkout $GIT_REMOTE_NAME $GIT_REMOTE_BRANCH
+        git checkout remote_local/$GIT_REMOTE_BRANCH
         cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm
         git submodule update --init --recursive
         git remote -v

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -31,7 +31,9 @@ jobs:
       run: echo	"GIT_REMOTE_HASH=`git rev-parse HEAD`" >> $GITHUB_ENV
 
     - name: Checkout latest ccpp-scm code
-      run: git clone https://github.com/NCAR/ccpp-scm.git
+      run: |
+        git clone https://github.com/NCAR/ccpp-scm.git
+        pwd
 
     - name: Test GIT_REMOTE_URL
       run: echo $GIT_REMOTE_URL
@@ -51,8 +53,6 @@ jobs:
       run: |
         cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm
         git submodule update --init --recursive
-        git remote -v
-        git log
     
     - name: Set up Python 3.8.5
       uses: actions/setup-python@v3
@@ -67,5 +67,6 @@ jobs:
     - name: Run ccpp_prebuild.py
       run: |
         cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/
+        git status
         mkdir -p /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/scm/bin/ccpp/physics/physics/
         ./ccpp/framework/scripts/ccpp_prebuild.py --config ccpp/config/ccpp_prebuild_config.py

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -42,17 +42,17 @@ jobs:
     - name: Test GIT_REMOTE_HASH
       run: echo	$GIT_REMOTE_HASH
 
+    - name: Initialize submodules
+      run: |
+        cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm
+        git submodule update --init --recursive
+
     - name: Update ccpp-physics hash in ccpp-scm
       run: |
         cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/ccpp/physics
         git remote add remote_local $GIT_REMOTE_URL
         git fetch remote_local $GIT_REMOTE_BRANCH
         git checkout remote_local/$GIT_REMOTE_BRANCH
-
-    - name: Initialize submodules
-      run: |
-        cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm
-        git submodule update --init --recursive
     
     - name: Set up Python 3.8.5
       uses: actions/setup-python@v3

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Checkout current ccpp-physics code
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: "refs/pull/${{ github.event.number }}/merge"
 
     - name: Store remote-URL for current ccpp-physics code
       run: echo "GIT_REMOTE_URL=`git remote get-url origin`" >> $GITHUB_ENV

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -37,6 +37,7 @@ jobs:
         cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/ccpp/physics
         echo $GIT_REMOTE_URL
         echo $GIT_REMOTE_BRANCH
+        echo ${{github.repository}}
         git remote add remote_local $GIT_REMOTE_URL
         git fetch remote_local $GIT_REMOTE_BRANCH
         git checkout remote_local/$GIT_REMOTE_BRANCH

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -20,11 +20,13 @@ jobs:
 
     - name: Checkout current ccpp-physics code
       uses: actions/checkout@v2
-      run: echo "GIT_REMOTE=`git remote get-url origin` >> $GIT_REMOTE_URL
+      run: echo "GIT_REMOTE_URL=`git remote get-url origin` >> $GITHUB_ENV
 
     - name: Checkout latest ccpp-scm code
-      run: |
-        git clone https://github.com/NCAR/ccpp-scm.git
+      run: git clone https://github.com/NCAR/ccpp-scm.git
+
+    - name: Test
+      run: echo $GIT_REMOTE_URL
 
     - name: Initialize submodules
       run: |

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -26,6 +26,12 @@ jobs:
     - name: Checkout latest ccpp-scm code
       run: |
         git clone https://github.com/NCAR/ccpp-scm.git
+        cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/ccpp/physics
+        pwd
+        ls
+        git status
+        git remote -v
+        echo $GIT_REMOTE
 
     - name: Initialize submodules
       run: |

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -24,11 +24,19 @@ jobs:
     - name: Get remote-URL for current ccpp-physics code
       run: echo "GIT_REMOTE_URL=`git remote get-url origin`" >> $GITHUB_ENV
 
+    - name: Get branch name for current ccpp-physics code
+      run: echo "GIT_REMOTE_BRANCH=`git rev-parse --abbrev-ref HEAD`" >> $GITHUB_ENV
+
+    - name: Get hash for HEAD of current ccpp-physics code
+      run: echo	"GIT_REMOTE_HASH=`git rev-parse HEAD`" >> $GITHUB_ENV
+
     - name: Checkout latest ccpp-scm code
       run: git clone https://github.com/NCAR/ccpp-scm.git
 
     - name: Test
       run: echo $GIT_REMOTE_URL
+      run: echo $GIT_REMOTE_BRANCH
+      run: echo	$GIT_REMOTE_HASH
 
     - name: Initialize submodules
       run: |

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -32,12 +32,12 @@ jobs:
 
     - name: Initialize submodules
       run: |
-        cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/
-        git submodule update --init --recursive
-        cd ccpp/physics
+        cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/ccpp/physics
         git remote add remote_local $GIT_REMOTE
         git fetch $GIT_REMOTE
         git checkout $GIT_REMOTE/$GIT_BRANCH
+        cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm
+        git submodule update --init --recursive
         git remote -v
     
     - name: Set up Python 3.8.5

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -21,6 +21,7 @@ jobs:
         ls
         git status
         git remote -v
+        GIT_REMOTE=`git remote get-url origin` && export GIT_REMOTE
 
     - name: Checkout latest ccpp-scm code
       run: |

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -2,12 +2,6 @@ name: CI test to run SCM ccpp_prebuild script
 
 on: [push, pull_request]
 
-env:
-  GIT_REMOTE_URL: https://github.com/NCAR/ccpp-physics.git
-  GIT_REMOTE_HASH: 255035269760c1a6560317c400727d962cdc57f0
-  GIT_REMOTE_NAME: origin
-  GIT_REMOTE_BRANCH: main
-
 jobs:
   build-linux:
 

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -14,12 +14,12 @@ jobs:
 
     - name: Checkout code
       run: |
-        pwd
         git clone https://github.com/NCAR/ccpp-scm.git
-        cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/
 
     - name: Initialize submodules
-      run: git submodule update --init --recursive
+      run: |
+        cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/
+        git submodule update --init --recursive
     
     - name: Set up Python 3.8.5
       uses: actions/setup-python@v3

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Get remote-URL for current ccpp-physics code
-      run: echo "GIT_REMOTE_URL=`git remote get-url origin` >> $GITHUB_ENV
+      run: echo "GIT_REMOTE_URL=`git remote get-url origin`" >> $GITHUB_ENV
 
     - name: Checkout latest ccpp-scm code
       run: git clone https://github.com/NCAR/ccpp-scm.git

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -15,11 +15,9 @@ jobs:
     - name: Checkout current ccpp-physics code
       uses: actions/checkout@v2
 
-    - name: Get repository information from current ccpp-physics code
-      run: |
-        GIT_REMOTE=`git remote get-url origin` && export GIT_REMOTE
-        GIT_REMOTE_HASH=`git rev-parse HEAD` && export GIT_REMOTE_HASH
-        GIT_REMOTE_BRANCH=`git rev-parse --abbrev-ref HEAD` && export GIT_REMOTE_BRANCH
+    - run: GIT_REMOTE=`git remote get-url origin` && export GIT_REMOTE
+    - run: GIT_REMOTE_HASH=`git rev-parse HEAD` && export GIT_REMOTE_HASH
+    - run: GIT_REMOTE_BRANCH=`git rev-parse --abbrev-ref HEAD` && export GIT_REMOTE_BRANCH
 
     - name: Checkout latest ccpp-scm code
       run: |

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -29,12 +29,16 @@ jobs:
         ls
         git remote 
         git remote -v
-        $GIT_REMOTE
 
     - name: Initialize submodules
       run: |
         cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/
         git submodule update --init --recursive
+        cd ccpp/physics
+        git remote add remote_local $GIT_REMOTE
+        git fetch $GIT_REMOTE
+        git checkout $GIT_REMOTE/$GIT_BRANCH
+        git remote -v
     
     - name: Set up Python 3.8.5
       uses: actions/setup-python@v3

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -15,26 +15,17 @@ jobs:
     - name: Checkout current ccpp-physics code
       uses: actions/checkout@v2
 
-    - name: Get remote-URL for current ccpp-physics code
+    - name: Store remote-URL for current ccpp-physics code
       run: echo "GIT_REMOTE_URL=`git remote get-url origin`" >> $GITHUB_ENV
 
-    - name: Get branch name for current ccpp-physics code
+    - name: Store branch name for current ccpp-physics code
       run: echo "GIT_REMOTE_BRANCH=`git rev-parse --abbrev-ref HEAD`" >> $GITHUB_ENV
 
-    - name: Get hash for HEAD of current ccpp-physics code
+    - name: Store hash for HEAD of current ccpp-physics code
       run: echo	"GIT_REMOTE_HASH=`git rev-parse HEAD`" >> $GITHUB_ENV
 
     - name: Checkout latest ccpp-scm code
-      run: |
-        git clone https://github.com/NCAR/ccpp-scm.git
-        pwd
-
-    - name: Test GIT_REMOTE_URL
-      run: echo $GIT_REMOTE_URL
-    - name: Test GIT_REMOTE_BRANCH
-      run: echo $GIT_REMOTE_BRANCH
-    - name: Test GIT_REMOTE_HASH
-      run: echo	$GIT_REMOTE_HASH
+      run: git clone https://github.com/NCAR/ccpp-scm.git
 
     - name: Initialize submodules
       run: |
@@ -62,6 +53,5 @@ jobs:
       run: |
         cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/
         git status
-        ls
         mkdir -p /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/scm/bin/ccpp/physics/physics/
         ./ccpp/framework/scripts/ccpp_prebuild.py --config ccpp/config/ccpp_prebuild_config.py

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -18,6 +18,12 @@ jobs:
 
     steps:
 
+      env:
+        GIT_REMOTE_URL_local: https://github.com/NCAR/ccpp-physics.git
+        GIT_REMOTE_HASH_local: 255035269760c1a6560317c400727d962cdc57f0
+        GIT_REMOTE_NAME_local: origin
+        GIT_REMOTE_BRANCH_local: main
+
     - name: Checkout current ccpp-physics code
       uses: actions/checkout@v2
 

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -1,4 +1,4 @@
-B1;95;0cname: CI test to run SCM ccpp_prebuild script
+name: CI test to run SCM ccpp_prebuild script
 
 on: [push, pull_request]
 

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -33,6 +33,7 @@ jobs:
         git submodule update --init --recursive
 
     - name: Update ccpp-physics hash in ccpp-scm
+      if: github.event.pull_request == false
       run: |
         cd /home/runner/work/ccpp-physics/ccpp-physics/ccpp-scm/ccpp/physics
         echo $GIT_REMOTE_URL

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -40,6 +40,8 @@ jobs:
         echo $GIT_REMOTE_URL
         echo $GIT_REMOTE_BRANCH
         echo ${{github.repository}}
+        echo ${{ github.event.pull_request.head.sha }}
+        echo $GITHUB_SHA
         git remote add remote_local $GIT_REMOTE_URL
         git fetch remote_local $GIT_REMOTE_BRANCH
         git checkout remote_local/$GIT_REMOTE_BRANCH


### PR DESCRIPTION
This PR adds continuous integration tests to run the ccpp_prebuild script for all available host models, currently NCAR/ccpp-scm and NOAA-EMC/fv3atm.

For each host-model, the scripts do the following:
- Check out local ccpp-physics code (save github URL and branch information)
- Check out host-model interface and ccpp_prebuild
- Switch host-model ccpp-physics to use local ccpp-physics
- Set up Python environment (v3.8.5)
- Run ccpp_prebuild.py

This is done for all commits and PRs.