### PR TITLE
Fix SCM link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Please see more information about the CCPP at the locations below.
 - [CCPP Physics GitHub wiki](https://github.com/NCAR/ccpp-physics/wiki)
 - [CCPP Framework GitHub wiki](https://github.com/NCAR/ccpp-framework/wiki)
 
-For the use of CCPP with its Single Column Model, see the [Single Column Model User's Guide](http://dtcenter.org/sites/default/files/paragraph/scm-ccpp-guide-v6.0.0.pdf).
+For the use of CCPP with its Single Column Model, see the [Single Column Model User's Guide](https://dtcenter.org/sites/default/files/paragraph/scm-ccpp-guide-v6-0-0.pdf).
 
 For the use of CCPP with NOAA's Unified Forecast System (UFS), see the [UFS Medium-Range Application User's Guide](https://ufs-mrweather-app.readthedocs.io/en/latest), the [UFS Short-Range Application User's Guide](https://ufs-srweather-app.readthedocs.io/en/latest) and the [UFS Weather Model User's Guide](https://ufs-weather-model.readthedocs.io/en/latest).
 

--- a/physics/docs/ccpp_doxyfile
+++ b/physics/docs/ccpp_doxyfile
@@ -400,7 +400,6 @@ FORMULA_MACROFILE      =
 USE_MATHJAX            = YES
 MATHJAX_VERSION        = MathJax_2
 MATHJAX_FORMAT         = HTML-CSS
-#MATHJAX_RELPATH        = https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2
 MATHJAX_RELPATH        = https://cdn.jsdelivr.net/npm/mathjax@2
 MATHJAX_EXTENSIONS     =
 MATHJAX_CODEFILE       =

--- a/physics/docs/ccppsrw_doxyfile
+++ b/physics/docs/ccppsrw_doxyfile
@@ -398,7 +398,6 @@ FORMULA_MACROFILE      =
 USE_MATHJAX            = YES
 MATHJAX_VERSION        = MathJax_2
 MATHJAX_FORMAT         = HTML-CSS
-#MATHJAX_RELPATH        = https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2
 MATHJAX_RELPATH        = https://cdn.jsdelivr.net/npm/mathjax@2
 MATHJAX_EXTENSIONS     =
 MATHJAX_CODEFILE       =


### PR DESCRIPTION
I also found a few old links that don't work that could be updated if want:
* http://www.rtweb.aer.com/
* https://www.jcsda.noaa.gov/documents/meetings/wkshp2008/4/JCSDA_2008_Li.pdf

AER has a new website (<https://www.aer.com/>) and the presentation can be found with Wayback Machine (<http://web.archive.org/web/20170508024706/https://www.jcsda.noaa.gov/documents/meetings/wkshp2008/4/JCSDA_2008_Li.pdf>)