### PR TITLE
Update GFS_rrtmg_setup.F90

### DIFF
--- a/physics/GFS_rrtmg_setup.F90
+++ b/physics/GFS_rrtmg_setup.F90
@@ -171,8 +171,6 @@ module GFS_rrtmg_setup
       ! Initialize the CCPP error handling variables
       errmsg = ''
       errflg = 0
-
-      if (is_initialized) return
       
       if (do_RRTMGP) then
         write(errmsg,'(*(a))') "Logic error: do_RRTMGP must be set to .false."
@@ -212,6 +210,8 @@ module GFS_rrtmg_setup
                  ' lcnorm=',lcnorm,' lnoprec=',lnoprec
          print *, 'lextop=',lextop, ' ltp=',ltp
       endif
+
+      if (is_initialized) return
 
       ! Call initialization routines
       call sol_init ( me, isol, solar_file, con_solr_2008,con_solr_2002,&

--- a/physics/GFS_rrtmgp_setup.F90
+++ b/physics/GFS_rrtmgp_setup.F90
@@ -74,8 +74,6 @@ contains
     ! Initialize the CCPP error handling variables
     errmsg = ''
     errflg = 0
-    
-    if (is_initialized) return
 
     ! Consistency checks
     if (.not. do_RRTMGP) then
@@ -124,6 +122,8 @@ contains
     month0 = 0
     iyear0 = 0
     monthd = 0
+
+    if (is_initialized) return
 
     ! Call initialization routines..
     call sol_init ( me, isol, solar_file, con_solr_2008, con_solr_2002, con_pi )


### PR DESCRIPTION
 Move statement testing the `is_initialized `variable until after control variables in the argument list have been set. This is needed to make sure that the control variables are set for multiple instances of physics.  This is related to the previously addressed issue https://github.com/NCAR/ccpp-physics/issues/999 "Allow multiple instances of CCPP physics in single executable for ensemble DA".  

The GFS_rrtmg_setup had not been a problem when #999 was being addressed, even though it has a heap-stored latch variable, because `iaerflg `andother control flags were _also_ stored as module data in the physparam module and use-associated through the GFS_rrtmg_setup module.  Since that time, GFS_rrtmg_setup was changed and these control variables are now passed in through the argument list of GFS_rrtmg_setup_init, where the are set only after the test to see if is_initialized is .true.

The error showed up in testing as NRL updated to the newer version of ccpp-physics.