### PR TITLE
Match ozone diagnostics to terms of the parametrization

### DIFF
--- a/physics/photochem/module_ozphys.F90
+++ b/physics/photochem/module_ozphys.F90
@@ -297,8 +297,8 @@ contains
        enddo
 
        ! Diagnostics (optional)
-       if (associated(do3_dt_prd))  do3_dt_prd(:,iLev)  = (prod(:,1)-prod(:,2)*prod(:,6))*dt
-       if (associated(do3_dt_ozmx)) do3_dt_ozmx(:,iLev) = (oz(:,iLev) - ozib(:))
+       if (associated(do3_dt_prd))  do3_dt_prd(:,iLev)  = prod(:,1)*dt
+       if (associated(do3_dt_ozmx)) do3_dt_ozmx(:,iLev) = prod(:, 2) * (oz(:,iLev) - prod(:, 6)) * dt
        if (associated(do3_dt_temp)) do3_dt_temp(:,iLev) = prod(:,3)*(t(:,iLev)-prod(:,5))*dt
        if (associated(do3_dt_ohoz)) do3_dt_ohoz(:,iLev) = prod(:,4) * (colo3(:,iLev)-coloz(:,iLev))*dt
     enddo


### PR DESCRIPTION
I changed each diagnostic to correspond to a single term in the parametrization, rather than one-and-a-half and then the sum of all four.  

That is, the first diagnostic of the old version was the first term of the parametrization plus the part of the second term that does not uses variables at the future time in the implicit update step (the $\left.\frac{d(P-L)}{dr}\right|_0 (r - r_0)$ term is implicit in `r`; the first diagnostic included the $r_0$ part and excluded the $r(t+dt)$ part), and the second looked like the total photochemical tendency from the scheme, which the driver could accumulate on its own.  In the new version, each diagnostic in `run_o3prog_2015` corresponds to a term of the equation in [the documentation](https://dtcenter.ucar.edu/GMTB/v6.0.0/sci_doc/_g_f_s__o_z_p_h_y_s.html).