### PR TITLE
bugfix: build_scm nvfortran CI

### DIFF
--- a/physics/CONV/Grell_Freitas/cu_gf_deep.F90
+++ b/physics/CONV/Grell_Freitas/cu_gf_deep.F90
@@ -316,7 +316,7 @@ contains
      real(kind=kind_phys), dimension (its:ite,kts:kte) :: pwdper, massflx
      integer :: nv
 !$acc declare create(chem,chem_cup,chem_up,chem_down,dellac,dellac2,chem_c,chem_pw,chem_pwd,   &
-!$acc                         chem_pwav,chem_psum,pwdper,massflux)
+!$acc                         chem_pwav,chem_psum,pwdper,massflx)
 
      real(kind=kind_phys),    dimension (its:ite,kts:kte) ::            &
         entr_rate_2d,mentrd_rate_2d,he,hes,qes,z, heo,heso,qeso,zo,     &                    


### PR DESCRIPTION
The SCM Github Actions for the [build_scm nvfortran](https://github.com/NCAR/ccpp-scm/actions/runs/9201162560) builds now pass.

Used in [SCM PR#478](https://github.com/NCAR/ccpp-scm/pull/478)