### PR TITLE
Bugfix: aerosol data error reporting

### DIFF
--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.scm.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.scm.F90
@@ -230,6 +230,7 @@
                ! Read aerosol climatology
                call read_aerdata (me,master,iflip,idate,errmsg,errflg)
             endif
+            if (errflg /= 0) return
          else
             ! Update the value of ntrcaer in aerclm_def with the value defined
             ! in GFS_typedefs.F90 that is used to allocate the Tbd DDT.


### PR DESCRIPTION
Return if there is an error in reading the aerosol data. This will more accurately report the error message instead of failing later in the subroutine because the data isn't there. Discovered while fixing the CI error reporting in the [PR#494](https://github.com/NCAR/ccpp-scm/pull/494)