### PR TITLE
Update CODEOWNERS: add NRL representatives

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,7 +4,7 @@
 
 # Default codeowners for files that don't have specific owners:
 
-*           @grantfirl @Qingfu-Liu @dustinswales @mzhangw
+*           @grantfirl @Qingfu-Liu @dustinswales @mzhangw @matusmartini @climbfuji
 
 
 # The following lines are from the CCPP Primary Schemes Points of Contact


### PR DESCRIPTION
As previously discussed, add representatives from NRL as codeowners for ccpp-physics. I am going to create a similar PR for the ufs/dev branch in the ufs-community fork.

I will also note that there are still errors in this CODEOWNERS file (before me making any changes), as indicated by Github.