### PR TITLE
Gcycle Modification for its more flexible applications in GFS/UFS

### DIFF
--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.fv3.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.fv3.F90
@@ -714,7 +714,7 @@
             zorlo, weasd, slope, snoalb, canopy, vfrac, vtype, stype,scolor, shdmin, shdmax, snowd, &
             cv, cvb, cvt, oro, oro_uf, xlat_d, xlon_d, slmsk, landfrac, ozphys, h2ophys,            &
             do_ugwp_v1, jindx1_tau, jindx2_tau, ddy_j1tau, ddy_j2tau, tau_amf, is_initialized,      &
-            errmsg, errflg)
+            cplflx, lakefrac_threshold, errmsg, errflg)
 
          implicit none
 
@@ -722,8 +722,8 @@
          integer,              intent(in)    :: me, master, cnx, cny, isc, jsc, nrcm, im, levs, kdt, &
                                                 nsswr, imfdeepcnv, iccn, nscyc, ntoz, iflip
          integer,              intent(in)    :: idate(:)
-         real(kind_phys),      intent(in)    :: fhswr, fhour
-         logical,              intent(in)    :: lsswr, cal_pre, random_clds, h2o_phys, iaerclm
+         real(kind_phys),      intent(in)    :: fhswr, fhour, lakefrac_threshold
+         logical,              intent(in)    :: lsswr, cal_pre, random_clds, h2o_phys, iaerclm, cplflx
          real(kind_phys),      intent(out)   :: clstp
          integer,              intent(in), optional    :: jindx1_o3(:), jindx2_o3(:), jindx1_h(:), jindx2_h(:)
          real(kind_phys),      intent(in), optional    :: ddy_o3(:),  ddy_h(:)
@@ -920,13 +920,13 @@
          if (nscyc >  0) then
            if (mod(kdt,nscyc) == 1) THEN
              call gcycle (me, nthrds, nx, ny, isc, jsc, nsst, tile_num, nlunit, fn_nml,      &
-                 input_nml_file, lsoil, lsoil_lsm, kice, idate, ialb, isot, ivegsrc,         &
+                 input_nml_file, lsoil, lsoil_lsm, kice, idate, ialb, isot, ivegsrc, cplflx, &
                  use_ufo, nst_anl, fhcyc, phour, landfrac, lakefrac, min_seaice, min_lakeice,&
                  frac_grid, smc, slc, stc, smois, sh2o, tslb, tiice, tg3, tref, tsfc,        &
                  tsfco, tisfc, hice, fice, facsf, facwf, alvsf, alvwf, alnsf, alnwf,         &
                  zorli, zorll, zorlo, weasd, slope, snoalb, canopy, vfrac, vtype,            &
                  stype, scolor, shdmin, shdmax, snowd, cv, cvb, cvt, oro, oro_uf,            &
-                 xlat_d, xlon_d, slmsk, imap, jmap, errmsg, errflg)
+                 lakefrac_threshold, xlat_d, xlon_d, slmsk, imap, jmap, errmsg, errflg)
            endif
          endif
 

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.fv3.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.fv3.meta
@@ -1166,6 +1166,21 @@
   dimensions = ()
   type = integer
   intent = in
+[cplflx]
+  standard_name = flag_for_surface_flux_coupling
+  long_name = flag controlling cplflx collection (default off)
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+[lakefrac_threshold]
+  standard_name = lakefrac_threshold_for_enabling_lake_model
+  long_name = fraction of horizontal grid area occupied by lake must be greater than this value to enable a lake model
+  units = frac
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
 [idate]
   standard_name = date_and_time_at_model_initialization_in_united_states_order
   long_name = initial date with different size and ordering


### PR DESCRIPTION
Background

In the uncoupled GFS, a utility is required to initialize and update/evolve the surface variables, which is called gcycle (Global Cycle).
However, currently, gcycle is applied without distinguishing between the ocean and lake water surfaces. In order to know if the gcycle needs to be applied, two logics to determine if the water surface is ocean or lake, and if it is coupled or uncoupled, need to be added. 
The lake mask, lakefrac (1=lake, 0=non-lake), is available by reading a fix file and is available in ccpp physics Fortran code while a subroutine gcycle is called. Another logical variable, cplflx is available in ccpp code, but needs to be added in the subroutine gcycle.

Solutions

In the forecasting mode in CCPP physics 

Cplflx (cplice) needs to be added in a ccpp subroutine gcycle
Figure out all the lake related variables (need to be updated with gcycle) , as follows:

    tref(:)        = foundation temperature over water surface, identical to tsfc over non-water surface
    tsfc(:)        = surface skin temperature
    tsfco(:)       = water Lake, ocean (or other like river) surface temperature
    tisfc(:)       = surface skin temperature over (sea or lake) ice
    hice(:)        = (sih) sea or lake ice thickness
    fice(:)        = (sic) sea or lake ice fraction/concentration
    zorli(:)       = surface roughness length over ice
    zorlo(:)       = surface_roughness_length_over_water
    weasd(:)       = water equiv of acc snow depth over land and (sea or lake)  ice
    snowd(:)       = water equivalent snow depth
    snoalb(:)      = maximum snow albedo
   

This project is to let the current sfccycle subroutine does what it does (as is), but update the related variables (listed above) at Lake grids only and when the system is in a coupled model, with lakefrac and landfrac, and cplflx dependency. Concretely, this requires to save the listed variables before the call of sfccycle in gcycle.F90, then update them as above after the call of sfccycle.

The code has been done and tested. 

Only three need to be modified:

Interstitials/UFS_SCM_NEPTUNE/gcycle.F90
Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.fv3.F90
Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.fv3.meta

