### PR TITLE
CI Hotfix: bumping Ubuntu version to latest

### DIFF
--- a/.github/workflows/ci_fv3_ccpp_prebuild.yml
+++ b/.github/workflows/ci_fv3_ccpp_prebuild.yml
@@ -6,7 +6,7 @@ jobs:
   ccpp-prebuild-FV3:
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout current ccpp-physics code
@@ -38,11 +38,11 @@ jobs:
         git remote add remote_local $GIT_REMOTE_URL
         git fetch remote_local $GIT_REMOTE_BRANCH
         git checkout remote_local/$GIT_REMOTE_BRANCH
-    
-    - name: Set up Python 3.8.5
+
+    - name: Set up Python 3.10.13
       uses: actions/setup-python@v3
       with:
-        python-version: 3.8.5
+        python-version: 3.10.13
 
     - name: Add conda to system path
       run: |

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -6,7 +6,7 @@ jobs:
   ccpp-prebuild-SCM:
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
 
@@ -42,11 +42,11 @@ jobs:
         git remote add remote_local $GIT_REMOTE_URL
         git fetch remote_local $GIT_REMOTE_BRANCH
         git checkout remote_local/$GIT_REMOTE_BRANCH
-    
-    - name: Set up Python 3.8.5
+
+    - name: Set up Python 3.10.13
       uses: actions/setup-python@v3
       with:
-        python-version: 3.8.5
+        python-version: 3.10.13
 
     - name: Add conda to system path
       run: |


### PR DESCRIPTION
## Description of Changes: 
Github CI is [failing](https://github.com/NCAR/ccpp-physics/actions/runs/14540952972) because Ubuntu 20.04 runners are retired. 
- Bumping Ubuntu version to latest.
- Bumping Python version to match one used in modules. Fails otherwise since current version is not available on the runner

## Tests Conducted: 
Github CI will pass

