### PR TITLE
GFS_time_vary_pre: check that w3emc uses the expected precision

### DIFF
--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_time_vary_pre.fv3.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_time_vary_pre.fv3.F90
@@ -96,7 +96,8 @@
         real(kind=kind_phys), parameter :: con_hr  = 3600.0_kind_phys
         real(kind=kind_dbl_prec)  :: rinc8(5)
 
-        integer ::  iw3jdn
+        integer :: w3kindreal, w3kindint
+        integer :: iw3jdn
         integer :: jd0, jd1
         real    :: fjd
 
@@ -113,9 +114,17 @@
 
         !--- jdat is being updated directly inside of FV3GFS_cap.F90
         !--- update calendars and triggers
-        rinc8(1:5) = 0
-        call w3difdat(jdat,idat,4,rinc8)
-        sec = rinc8(4)
+        call w3kind(w3kindreal, w3kindint)
+        !--- CCPP uses w3emc_d, therefore expecting the following values
+        if (w3kindreal == 8 .and. w3kindint==4) then
+           rinc8(1:5) = 0
+           call w3difdat(jdat,idat,4,rinc8)
+           sec = rinc8(4)
+        else
+           write(errmsg,'(*(a))') "FATAL ERROR: Invalid w3kindreal or w3kindint:", w3kindreal, w3kindint
+           errflg = 1
+           return
+        end if
         phour = sec/con_hr
         !--- set current bucket hour
         zhour = phour

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_time_vary_pre.scm.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_time_vary_pre.scm.F90
@@ -30,7 +30,7 @@
          errflg = 0
 
          if (is_initialized) return
- 
+
          !--- Call gfuncphys (funcphys.f) to compute all physics function tables.
          call gfuncphys ()
 
@@ -93,7 +93,8 @@
         real(kind=kind_phys), parameter :: con_hr  = 3600.0_kind_phys
         real(kind=kind_dbl_prec)  :: rinc8(5)
 
-        integer ::  iw3jdn      
+        integer :: w3kindreal, w3kindint
+        integer :: iw3jdn
         integer :: jd0, jd1
         real    :: fjd
 
@@ -112,9 +113,17 @@
         !--- jdat is being updated directly inside of the time integration
         !--- loop of scm.F90
         !--- update calendars and triggers
-        rinc8(1:5) = 0
-        call w3difdat(jdat,idat,4,rinc8)
-        sec = rinc8(4)
+        call w3kind(w3kindreal, w3kindint)
+        !--- CCPP uses w3emc_d, therefore expecting the following values
+        if (w3kindreal == 8 .and. w3kindint==4) then
+           rinc8(1:5) = 0
+           call w3difdat(jdat,idat,4,rinc8)
+           sec = rinc8(4)
+        else
+           write(errmsg,'(*(a))') "FATAL ERROR: Invalid w3kindreal or w3kindint:", w3kindreal, w3kindint
+           errflg = 1
+           return
+        end if
         phour = sec/con_hr
         !--- set current bucket hour
         zhour = phour


### PR DESCRIPTION
## Description of Changes:

See #1151

## Tests Conducted:

Tested the NRL version of this code.

## Dependencies:

None

## Documentation:

None

## Issue (optional):

Closes #1151 

## Contributors (optional):

@areinecke and @matusmartini