### PR TITLE
bugfix: NaNs in module_mp_nssl_2mom.F90

### DIFF
--- a/physics/MP/NSSL/module_mp_nssl_2mom.F90
+++ b/physics/MP/NSSL/module_mp_nssl_2mom.F90
@@ -10052,6 +10052,8 @@ END SUBROUTINE nssl_2mom_driver
 
           IF ( c1 > 0. ) THEN
             ssfilt(ix,jy,kz) = 100.*(an(ix,jy,kz,lv)/c1 - 1.0)  ! from "new" values
+          ELSE
+            ssfilt(ix,jy,kz) = -100.
           ENDIF
 
         ENDDO


### PR DESCRIPTION
## Description of Changes:
bugfix: initialize data so it is never NaN. See Issue #1155 for details

## Tests Conducted:
NCAR/ccpp-scm#613 CI

## Issue (optional):
#1155 

## Co-author
@MicroTed 