### PR TITLE
Tunable parameters in Thompson microphysics

### DIFF
--- a/physics/MP/Thompson/module_mp_thompson.F90
+++ b/physics/MP/Thompson/module_mp_thompson.F90
@@ -91,10 +91,17 @@ module module_mp_thompson
 !.. scheme.  In 2-moment cloud water, Nt_c represents a maximum of
 !.. droplet concentration and nu_c is also variable depending on local
 !.. droplet number concentration.
-   !real(wp), parameter :: Nt_c = 100.e6
-   real(wp), parameter :: Nt_c_o = 50.e6
-   real(wp), parameter :: Nt_c_l = 150.e6
    real(wp), parameter, private :: Nt_c_max = 1999.e6
+
+
+! Tuning parameters
+   real(wp)          :: Nt_c_l     ! Cloud number concentration over land
+   real(wp)          :: Nt_c_o     ! Cloud number concentration over ocean
+   real(dp), private :: Nt_i_max   ! Maximum of ice crystals per liter
+   real(wp), private :: av_i       ! Transition value of coefficient matching at crossover from cloud ice to snow
+   real(wp), private :: xnc_max    ! Maximum for ice generation
+   real(wp), private :: rr_min
+   real(wp), private :: ssati_min
 
 !..Declaration of constants for assumed CCN/IN aerosols when none in
 !.. the input data.  Look inside the init routine for modifications
@@ -456,6 +463,28 @@ module module_mp_thompson
          logical:: micro_init
          real(wp) :: stime, etime
          logical, parameter :: precomputed_tables = .FALSE.
+         logical, parameter :: do_mp_cloud_tuning = .true.
+
+         if (do_mp_cloud_tuning) then
+!> https://github.com/ufs-community/ccpp-physics/pull/244
+           Nt_c_l = 150.e6
+!> https://github.com/ufs-community/ccpp-physics/pull/19
+           Nt_c_o = 50.e6
+           av_i = av_s * D0s ** (bv_s - bv_i)
+           xnc_max = 1000.e3
+           ssati_min = 0.15
+!> https://github.com/ufs-community/ccpp-physics/pull/1
+           Nt_i_max = 4999.e3_dp
+           rr_min = 1000.0
+         else
+           Nt_c_l = 100.e6
+           Nt_c_o = Nt_c_l
+           av_i = 1493.9
+           xnc_max = 250.e3
+           ssati_min = 0.25
+           Nt_i_max = 499.e3
+           rr_min = 10.0
+         endif
 
 ! Set module derived constants
          am_r = PI*rho_w/6.0
@@ -2017,7 +2046,6 @@ module module_mp_thompson
       real(wp) :: Ef_ra, Ef_sa, Ef_ga
       real(wp) :: dtsave, odts, odt, odzq, hgt_agl, SR
       real(wp) :: xslw1, ygra1, zans1, eva_factor
-      real(wp) av_i
       integer :: i, k, k2, n, nn, nstep, k_0, kbot, IT, iexfrq
       integer, dimension(5) :: ksed1
       integer :: nir, nis, nig, nii, nic, niin
@@ -2042,8 +2070,6 @@ module module_mp_thompson
       odt = 1./dt
       odts = 1./dtsave
       iexfrq = 1
-! Transition value of coefficient matching at crossover from cloud ice to snow
-      av_i = av_s * D0s ** (bv_s - bv_i)
 
 !+---+-----------------------------------------------------------------+
 !> - Initialize Source/sink terms.  First 2 chars: "pr" represents source/sink of
@@ -2269,7 +2295,7 @@ module module_mp_thompson
             ni(k) = max(R2, ni1d(k)*rho(k))
             if (ni(k).le. R2) then
                lami = cie(2)/5.E-6
-               ni(k) = min(4999.e3_dp, cig(1)*oig2*ri(k)/am_i*lami**bm_i)
+               ni(k) = min(Nt_i_max, cig(1)*oig2*ri(k)/am_i*lami**bm_i)
             endif
             L_qi(k) = .true.
             lami = (am_i*cig(2)*oig1*ni(k)/ri(k))**obmi
@@ -2277,7 +2303,7 @@ module module_mp_thompson
             xDi = (bm_i + mu_i + 1.) * ilami
             if (xDi.lt. 5.E-6) then
                lami = cie(2)/5.E-6
-               ni(k) = min(4999.e3_dp, cig(1)*oig2*ri(k)/am_i*lami**bm_i)
+               ni(k) = min(Nt_i_max, cig(1)*oig2*ri(k)/am_i*lami**bm_i)
             elseif (xDi.gt. 300.E-6) then
                lami = cie(2)/300.E-6
                ni(k) = cig(1)*oig2*ri(k)/am_i*lami**bm_i
@@ -2933,13 +2959,13 @@ module module_mp_thompson
 
 !>  - Deposition nucleation of dust/mineral from DeMott et al (2010)
 !! we may need to relax the temperature and ssati constraints.
-               if ( (ssati(k).ge. 0.15) .or. (ssatw(k).gt. eps &
+               if ( (ssati(k).ge. ssati_min) .or. (ssatw(k).gt. eps &
                                     .and. temp(k).lt.253.15) ) then
                   if (dustyIce .AND. (is_aerosol_aware .or. merra2_aerosol_aware)) then
                      xnc = iceDeMott(tempc,qv(k),qvs(k),qvsi(k),rho(k),nifa(k))
                      xnc = xnc*(1.0 + 50.*rand3)
                   else
-                     xnc = min(1000.E3, TNO*EXP(ATO*(T_0-temp(k))))
+                     xnc = min(xnc_max, TNO*EXP(ATO*(T_0-temp(k))))
                   endif
                   xni = ni(k) + (pni_rfz(k)+pni_wfz(k))*dtsave
                   pni_inu(k) = 0.5*(xnc-xni + abs(xnc-xni))*odts
@@ -2949,7 +2975,7 @@ module module_mp_thompson
 
 !>  - Freezing of aqueous aerosols based on Koop et al (2001, Nature)
                xni = smo0(k)+ni(k) + (pni_rfz(k)+pni_wfz(k)+pni_inu(k))*dtsave
-               if ((is_aerosol_aware .or. merra2_aerosol_aware) .AND. homogIce .AND. (xni.le.4999.E3)    & 
+               if ((is_aerosol_aware .or. merra2_aerosol_aware) .AND. homogIce .AND. (xni.le.Nt_i_max)    & 
                               .AND.(temp(k).lt.238).AND.(ssati(k).ge.0.4) ) then
                   xnc = iceKoop(temp(k),qv(k),qvs(k),nwfa(k), dtsave)
                   pni_iha(k) = xnc*odts
@@ -3282,7 +3308,7 @@ module module_mp_thompson
             xDi = (bm_i + mu_i + 1.) * ilami
             if (xDi.lt. 5.E-6) then
                lami = cie(2)/5.E-6
-               xni = min(4999.e3_dp, cig(1)*oig2*xri/am_i*lami**bm_i)
+               xni = min(Nt_i_max, cig(1)*oig2*xri/am_i*lami**bm_i)
                niten(k) = (xni-ni1d(k)*rho(k))*odts*orho
             elseif (xDi.gt. 300.E-6) then 
                lami = cie(2)/300.E-6
@@ -3293,8 +3319,8 @@ module module_mp_thompson
             niten(k) = -ni1d(k)*odts
          endif
          xni=max(0.,(ni1d(k) + niten(k)*dtsave)*rho(k))
-         if (xni.gt.4999.E3) &
-                niten(k) = (4999.E3-ni1d(k)*rho(k))*odts*orho
+         if (xni.gt.Nt_i_max) &
+                niten(k) = (Nt_i_max-ni1d(k)*rho(k))*odts*orho
 
 !>  - Rain tendency
          qrten(k) = qrten(k) + (prr_wau(k) + prr_rcw(k) &
@@ -3977,7 +4003,7 @@ module module_mp_thompson
                   pfll1(k) = pfll1(k) + sed_r(k)*DT*onstep(1)
                enddo
 
-               if (rr(kts).gt.R1*1000.) then
+               if (rr(kts).gt.R1*rr_min) then
                   pptrain = pptrain + sed_r(kts)*DT*onstep(1)
                endif 
             enddo
@@ -4072,7 +4098,7 @@ module module_mp_thompson
                pfil1(k) = pfil1(k) + sed_i(k)*DT*onstep(2)
             enddo
 
-            if (ri(kts).gt.R1*1000.) then
+            if (ri(kts).gt.R1*rr_min) then
                pptice = pptice + sed_i(kts)*DT*onstep(2)
             endif 
          enddo
@@ -4102,7 +4128,7 @@ module module_mp_thompson
                pfil1(k) = pfil1(k) + sed_s(k)*DT*onstep(3)
             enddo
 
-            if (rs(kts).gt.R1*1000.) then
+            if (rs(kts).gt.R1*rr_min) then
                pptsnow = pptsnow + sed_s(kts)*DT*onstep(3)
             endif 
          enddo
@@ -4133,7 +4159,7 @@ module module_mp_thompson
                   pfil1(k) = pfil1(k) + sed_g(k)*DT*onstep(4)
                enddo
 
-               if (rg(kts).gt.R1*1000.) then
+               if (rg(kts).gt.R1*rr_min) then
                   pptgraul = pptgraul + sed_g(kts)*DT*onstep(4)
                endif
             enddo
@@ -4261,7 +4287,7 @@ module module_mp_thompson
                lami = cie(2)/300.E-6
             endif
             ni1d(k) = min(cig(1)*oig2*qi1d(k)/am_i*lami**bm_i,           &
-                           4999.e3_dp/rho(k))
+                           Nt_i_max/rho(k))
          endif
          qr1d(k) = qr1d(k) + qrten(k)*DT
          nr1d(k) = max(R2/rho(k), nr1d(k) + nrten(k)*DT)

--- a/physics/MP/Thompson/mp_thompson.F90
+++ b/physics/MP/Thompson/mp_thompson.F90
@@ -11,7 +11,7 @@ module mp_thompson
       use machine, only : kind_phys
 
       use module_mp_thompson, only : thompson_init, mp_gt_driver, thompson_finalize, calc_effectRad
-      use module_mp_thompson, only : naIN0, naIN1, naCCN0, naCCN1, eps, Nt_c_l, Nt_c_o
+      use module_mp_thompson, only : naIN0, naIN1, naCCN0, naCCN1, eps, Nt_c_l
       use module_mp_thompson, only : re_qc_min, re_qc_max, re_qi_min, re_qi_max, re_qs_min, re_qs_max
 
       use module_mp_thompson_make_number_concentrations, only: make_IceNumber, make_DropletNumber, make_RainNumber


### PR DESCRIPTION
## Description of Changes:
Isolate cloud tuning parameters in Thompson microphysics. Turn these currently hardcoded values into module variables so they can be configured. Maybe in the future, these module variables will become arguments or namelist parameters.

For now, introduce a new logical parameter `do_mp_cloud_tuning` which allows to _turn off_ the tuning from the following PRs:
https://github.com/ufs-community/ccpp-physics/pull/1
https://github.com/ufs-community/ccpp-physics/pull/19
https://github.com/ufs-community/ccpp-physics/pull/244


## Tests Conducted:
At NRL, we tested with NEPTUNE at various horizontal resolutions from 9 to 36 km globally, and for all seasons with a suite of 46 simulations. In NEPTUNE, the control flag `do_mp_cloud_tuning` is set to `.false.` by default and can be passed from physics namelist. This setting effectively reverts the above-mentioned tuning changes and improves skill scores in NEPTUNE, especially in tropics. 

Please note, that our findings hold with both with CCPP v6.1, and with CCPP v7.0.0, and all tests in NEPTUNE used `Nt_c_l` set to the original value of `100e6`. In this PR, `Nt_c_l` is also proposed to be added to the tuning parameters.

## Dependencies:
None.

## Documentation:
The three PRs referenced above.