### PR TITLE
Combination PR for #1141, #1152 and ufs/dev #304

### DIFF
--- a/physics/GWD/cires_ugwpv1_oro.F90
+++ b/physics/GWD/cires_ugwpv1_oro.F90
@@ -120,7 +120,7 @@ contains
       real(kind=kind_phys),dimension(im),intent(out) :: zobl, zogw, zlwb, tau_ogw
       
       character(len=*), intent(out) :: errmsg
-      integer,          intent(out) :: errflg		    
+      integer,          intent(out) :: errflg
 !
 ! 
 ! locals vars for SSO
@@ -1009,13 +1009,12 @@ contains
         endif
        endif
        
-      return
       end subroutine orogw_v1 
 !
 !      
      subroutine ugwp_tofd1d(levs, con_cp, dtp, sigflt, zsurf, zpbl,  u, v, &
                             zmid, utofd, vtofd, epstofd, krf_tofd)
-			    
+
       use machine ,       only : kind_phys 
       use ugwp_oro_init,  only : n_tofd, const_tofd, ze_tofd, a12_tofd, ztop_tofd
 !

--- a/physics/GWD/ugwpv1_gsldrag.F90
+++ b/physics/GWD/ugwpv1_gsldrag.F90
@@ -591,6 +591,8 @@ contains
                  index_of_y_wind, ldiag3d, ldiag_ugwp,               &
                  ugwp_seq_update, spp_wts_gwd, spp_gwd, errmsg, errflg)
      endif
+     if(errflg/=0) return
+
 !
 ! dusfcg = du_ogwcol + du_oblcol + du_osscol + du_ofdcol
 !
@@ -640,6 +642,8 @@ contains
                       dudt_obl, dvdt_obl,dudt_ofd, dvdt_ofd,              &
                       du_ogwcol, dv_ogwcol, du_oblcol, dv_oblcol,         &
                       du_ofdcol, dv_ofdcol, errmsg,errflg           )
+       if(errflg/=0) return
+
 !
 ! orogw_v1: dusfcg = du_ogwcol + du_oblcol  + du_ofdcol                           only 3 terms
 !

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.fv3.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.fv3.F90
@@ -215,6 +215,9 @@
          ! Initialize CCPP error handling variables
          errmsg = ''
          errflg = 0
+         ! Initialize copy_error variables
+         myerrflg = 0
+         myerrmsg = 'Error in GFS_phys_time_vary'
 
          if (is_initialized) return
          iamin=999
@@ -226,15 +229,13 @@
 !>  added coupled gocart and radiation option to initializing aer_nm
          if (iaerclm) then
            ntrcaer = ntrcaerm
-           myerrflg = 0
-           myerrmsg = 'read_aerdata failed without a message'
            if(iaermdl == 1) then
-             call read_aerdata (me,master,iflip,idate,myerrmsg,myerrflg)
+             call read_aerdata (me,master,iflip,idate,errmsg,errflg)
            elseif (iaermdl == 6) then
              call read_aerdata_dl(me,master,iflip,                       &
-                                 idate,fhour, myerrmsg,myerrflg)
+                                 idate,fhour, errmsg,errflg)
            end if
-           call copy_error(myerrmsg, myerrflg, errmsg, errflg)
+           if(errflg/=0) return
          else if(iaermdl ==2 ) then
            do ix=1,ntrcaerm
              do j=1,levs
@@ -257,24 +258,18 @@
 
 !> - Call tau_amf dats for  ugwp_v1
          if (do_ugwp_v1) then
-            myerrflg = 0
-            myerrmsg = 'read_tau_amf failed without a message'
-            call read_tau_amf(me, master, myerrmsg, myerrflg)
-            call copy_error(myerrmsg, myerrflg, errmsg, errflg)
+            call read_tau_amf(me, master, errmsg, errflg)
+            if(errflg/=0) return
          endif
 
 !> - Initialize soil vegetation (needed for sncovr calculation further down)
-         myerrflg = 0
-         myerrmsg = 'set_soilveg failed without a message'
-         call set_soilveg(me, isot, ivegsrc, nlunit, myerrmsg, myerrflg)
-         call copy_error(myerrmsg, myerrflg, errmsg, errflg)
+         call set_soilveg(me, isot, ivegsrc, nlunit, errmsg, errflg)
+         if(errflg/=0) return
 
 !> - read in NoahMP table (needed for NoahMP init)
          if(lsm == lsm_noahmp) then
-           myerrflg = 0
-           myerrmsg = 'read_mp_table_parameters failed without a message'
-           call read_mp_table_parameters(myerrmsg, myerrflg)
-           call copy_error(myerrmsg, myerrflg, errmsg, errflg)
+           call read_mp_table_parameters(errmsg, errflg)
+           if(errflg/=0) return
          endif
 
 
@@ -913,11 +908,11 @@
            ! aerinterpol is using threading inside, don't
            ! move into OpenMP parallel section above
            if (iaermdl==1) then
-             call aerinterpol (me, master, nthrds, im, idate,        &
-                               fhour, iflip, jindx1_aer, jindx2_aer, &
-                               ddy_aer, iindx1_aer,                  &
-                               iindx2_aer, ddx_aer,                  &
-                               levs, prsl, aer_nm, errmsg, errflg)
+             call aerinterpol (me, master, nthrds, im, idate, &
+                              fhour, iflip, jindx1_aer, jindx2_aer, &
+                              ddy_aer, iindx1_aer,           &
+                              iindx2_aer, ddx_aer,           &
+                              levs, prsl, aer_nm, errmsg, errflg)
            else if (iaermdl==6) then
              call aerinterpol_dl (me, master, nthrds, im, idate,       &
                                  fhour, iflip, jindx1_aer, jindx2_aer, &
@@ -925,9 +920,7 @@
                                  iindx2_aer, ddx_aer,                  &
                                  levs, prsl, aer_nm, errmsg, errflg)
            endif
-           if(errflg /= 0) then
-             return
-           endif
+           if(errflg /= 0) return
          endif
 
 !> - Call gcycle() to repopulate specific time-varying surface properties for AMIP/forecast runs

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmg_setup.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmg_setup.F90
@@ -212,14 +212,23 @@ module GFS_rrtmg_setup
            con_pi )
       call aer_init ( levr, me, iaermdl, iaerflg, lalw1bd, aeros_file,  &
            con_pi, con_t0c, con_c, con_boltz, con_plnk, errflg, errmsg)
+      if(errflg/=0) return
+
       call gas_init ( me, co2usr_file, co2cyc_file, ico2, ictm, con_pi, errflg, errmsg )
+      if(errflg/=0) return
+
       call cld_init ( si, levr, imp_physics, me, con_g, con_rd, errflg, errmsg)
+      if(errflg/=0) return
+
       call rlwinit ( me, rad_hr_units, inc_minor_gas, icliq_lw, isubcsw, &
            iovr, iovr_rand, iovr_maxrand, iovr_max, iovr_dcorr,         &
            iovr_exp, iovr_exprand, errflg, errmsg )
+      if(errflg/=0) return
+
       call rswinit ( me, rad_hr_units, inc_minor_gas, icliq_sw, isubclw, &
            iovr, iovr_rand, iovr_maxrand, iovr_max, iovr_dcorr,         &
            iovr_exp, iovr_exprand,iswmode, errflg, errmsg )
+      if(errflg/=0) return
 
       if ( me == 0 ) then
         print *,'  Radiation sub-cloud initial seed =',ipsd0,           &
@@ -229,8 +238,6 @@ module GFS_rrtmg_setup
 !
       is_initialized = .true.
 !
-      return
-
    end subroutine GFS_rrtmg_setup_init
 
 !> \section arg_table_GFS_rrtmg_setup_timestep_init Argument Table
@@ -440,6 +447,7 @@ module GFS_rrtmg_setup
 !  ---  outputs:
      &       slag,sdec,cdec,solcon,con_pi,errmsg,errflg                 &
      &     )
+        if(errflg/=0) return
 
       endif  ! end_if_lsswr_block
 
@@ -447,6 +455,7 @@ module GFS_rrtmg_setup
 !! time interpolation
       if ( lmon_chg ) then
         call aer_update ( iyear, imon, me, iaermdl, aeros_file, errflg, errmsg )
+        if(errflg/=0) return
       endif
 
 !> -# Call co2 and other gases update routine:
@@ -460,6 +469,8 @@ module GFS_rrtmg_setup
 
       call gas_update ( kyear,kmon,kday,khour,lco2_chg, me, co2dat_file, &
            co2gbl_file, ictm, ico2, errflg, errmsg )
+      if(errflg/=0) return
+
       if (ntoz == 0) then
          call ozphys%update_o3clim(kmon, kday, khour, loz1st)
       endif
@@ -472,7 +483,6 @@ module GFS_rrtmg_setup
 !> -# Call clouds update routine (currently not needed)
 !     call cld_update ( iyear, imon, me )
 !
-      return
 !...................................
       end subroutine radupdate
 !-----------------------------------

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_setup.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_setup.F90
@@ -123,7 +123,9 @@ contains
     call sol_init ( me, isol, solar_file, con_solr_2008, con_solr_2002, con_pi )
     call aer_init ( levr, me, iaermdl, iaerflg, lalw1bd, aeros_file, con_pi, con_t0c,    &
          con_c, con_boltz, con_plnk, errflg, errmsg)
+    if(errflg/=0) return
     call gas_init ( me, co2usr_file, co2cyc_file, ico2, ictm, con_pi, errflg, errmsg )
+    if(errflg/=0) return
 
     if ( me == 0 ) then
        print *,' return from rad_initialize (GFS_rrtmgp_setup_init) - after calling radinit'
@@ -131,7 +133,6 @@ contains
     
     is_initialized = .true.
 
-    return
   end subroutine GFS_rrtmgp_setup_init
 
 !> \section arg_table_GFS_rrtmgp_setup_timestep_init Argument Table
@@ -217,11 +218,13 @@ contains
        endif
        iyear0 = iyear
        call sol_update(jdate, kyear, deltsw, deltim, lsol_chg, me, slag, sdec, cdec, solcon, con_pi, errmsg, errflg)
+       if(errflg/=0) return
     endif
 
     ! Update aerosols...
     if ( lmon_chg ) then
        call aer_update ( iyear, imon, me, iaermdl, aeros_file, errflg, errmsg)
+       if(errflg/=0) return
     endif
 
     ! Update trace gases (co2 only)...
@@ -233,13 +236,13 @@ contains
     endif
     call gas_update (kyear, kmon, kday, khour, lco2_chg, me, co2dat_file, co2gbl_file, ictm,&
          ico2, errflg, errmsg )
+    if(errflg/=0) return
     if (ntoz == 0) then
        call ozphys%update_o3clim(kmon, kday, khour, loz1st)
     endif
     
     if ( loz1st ) loz1st = .false.
 
-    return
   end subroutine GFS_rrtmgp_setup_timestep_init
 
 !> \section arg_table_GFS_rrtmgp_setup_finalize Argument Table

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_time_vary_pre.fv3.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_time_vary_pre.fv3.F90
@@ -96,7 +96,8 @@
         real(kind=kind_phys), parameter :: con_hr  = 3600.0_kind_phys
         real(kind=kind_dbl_prec)  :: rinc8(5)
 
-        integer ::  iw3jdn
+        integer :: w3kindreal, w3kindint
+        integer :: iw3jdn
         integer :: jd0, jd1
         real    :: fjd
 
@@ -113,9 +114,17 @@
 
         !--- jdat is being updated directly inside of FV3GFS_cap.F90
         !--- update calendars and triggers
-        rinc8(1:5) = 0
-        call w3difdat(jdat,idat,4,rinc8)
-        sec = rinc8(4)
+        call w3kind(w3kindreal, w3kindint)
+        !--- CCPP uses w3emc_d, therefore expecting the following values
+        if (w3kindreal == 8 .and. w3kindint==4) then
+           rinc8(1:5) = 0
+           call w3difdat(jdat,idat,4,rinc8)
+           sec = rinc8(4)
+        else
+           write(errmsg,'(*(a))') "FATAL ERROR: Invalid w3kindreal or w3kindint:", w3kindreal, w3kindint
+           errflg = 1
+           return
+        end if
         phour = sec/con_hr
         !--- set current bucket hour
         zhour = phour

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_time_vary_pre.scm.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_time_vary_pre.scm.F90
@@ -30,7 +30,7 @@
          errflg = 0
 
          if (is_initialized) return
- 
+
          !--- Call gfuncphys (funcphys.f) to compute all physics function tables.
          call gfuncphys ()
 
@@ -93,7 +93,8 @@
         real(kind=kind_phys), parameter :: con_hr  = 3600.0_kind_phys
         real(kind=kind_dbl_prec)  :: rinc8(5)
 
-        integer ::  iw3jdn      
+        integer :: w3kindreal, w3kindint
+        integer :: iw3jdn
         integer :: jd0, jd1
         real    :: fjd
 
@@ -112,9 +113,17 @@
         !--- jdat is being updated directly inside of the time integration
         !--- loop of scm.F90
         !--- update calendars and triggers
-        rinc8(1:5) = 0
-        call w3difdat(jdat,idat,4,rinc8)
-        sec = rinc8(4)
+        call w3kind(w3kindreal, w3kindint)
+        !--- CCPP uses w3emc_d, therefore expecting the following values
+        if (w3kindreal == 8 .and. w3kindint==4) then
+           rinc8(1:5) = 0
+           call w3difdat(jdat,idat,4,rinc8)
+           sec = rinc8(4)
+        else
+           write(errmsg,'(*(a))') "FATAL ERROR: Invalid w3kindreal or w3kindint:", w3kindreal, w3kindint
+           errflg = 1
+           return
+        end if
         phour = sec/con_hr
         !--- set current bucket hour
         zhour = phour

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/gcycle.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/gcycle.F90
@@ -251,7 +251,6 @@ contains
 #ifndef INTERNAL_FILE_NML
       inquire (file=trim(fn_nml),exist=exists)
       if (.not. exists) then
-        write(6,*) 'gcycle:: namelist file: ',trim(fn_nml),' does not exist'
         errflg = 1
         errmsg = 'ERROR(gcycle): namelist file: ',trim(fn_nml),' does not exist.'
         return
@@ -359,7 +358,6 @@ contains
 !
 !     if (Model%me .eq. 0) print*,'executed gcycle during hour=',fhour
 !
-      RETURN
-      END
+      end subroutine gcycle
 
 end module gcycle_mod

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/sfcsub.F
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/sfcsub.F
@@ -7947,7 +7947,7 @@ cjfe
                   ! points.  so for efficiency, don't have fixrdc try to
                   ! find a value at landice points as defined by the vet type (vet).
               allocate(slmask_noice(len))
-              slmask_noice=1.0
+              slmask_noice = slmskl
               do i = 1, len
                 if (nint(vet(i)) < 1 .or.
      &              nint(vet(i)) == landice_cat) then

--- a/physics/MP/GFDL/v1_2019/gfdl_cloud_microphys_mod.F90
+++ b/physics/MP/GFDL/v1_2019/gfdl_cloud_microphys_mod.F90
@@ -3441,6 +3441,7 @@ subroutine gfdl_cloud_microphys_mod_init (me, master, nlunit, input_nml_file, lo
     call read_gfdlmp_nml(errmsg = errmsg, errflg = errflg, unit = nlunit,   &
          input_nml_file = input_nml_file, fn_nml = fn_nml, version=1,       &
          iostat = ios)
+    if(errflg/=0) return
 
     ! write version number and namelist to log file
     if (me == master) then

--- a/physics/MP/Morrison_Gettelman/aer_cloud.F
+++ b/physics/MP/Morrison_Gettelman/aer_cloud.F
@@ -620,10 +620,6 @@
 
 !      deallocate (kappa_par)
 
-
-
-2033    return
-
        END subroutine aerosol_activate
 !
 
@@ -808,7 +804,6 @@
        AerPr_base_clean%dpg(9:11) = DPGI_aux(9:11)
        AerPr_base_clean%sig(9:11) = SIGI_aux(9:11)
 
-       RETURN
 !
        END SUBROUTINE AerConversion_base
 
@@ -920,7 +915,6 @@
          end do
        end do
 
-       RETURN
 !
        END SUBROUTINE AerConversion
 
@@ -1013,7 +1007,6 @@
          end do
        end do
 
-       RETURN
 !
        END SUBROUTINE AerConversion1
 
@@ -1382,7 +1375,6 @@
 
 ! *** end of subroutine ccnspec ****************************************
 !
-       return
        end subroutine ccnspec
 
 
@@ -1469,7 +1461,6 @@
          smax = smax*scal
        endif
 !
-       return
 !
 ! *** end of subroutine pdfactiv ****************************************
 !
@@ -1591,7 +1582,6 @@
        smax = x3
 
        ndroplet=ndrpl
-       return
 !
 ! *** end of subroutine activate ****************************************
 !
@@ -1678,7 +1668,6 @@
        summa = summa + nd(j)
 999     continue
 !
-       return
        end subroutine sintegral
 
 !=======================================================================
@@ -1732,7 +1721,6 @@
 
        end if
 !
-       return
 !
 ! *** end of subroutine props *******************************************
 !
@@ -1783,7 +1771,6 @@
 !
 ! end of function vpres
 !
-       return
        end function vpres
 
 
@@ -1819,7 +1806,6 @@
        tpars = t-273.15d0
        sft = 0.0761-1.55e-4*tpars
 !
-       return
        end function sft
 
 
@@ -1859,7 +1845,6 @@
        w(i)=2.d0*xl/((1.d0-z*z)*pp*pp)
        w(n+1-i)=w(i)
  12    continue
-       return
        end subroutine gauleg
 
 !C=======================================================================
@@ -1885,7 +1870,6 @@
        else
        erf = axx
        endif
-       RETURN
        END FUNCTION
 
 
@@ -1907,7 +1891,6 @@
 !      else
 !        erf=gammp(.5d0,x**2)
 !      endif
-!      return
 
 !      end function erf
 
@@ -1934,7 +1917,6 @@
        ser=ser+cof(j)/x
  11    continue
        gammln=tmp+log(stp*ser)
-       return
        end function gammln
 
 
@@ -1955,7 +1937,6 @@
 !       call gcf(gammcf,a,x,gln)
 !       gammp=1.d0-gammcf
 !     endif
-!     return
 !     end function gammp
 
 
@@ -1996,7 +1977,6 @@
 !1    continue
 !     pause 'a too large, itmax too small'
 !     gammcf=exp(-x+a*log(x)-gln)*g
-!     return
 !     end subroutine gcf
 
 
@@ -2030,7 +2010,6 @@
 !1    continue
 !     pause 'a too large, itmax too small'
 !     gamser=sum*exp(-x+a*log(x)-gln)
-!     return
 !     end subroutine gser
 
 ! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -2146,7 +2125,6 @@
        end if
 
 
-       return
        END subroutine IceParam
 
 
@@ -2239,7 +2217,6 @@
        nhet=sum3*(vmax_ice-vmin_ice)*0.5d0
        nlim=sum4*(vmax_ice-vmin_ice)*0.5d0
        sc_ice=sum5*(vmax_ice-vmin_ice)*0.5d0
-       RETURN
 
 
        END subroutine nice_Vdist
@@ -2591,8 +2568,6 @@
        sc_ice=min(shom_ice+1.0, sc_ice)
 
 
-       return
-
        END subroutine nice_param
 !*************************************************************
        real*8 function FINDSMAX(SX,DSH,
@@ -2670,7 +2645,6 @@
 
        VPRESWATER_ice=EXP(VPRESWATER_ice)
 
-       return
        END function VPRESWATER_ice
 
 !*************************************************************
@@ -2690,7 +2664,6 @@
        VPRESICE = A(0)+(A(1)/T)+(A(2)*LOG(T))+(A(3)*T)
        VPRESICE=EXP(VPRESICE)
 
-       return
        END function VPRESICE
 
 !*************************************************************
@@ -2711,7 +2684,7 @@
      & A(4))**2)))
 
        DHSUB_ice=1000d0*DHSUB_ice/18d0
-       return
+
        END function DHSUB_ice
 
 !*************************************************************
@@ -2730,7 +2703,7 @@
        TTEMP=T-273d0
 
        DENSITYICE= 1000d0*(A(0)+(A(1)*TTEMP)+(A(2)*TTEMP*TTEMP))
-       return
+
        END function DENSITYICE
 
 !*************************************************************
@@ -2768,7 +2741,7 @@
 
        WATDENSITY=WATDENSITY*1000d0
        WATDENSITY_ice=WATDENSITY
-       return
+
        END function WATDENSITY_ice
 
 
@@ -2914,8 +2887,6 @@
        del1bc_ice=cubicint_ice(Tc, T0bc, T0bc+5d0, 1d0, hbc)
        end if
 
-       RETURN
-
        END SUBROUTINE prop_ice
 
 !*************************************************************
@@ -2936,8 +2907,6 @@
        dp=EXP(-0.5d0*(x-miuv_ice)*(x-miuv_ice)/sigmav_ice/sigmav_ice) /
      &sigmav_ice/sq2pi_par/(normv_ice + 0.001)
 
-
-       RETURN
 
 
        END SUBROUTINE gausspdf
@@ -3967,7 +3936,6 @@
 
       if( X_2 <= X_1) stop 91919
 
-      return
       end function
 
 
@@ -3999,10 +3967,7 @@
 
       if( X_2 <= X_1) stop 91919
 
-      return
       end function
-
-
 
 
 

--- a/physics/MP/Morrison_Gettelman/m_micro.F90
+++ b/physics/MP/Morrison_Gettelman/m_micro.F90
@@ -1987,7 +1987,6 @@ end subroutine m_micro_init
          end do
        end do
 
-       return
        end subroutine gw_prof
 !> @}
 
@@ -2022,7 +2021,6 @@ end subroutine m_micro_init
          kcldtop = pver
          return
        endif
-
 
       end subroutine find_cldtop
 

--- a/physics/Radiation/RRTMG/radlw_main.F90
+++ b/physics/Radiation/RRTMG/radlw_main.F90
@@ -1830,7 +1830,6 @@
 
       endif   ! end if_isubclw_block
 
-      return
 ! ..................................
       end subroutine cldprop
 ! ----------------------------------
@@ -2103,7 +2102,6 @@
         enddo
       enddo
 
-      return
 ! ..................................
       end subroutine mcica_subcol
 ! ----------------------------------
@@ -2402,7 +2400,6 @@
 
       enddo   ! end do_k layer loop
 
-      return
 ! ..................................
       end subroutine setcoef
 ! ----------------------------------

--- a/physics/Radiation/radiation_aerosols.f
+++ b/physics/Radiation/radiation_aerosols.f
@@ -574,6 +574,7 @@
         call wrt_aerlog(iaermdl, iaerflg, lalw1bd, errflg, errmsg)      ! write aerosol param info to log file
 !  ---  inputs:   (in scope variables)
 !  ---  outputs:  (CCPP error handling)
+        if(errflg/=0) return
 
       endif
 
@@ -627,6 +628,7 @@
      &        errflg, errmsg)
 !  ---  inputs:   (module constants)
 !  ---  outputs:  (ccpp error handling)
+        if(errflg/=0) return
 
 !> -# Call clim_aerinit() to invoke tropospheric aerosol initialization.
 
@@ -636,6 +638,7 @@
      &     ( solfwv, eirfwv, me, aeros_file,                            &
 !  ---  outputs:
      &     errflg, errmsg)
+          if(errflg/=0) return
 
         elseif ( iaermdl==1 .or. iaermdl==2 .or. iaermdl==6) then  ! gocart clim/prog scheme
 
@@ -644,6 +647,7 @@
      &     ( solfwv, eirfwv, me,                                        &
 !  ---  outputs:
      &     errflg, errmsg)
+          if(errflg/=0) return
 
         else
           if ( me == 0 ) then
@@ -779,7 +783,6 @@
         endif
       endif     ! end if_iaerflg_block
 !
-      return
 !................................
       end subroutine wrt_aerlog
 !--------------------------------
@@ -890,7 +893,6 @@
         eirfwv(nw) = (tmp1 * tmp3**3) / (exp(tmp2*tmp3) - 1.0)
       enddo
 !
-      return
 !................................
       end subroutine set_spectrum
 !--------------------------------
@@ -938,7 +940,6 @@
         allocate ( ivolae(12,4,10) )   ! for 12-mon,4-lat_zone,10-year
       endif
 !
-      return
 !................................
       end subroutine set_volcaer
 !--------------------------------
@@ -1158,9 +1159,6 @@
      &        action='read',form='FORMATTED')
         rewind (NIAERCM)
       else
-        print *,'    Requested aerosol data file "',aeros_file,         &
-     &          '" not found!'
-        print *,'    *** Stopped in subroutine aero_init !!'
         errflg = 1
         errmsg = 'ERROR(set_aercoef): Requested aerosol data file '//   &
      &       aeros_file//' not found'
@@ -1488,7 +1486,6 @@
 !       print *,' extstra:', extstra(ii)
 !     enddo
 !
-      return
 !................................
       end subroutine set_aercoef
 !--------------------------------
@@ -1746,7 +1743,6 @@
         enddo   !  end do_nb_block for lw
       endif   !  end if_lalwflg_block
 !
-      return
 !................................
       end subroutine optavg
 !--------------------------------
@@ -1812,7 +1808,6 @@
       if ( imon < 1 .or. imon > 12 ) then
         print *,' ***** ERROR in specifying requested month !!! ',      &
      &          'imon=', imon
-        print *,' ***** STOPPED in subroutinte aer_update !!!'
         errflg = 1
         errmsg = 'ERROR(aer_update): Requested month not valid'
         return
@@ -1823,6 +1818,7 @@
 
         if ( iaermdl == 0 .or. iaermdl==5 ) then    ! opac-climatology scheme
         call trop_update(aeros_file, errflg, errmsg)
+        if(errflg/=0) return
         endif
 
       endif
@@ -1914,9 +1910,6 @@
           print *,'   Opened aerosol data file: ',aeros_file
         endif
       else
-        print *,'    Requested aerosol data file "',aeros_file,         &
-     &          '" not found!'
-        print *,'    *** Stopped in subroutine trop_update !!'
         errflg = 1
         errmsg = 'ERROR(trop_update):Requested aerosol data file '//    &
      &       aeros_file // ' not found.'
@@ -2003,7 +1996,6 @@
 !     print 17,kprfg
 ! 17  format(8e16.9)
 !
-      return
 !................................
       end subroutine trop_update
 !--------------------------------
@@ -2123,9 +2115,6 @@
 
             close (NIAERCM)
           else
-            print *,'   Requested volcanic data file "',                &
-     &              volcano_file,'" not found!'
-            print *,'   *** Stopped in subroutine VOLC_AERINIT !!'
             errflg = 1
             errmsg = 'ERROR(volc_update): Requested volcanic data '//   &
      &              'file '//volcano_file//' not found!'
@@ -2143,7 +2132,6 @@
         print *,  ivolae(kmonsav,:,k)
       endif
 !
-      return
 !................................
       end subroutine volc_update
 !--------------------------------
@@ -2395,7 +2383,7 @@
 !!      subroutine computes sw + lw aerosol optical properties for gocart
 !!      aerosol species (merged from fcst and clim fields).
 
-          if ( iaermdl==0 .or. iaermdl==5 ) then  ! use opac aerosol climatology
+        if ( iaermdl==0 .or. iaermdl==5 ) then  ! use opac aerosol climatology
 
           call aer_property                                               &
 !  ---  inputs:
@@ -2408,7 +2396,7 @@
      &       )
 
 !
-          elseif ( iaermdl==1 .or. iaermdl==2 .or. iaermdl==6) then ! use gocart aerosols
+        elseif ( iaermdl==1 .or. iaermdl==2 .or. iaermdl==6) then ! use gocart aerosols
 
           call aer_property_gocart                                        &
 !  ---  inputs:
@@ -2419,6 +2407,7 @@
      &         aerosw,aerolw,aerodp,ext550,errflg,errmsg                  &
      &       )
         endif     ! end if_iaerflg_block
+        if(errflg/=0) return
 
 
 !  ---  check print
@@ -2742,7 +2731,6 @@
 
       endif   ! end if_lavoflg_block
 !
-      return
 !...................................
       end subroutine setaer
 !-----------------------------------
@@ -2916,7 +2904,7 @@
               print *,' ERROR! In setclimaer alon>360. ipt =',i,        &
      &           ',  dltg,alon,tlon,dlon =',dltg,alon(i),tmp1,dtmp
               errflg = 1
-              errmsg = 'ERROR(aer_property)'
+              errmsg = 'ERROR(aer_property) alon > 360'
               return
             endif
           elseif ( dtmp >= f_zero ) then
@@ -2936,7 +2924,7 @@
               print *,' ERROR! In setclimaer alon< 0. ipt =',i,         &
      &           ',  dltg,alon,tlon,dlon =',dltg,alon(i),tmp1,dtmp
               errflg = 1
-              errmsg = 'ERROR(aer_property)'
+              errmsg = 'ERROR(aer_property) alon < 0'
               return
             endif
           endif
@@ -2957,7 +2945,7 @@
               print *,' ERROR! In setclimaer alat<-90. ipt =',i,        &
      &           ',  dltg,alat,tlat,dlat =',dltg,alat(i),tmp2,dtmp
               errflg = 1
-              errmsg = 'ERROR(aer_property)'
+              errmsg = 'ERROR(aer_property) alat < -90'
               return
             endif
           elseif ( dtmp >= f_zero ) then
@@ -2977,7 +2965,7 @@
               print *,' ERROR! In setclimaer alat>90. ipt =',i,         &
      &           ',  dltg,alat,tlat,dlat =',dltg,alat(i),tmp2,dtmp
               errflg = 1
-              errmsg = 'ERROR(aer_property)'
+              errmsg = 'ERROR(aer_property) alat > 90'
               return
             endif
           endif
@@ -3512,7 +3500,6 @@
       endif
 
 !
-      return
 !................................
       end subroutine radclimaer
 !--------------------------------
@@ -3940,10 +3927,9 @@
          open (unit=niaercm, file=fin, status='OLD')
          rewind(niaercm)
        else
-         print *,' Requested luts file ',trim(fin),' not found'
-         print *,' ** Stopped in rd_gocart_luts ** '
          errflg = 1
-         errmsg = 'Requested luts file '//trim(fin)//' not found'
+         errmsg = 'ERROR(rd_gocart_luts): Requested luts file '//       &
+     &              trim(fin)//' not found'
          return
        endif      ! end if_file_exist_block
 
@@ -4007,10 +3993,9 @@
           open (unit=niaercm, file=fin, status='OLD')
           rewind(niaercm)
         else
-          print *,' Requested luts file ',trim(fin),' not found'
-          print *,' ** Stopped in rd_gocart_luts ** '
           errflg = 1
-          errmsg = 'Requested luts file '//trim(fin)//' not found'
+          errmsg = 'ERROR(rd_gocart_luts): Requested luts file '//      &
+     &              trim(fin)//' not found'
           return
         endif      ! end if_file_exist_block
 
@@ -4072,7 +4057,6 @@
 
        enddo       !! ib-loop
 
-      return
 !...................................
       end subroutine rd_gocart_luts
 !-----------------------------------
@@ -4299,8 +4283,6 @@
         enddo   !  end do_nb_block for lw
       endif   !  end if_lalwflg_block
 !
-      return
-      return
 !...................................
       end subroutine optavg_gocart
 !-----------------------------------
@@ -4693,7 +4675,6 @@
 
         enddo         ! end_do_ib_loop
 !
-      return
 !................................
       end subroutine aeropt
 !--------------------------------

--- a/physics/Radiation/radiation_astronomy.f
+++ b/physics/Radiation/radiation_astronomy.f
@@ -304,7 +304,6 @@
         endif
       endif       ! end if_isolar_block
 !
-      return
 !...................................
       end subroutine sol_init
 !-----------------------------------
@@ -433,7 +432,6 @@
 
           inquire (file=solar_fname, exist=file_exist)
           if ( .not. file_exist ) then
-            print *,' !!! ERROR! Can not find solar constant file!!!'
             errflg = 1
             errmsg = "ERROR(radiation_astronomy): solar constant file"//&
      &           " not found"
@@ -641,7 +639,6 @@
 
 !     if (me == 0) print*,'in sol_update completed sr solar'
 !
-      return
 !...................................
       end subroutine sol_update
 !-----------------------------------
@@ -805,7 +802,6 @@
       if (sun < 0.0) sun = sun + tpi
       sollag = sun - alp - 0.03255e0
 !
-      return
 !...................................
       end subroutine solar
 !-----------------------------------
@@ -904,7 +900,6 @@
         endif 
       enddo
 !
-      return
 !...................................
       end subroutine coszmn
 !-----------------------------------
@@ -1030,7 +1025,6 @@
      &       '  SOLAR CONSTANT',8X,F12.7,' (DISTANCE AJUSTED)'//)
 
 !
-      return
 !...................................
       end subroutine prtime
 !-----------------------------------

--- a/physics/Radiation/radiation_clouds.f
+++ b/physics/Radiation/radiation_clouds.f
@@ -330,7 +330,6 @@
          endif
       endif
 !
-      return
 !...................................
       end subroutine cld_init
 !-----------------------------------
@@ -879,7 +878,6 @@
      &       clds, mtop, mbot                                           &
      &     )
 
-      return
 !...................................
       end subroutine radiation_clouds_prop
 
@@ -1176,7 +1174,6 @@
         enddo
       enddo
 !
-      return
 !...................................
       end subroutine progcld_zhao_carr
 !-----------------------------------
@@ -1470,7 +1467,6 @@
         enddo
       enddo
 !
-      return
 !...................................
       end subroutine progcld_zhao_carr_pdf
 !-----------------------------------
@@ -1712,7 +1708,6 @@
         enddo
       enddo
 !
-      return
 !...................................
       end subroutine progcld_gfdl_lin
 !-----------------------------------
@@ -1960,7 +1955,6 @@
         enddo
       enddo
 !
-      return
 !...................................
       end subroutine progcld_fer_hires
 !...................................
@@ -2274,8 +2268,6 @@
         enddo
       enddo
 
-      return
-
 !............................................
       end subroutine progcld_thompson_wsm6
 !............................................
@@ -2560,8 +2552,6 @@
          iwp_ex(i) = iwp_ex(i)*1.E-3
       enddo
 !
-      return
-
 !............................................
       end subroutine progcld_thompson
 !............................................
@@ -2847,7 +2837,6 @@
         enddo
       enddo
 !
-      return
 !...................................
       end subroutine progclduni
 !-----------------------------------
@@ -3306,7 +3295,6 @@
       endif                                     ! end_if_top_at_1
 
 !
-      return
 !...................................
       end subroutine gethml
 !-----------------------------------

--- a/physics/Radiation/radiation_gases.f
+++ b/physics/Radiation/radiation_gases.f
@@ -281,9 +281,9 @@
 
           inquire (file=co2usr_file, exist=file_exist)
           if ( .not. file_exist ) then
-            print *,'   Can not find user CO2 data file: ',co2usr_file
             errflg = 1
-            errmsg = 'ERROR(gas_init): Can not find user CO2 data file'
+            errmsg = 'ERROR(gas_init): Cannot find user CO2 data file'//&
+     &               ': '//co2usr_file
             return
           else
             close (NICO2CN)
@@ -327,7 +327,7 @@
             else
               print *,' ICO2=',ico2flg,' is not a valid selection'
               errflg = 1
-              errmsg = 'ERROR(gas_init): ICO2 is not valid'
+              errmsg = 'ERROR(gas_init): ICO2 is not a valid selection'
               return
             endif    ! endif_ico2flg_block
 
@@ -349,20 +349,16 @@
           else
             print *,' ICO2=',ico2flg,' is not a valid selection'
             errflg = 1
-            errmsg = 'ERROR(gas_init): ICO2 is not valid'
+            errmsg = 'ERROR(gas_init): ICO2 is not a valid selection'
             return
           endif
 
           if ( ictmflg == -2 ) then
             inquire (file=co2cyc_file, exist=file_exist)
             if ( .not. file_exist ) then
-              if ( me == 0 ) then
-                print *,'   Can not find seasonal cycle CO2 data: ',    &
-     &               co2cyc_file
-              endif
               errflg = 1
-              errmsg = 'ERROR(gas_init): Can not find seasonal cycle '//&
-     &             'CO2 data'
+              errmsg = 'ERROR(gas_init): Cannot find seasonal cycle '// &
+     &             'CO2 data file: '//co2cyc_file
               return
             else
               allocate( co2cyc_sav(IMXCO2,JMXCO2,12) )
@@ -404,8 +400,6 @@
 
         endif   lab_ictm
       endif   lab_ico2
-
-      return
 !
 !...................................
       end subroutine gas_init
@@ -550,11 +544,9 @@
 
         inquire (file=co2gbl_file, exist=file_exist)
         if ( .not. file_exist ) then
-          print *,'   Requested co2 data file "',co2gbl_file,           &
-     &            '" not found'
           errflg = 1
           errmsg = 'ERROR(gas_update): Requested co2 data file not '//  &
-     &         'found'
+     &         'found: '//co2gbl_file
           return
         else
           close(NICO2CN)
@@ -648,12 +640,9 @@
             enddo   Lab_dowhile2
 
             if ( .not. file_exist ) then
-              if ( me == 0 ) then
-                print *,'   Can not find co2 data source file'
-              endif
               errflg = 1
-              errmsg = 'ERROR(gas_update): Can not find co2 data '//    &
-     &             'source file'
+              errmsg = 'ERROR(gas_update): Cannot find co2 data '//     &
+     &             'source file: '//co2dat_file
               return
             endif
           endif  Lab_if_ictm
@@ -767,8 +756,6 @@
         close ( NICO2CN )
 
       endif  Lab_if_idyr
-
-      return
 !
 !...................................
       end subroutine gas_update
@@ -934,9 +921,7 @@
           endif
         enddo
       endif
-
 !
-      return
 !...................................
       end subroutine getgases
 !-----------------------------------

--- a/physics/SFC_Layer/GFDL/gfdl_sfc_layer.F90
+++ b/physics/SFC_Layer/GFDL/gfdl_sfc_layer.F90
@@ -1149,6 +1149,7 @@
             zoc(i)  = -100.*znotm
             zot(i) =  -100* znott
           endif
+          if(errflg/=0) return
         endif
 !------------------------------------------------------------------------
 !     where necessary modify zo values over ocean.
@@ -1783,6 +1784,8 @@
         if ( iwavecpl .eq. 1 .and. zoc(i) .le. 0.0 ) then
           windmks = wind10(i) * 0.01
           call znot_wind10m(windmks,znott,znotm,icoef_sf,errmsg,errflg)
+          if(errflg/=0) return
+
           !Check if Charnock parameter ratio is received in a proper range.
           if ( alpha(i) .ge. 0.2 .and. alpha(i) .le. 5. ) then
             znotm = znotm*alpha(i)

--- a/physics/SFC_Layer/GFDL/module_sf_exchcoef.f90
+++ b/physics/SFC_Layer/GFDL/module_sf_exchcoef.f90
@@ -729,7 +729,6 @@ CONTAINS
               call  znot_m_v8(windmks,zm1)
               call  znot_t_v8(windmks,zt1)
            else
-             write(0,*)'stop, icoef_sf must be one of 0,1,2,3,4,5,6,7,8'
              errflg = 1
              errmsg = 'ERROR(znot_wind10m): icoef_sf must be one of 0,1,2,3,4,5,6,7,8'
              return

--- a/physics/SFC_Layer/MYJ/module_SF_JSFC.F90
+++ b/physics/SFC_Layer/MYJ/module_SF_JSFC.F90
@@ -715,10 +715,9 @@
               print*,'ZSLU,ZSLT,RLMO,ZU,ZT=',ZSLU,ZSLT,RLMO,ZU,ZT
               print*,'A,B,DTHV,DU2,RIB=',A,B,DTHV,DU2,RIB
               errflg = 1
-              errmsg = 'ERROR(SFCDIF): '
+              errmsg = 'ERROR(SFCDIF): in module_SF_JSFC.F90'
               return
             end if
-
 
 
             AKMS=MAX(USTARK/SIMM,CXCHS)
@@ -871,9 +870,6 @@
 !              print*,'ELFC,AKHS,DTHV,USTAR=',ELFC,AKHS,DTHV,USTAR
 !              stop
 !            end if
-
-
-
 
 !
             RZ=(ZETAT-ZTMIN2)/DZETA2

--- a/physics/SFC_Layer/MYJ/myjsfc_wrapper.F90
+++ b/physics/SFC_Layer/MYJ/myjsfc_wrapper.F90
@@ -335,6 +335,7 @@
                ,1,im,1,1,1,levs                              &
                ,1,im,1,1,1,levs                              &
                ,1,im,1,1,1,levs, errmsg, errflg)
+      if(errflg/=0) return
 
       do i = 1, im
          if(flag_iter(i))then

--- a/physics/SFC_Layer/MYNN/module_sf_mynn.F90
+++ b/physics/SFC_Layer/MYNN/module_sf_mynn.F90
@@ -1345,6 +1345,8 @@ CONTAINS
           ELSEIF ( ISFTCFLX .EQ. 4 ) THEN
              !GFS zt formulation
              CALL GFS_zt_wat(ZT_wat(i),ZNTstoch_wat(i),restar,WSPD(i),ZA(i),sfc_z0_type,device_errmsg,device_errflg)
+             if(errflg/=0) return
+
              ZQ_wat(i)=ZT_wat(i)
           ENDIF
        ELSE
@@ -2630,8 +2632,6 @@ END SUBROUTINE SFCLAY1D_mynn
 
        ENDIF
 
-       return
-
    END SUBROUTINE zilitinkevich_1995
 !--------------------------------------------------------------------
 !>\ingroup mynn_sfc
@@ -2663,8 +2663,6 @@ END SUBROUTINE SFCLAY1D_mynn
        Z_0 = MAX( Z_0, 1.27e-7_kind_phys)  !These max/mins were suggested by
        Z_0 = MIN( Z_0, 2.85e-3_kind_phys)  !Davis et al. (2008)
 
-       return
-
    END SUBROUTINE davis_etal_2008
 !--------------------------------------------------------------------
 !>\ingroup mynn_sfc
@@ -2689,8 +2687,6 @@ END SUBROUTINE SFCLAY1D_mynn
        Z_0 = MAX( Z_0, 1.27e-7_kind_phys)  !These max/mins were suggested by
        Z_0 = MIN( Z_0, 2.85e-3_kind_phys)  !Davis et al. (2008)
 
-       return
-
    END SUBROUTINE Taylor_Yelland_2001
 !--------------------------------------------------------------------
 !>\ingroup mynn_sfc
@@ -2713,8 +2709,6 @@ END SUBROUTINE SFCLAY1D_mynn
        Z_0 = CZC*ustar*ustar*g_inv + (0.11*visc/MAX(ustar,0.05_kind_phys))
        Z_0 = MAX( Z_0, 1.27e-7_kind_phys)  !These max/mins were suggested by
        Z_0 = MIN( Z_0, 2.85e-3_kind_phys)  !Davis et al. (2008)
-
-       return
 
    END SUBROUTINE charnock_1955
 !--------------------------------------------------------------------
@@ -2740,8 +2734,6 @@ END SUBROUTINE SFCLAY1D_mynn
        Z_0 = CZC*ustar*ustar*g_inv + (0.11*visc/MAX(ustar,0.07_kind_phys))
        Z_0 = MAX( Z_0, 1.27e-7_kind_phys)  !These max/mins were suggested by
        Z_0 = MIN( Z_0, 2.85e-3_kind_phys)  !Davis et al. (2008)
-
-       return
 
    END SUBROUTINE edson_etal_2013
 !--------------------------------------------------------------------
@@ -2773,8 +2765,6 @@ END SUBROUTINE SFCLAY1D_mynn
           Zq = Z_0/(e**2.)      !taken from Garratt (1980,1992)
           Zt = Zq
        ENDIF
-
-       return
 
     END SUBROUTINE garratt_1992
 !--------------------------------------------------------------------
@@ -2822,8 +2812,6 @@ END SUBROUTINE SFCLAY1D_mynn
        Zq = MIN(Zt,1.0e-4_kind_phys)
        Zq = MAX(Zt,2.0e-9_kind_phys)
 
-       return
-
     END SUBROUTINE fairall_etal_2003
 !--------------------------------------------------------------------
 !>\ingroup mynn_sfc
@@ -2850,8 +2838,6 @@ END SUBROUTINE SFCLAY1D_mynn
           Zt = MAX(Zt,2.0e-9_kind_phys)
           Zq = MAX(Zt,2.0e-9_kind_phys)
        ENDIF
-
-       return
 
     END SUBROUTINE fairall_etal_2014
 !--------------------------------------------------------------------
@@ -2908,8 +2894,6 @@ END SUBROUTINE SFCLAY1D_mynn
 
        Zt = MIN(Zt, Z_0/2.0)
        Zq = MIN(Zq, Z_0/2.0)
-
-       return
 
     END SUBROUTINE Yang_2008
 !--------------------------------------------------------------------
@@ -3109,7 +3093,7 @@ END SUBROUTINE SFCLAY1D_mynn
             else if (sfc_z0_type == 7) then
               call znot_t_v7(wind10m, ztmax)   ! 10-m wind,m/s, ztmax(m)
             else if (sfc_z0_type > 0) then
-              write(0,*)'no option for sfc_z0_type=',sfc_z0_type
+              write(0,*)'not a valid option for sfc_z0_type=',sfc_z0_type
 !              errflg = 1
 !              errmsg = 'ERROR(GFS_zt_wat): sfc_z0_type not valid.'
               device_errflg = 1
@@ -3402,8 +3386,6 @@ END SUBROUTINE SFCLAY1D_mynn
 
        ENDIF
 
-       return
-
     END SUBROUTINE Andreas_2002
 !--------------------------------------------------------------------
 !>\ingroup mynn_sfc
@@ -3437,8 +3419,6 @@ END SUBROUTINE SFCLAY1D_mynn
           psi_h = 2.*LOG((1.+y)/(1.+y0))
 
        ENDIF
-
-       return
 
     END SUBROUTINE PSI_Hogstrom_1996
 !--------------------------------------------------------------------
@@ -3477,8 +3457,6 @@ END SUBROUTINE SFCLAY1D_mynn
 
        ENDIF
 
-       return
-
     END SUBROUTINE PSI_DyerHicks
 !--------------------------------------------------------------------
 !>\ingroup mynn_sfc
@@ -3507,8 +3485,6 @@ END SUBROUTINE SFCLAY1D_mynn
                   b*(zL - (c/d))*exp(-d*zL) + (b*c/d) -1.)
 
        ENDIF
-
-       return
 
     END SUBROUTINE PSI_Beljaars_Holtslag_1991
 !--------------------------------------------------------------------
@@ -3539,8 +3515,6 @@ END SUBROUTINE SFCLAY1D_mynn
 
        ENDIF
 
-       return
-
     END SUBROUTINE PSI_Zilitinkevich_Esau_2007
 !--------------------------------------------------------------------
 !>\ingroup mynn_sfc
@@ -3570,8 +3544,6 @@ END SUBROUTINE SFCLAY1D_mynn
           psi_h = -(4.7/0.74)*zL
 
        ENDIF
-
-       return
 
     END SUBROUTINE PSI_Businger_1971
 !--------------------------------------------------------------------
@@ -3604,8 +3576,6 @@ END SUBROUTINE SFCLAY1D_mynn
 
        ENDIF
 
-       return
-
     END SUBROUTINE PSI_Suselj_Sood_2010
 !--------------------------------------------------------------------
 !>\ingroup mynn_sfc
@@ -3622,8 +3592,6 @@ END SUBROUTINE SFCLAY1D_mynn
                -6.1*LOG(z0L + (1.+ z0L**2.5)**0.4)
        psih1 = -5.5*log(zL + (1.+ zL**1.1)**0.90909090909)  &
                -5.5*log(z0L + (1.+ z0L**1.1)**0.90909090909)
-
-       return
 
     END SUBROUTINE PSI_CB2005
 !--------------------------------------------------------------------
@@ -3688,8 +3656,6 @@ END SUBROUTINE SFCLAY1D_mynn
           zL = MAX(zL,1._kind_phys)
        ENDIF
 
-       return
-
     END SUBROUTINE Li_etal_2010
 !-------------------------------------------------------------------
 !>\ingroup mynn_sfc
@@ -3745,7 +3711,6 @@ END SUBROUTINE SFCLAY1D_mynn
          !print*,"SUCCESS,n=",n," Ri=",ri," z0=",z0
       endif
 
-      return
       end function
 !-------------------------------------------------------------------
       REAL(kind_phys) function zolri2(zol2,ri2,za,z0,zt,psi_opt)
@@ -3786,7 +3751,6 @@ END SUBROUTINE SFCLAY1D_mynn
       zolri2=zol2*psit2/psix2**2 - ri2
       !print*,"  target ri=",ri2," est ri=",zol2*psit2/psix2**2
 
-      return
       end function
 !====================================================================
 
@@ -3863,7 +3827,6 @@ END SUBROUTINE SFCLAY1D_mynn
          !print*,"SUCCESS,n=",n," Ri=",ri," z0=",z0
       endif
 
-      return
       end function
 !====================================================================
 !>\ingroup mynn_sfc
@@ -3923,7 +3886,6 @@ END SUBROUTINE SFCLAY1D_mynn
         !psim_stable_full=-6.1*log(zolf+(1+zolf**2.5)**(1./2.5))
         psim_stable_full=-6.1*log(zolf+(1+zolf**2.5)**0.4)
 
-        return
    end function
 
 !>\ingroup mynn_sfc
@@ -3934,7 +3896,6 @@ END SUBROUTINE SFCLAY1D_mynn
         !psih_stable_full=-5.3*log(zolf+(1+zolf**1.1)**(1./1.1))
         psih_stable_full=-5.3*log(zolf+(1+zolf**1.1)**0.9090909090909090909)
 
-        return
    end function
 
 !>\ingroup mynn_sfc
@@ -3953,7 +3914,6 @@ END SUBROUTINE SFCLAY1D_mynn
 
         psim_unstable_full=(psimk+zolf**2*(psimc))/(1+zolf**2.)
 
-        return
    end function
 
 !>\ingroup mynn_sfc
@@ -3971,7 +3931,6 @@ END SUBROUTINE SFCLAY1D_mynn
 
         psih_unstable_full=(psihk+zolf**2*(psihc))/(1+zolf**2)
 
-        return
    end function
 
 ! ==================================================================
@@ -3988,7 +3947,6 @@ END SUBROUTINE SFCLAY1D_mynn
         aa     = sqrt(1. + alpha4 * zolf)
         psim_stable_full_gfs  = -1.*aa + log(aa + 1.)
 
-        return
    end function
 
 !>\ingroup mynn_sfc
@@ -4002,7 +3960,6 @@ END SUBROUTINE SFCLAY1D_mynn
         bb     = sqrt(1. + alpha4 * zolf)
         psih_stable_full_gfs  = -1.*bb + log(bb + 1.)
 
-        return
    end function
 
 !>\ingroup mynn_sfc
@@ -4023,7 +3980,6 @@ END SUBROUTINE SFCLAY1D_mynn
            psim_unstable_full_gfs  = log(hl1) + 2. * sqrt(tem1) - .8776
         end if
 
-        return
    end function
 
 !>\ingroup mynn_sfc
@@ -4044,7 +4000,6 @@ END SUBROUTINE SFCLAY1D_mynn
            psih_unstable_full_gfs  = log(hl1) + .5 * tem1 + 1.386
         end if
 
-        return
    end function
 
 !>\ingroup mynn_sfc
@@ -4066,7 +4021,6 @@ END SUBROUTINE SFCLAY1D_mynn
            endif
         endif
 
-      return
    end function
 
 !>\ingroup mynn_sfc
@@ -4087,7 +4041,6 @@ END SUBROUTINE SFCLAY1D_mynn
            endif
         endif
 
-      return
    end function
 
 !>\ingroup mynn_sfc
@@ -4108,7 +4061,6 @@ END SUBROUTINE SFCLAY1D_mynn
            endif
         endif
 
-      return
    end function
 
 !>\ingroup mynn_sfc
@@ -4129,7 +4081,6 @@ END SUBROUTINE SFCLAY1D_mynn
            endif
         endif
 
-      return
    end function
 !========================================================================
 

--- a/physics/SFC_Layer/UFS/sfc_diff.f
+++ b/physics/SFC_Layer/UFS/sfc_diff.f
@@ -456,7 +456,6 @@
         endif                ! end of if(flagiter) loop
       enddo
 
-      return
       end subroutine sfc_diff_run
 
 !----------------------------------------
@@ -631,7 +630,6 @@
           stress    = cm * wind * wind
           ustar     = sqrt(stress)
 
-      return
 !.................................
       end subroutine stability
 !---------------------------------

--- a/physics/SFC_Models/Land/Noah/lsm_noah.f
+++ b/physics/SFC_Models/Land/Noah/lsm_noah.f
@@ -546,6 +546,7 @@
      &       snomlt, sncovr, rc, pc, rsmin, xlai, rcs, rct, rcq,        &
      &       rcsoil, soilw, soilm, smcwlt, smcdry, smcref, smcmax,      &
      &       errmsg, errflg )
+          if(errflg/=0) return
 
 !> - Noah LSM: prepare variables for return to parent model and unit conversion.
 !  -   6. output (o):
@@ -677,7 +678,6 @@
         endif     ! land
       enddo
 !
-      return
 !...................................
       end subroutine lsm_noah_run
 !-----------------------------

--- a/physics/SFC_Models/Land/Noah/set_soilveg.f
+++ b/physics/SFC_Models/Land/Noah/set_soilveg.f
@@ -430,7 +430,6 @@ c-----------------------------
          END DO
          
 !       if (me == 0) write(6,soil_veg)
-       return
        end subroutine set_soilveg
 
        end module set_soilveg_mod

--- a/physics/SFC_Models/Land/Noah/sflx.f
+++ b/physics/SFC_Models/Land/Noah/sflx.f
@@ -422,6 +422,8 @@
 !> - Call redprm() to set the land-surface paramters,
 !! including soil-type and veg-type dependent parameters.
       call redprm(errmsg, errflg)
+      if(errflg/=0) return
+
         if(ivegsrc == 1) then
 !only igbp type has urban
 !urban
@@ -1058,7 +1060,6 @@
 !     endif
 
 !
-      return
 !...................................
       end subroutine alcalc
 !-----------------------------------
@@ -1216,7 +1217,6 @@
 
       pc = (rr + delta) / (rr*(1.0 + rc*ch) + delta)
 !
-      return
 !...................................
       end subroutine canres
 !-----------------------------------
@@ -1279,7 +1279,6 @@
 
 !      sncond = 0.021 + 2.51 * sndens**2
 !
-      return
 !...................................
       end subroutine csnow
 !-----------------------------------
@@ -1559,7 +1558,6 @@
       flx1 = 0.0
       flx3 = 0.0
 !
-      return
 !...................................
       end subroutine nopac
 !-----------------------------------
@@ -1671,7 +1669,6 @@
       epsca = (a*rr + rad*delta) / (delta + rr)
       etp = epsca * rch / lsubc
 !
-      return
 !...................................
       end subroutine penman
 !-----------------------------------
@@ -1960,7 +1957,6 @@
       if (vegtyp == bare) shdfac = 0.0
 
       if (nroot > nsoil) then
-        write(*,*) 'warning: too many root layers'
         errflg = 1
         errmsg = 'ERROR(sflx.f): too many root layers'
         return
@@ -1977,7 +1973,6 @@
 
       slope = slope_data(slopetyp)
 !
-      return
 !...................................
       end subroutine redprm
 !-----------------------------------
@@ -2265,7 +2260,6 @@
 !     print*,'ch=',ch
 !     print*,'----------------------------'
 !
-      return
 !...................................
       end subroutine sfcdif
 !-----------------------------------
@@ -2336,7 +2330,6 @@
 !       sncovr = sneqv / (sneqv + 2.0*z0n)
 
 !
-      return
 !...................................
       end subroutine snfrac
 !-----------------------------------
@@ -2865,7 +2858,6 @@
       endif   ! end if_ice_block
 
 !
-      return
 !...................................
       end subroutine snopac
 !-----------------------------------
@@ -2944,7 +2936,6 @@
       snowhc = snowhc + hnewc
       snowh  = snowhc * 0.01
 !
-      return
 !...................................
       end subroutine snow_new
 !-----------------------------------
@@ -2996,7 +2987,6 @@
       z0 = (1.0 - sncovr)*z0 + sncovr*z0s
 
 !
-      return
 !...................................
       end subroutine snowz0
 !-----------------------------------
@@ -3135,7 +3125,6 @@
 
       df = ake * (thksat - thkdry) + thkdry
 !
-      return
 !...................................
       end subroutine tdfcnd
 !-----------------------------------
@@ -3291,7 +3280,6 @@
       eta1 = edir1 + ett1 + ec1
 
 !
-      return
 !...................................
       end subroutine evapo
 !-----------------------------------
@@ -3462,7 +3450,6 @@
       ssoil = df1*(stc(1) - t1) / (0.5*zsoil(1))
 
 !
-      return
 !...................................
       end subroutine shflx
 !-----------------------------------
@@ -3675,7 +3662,6 @@
 
 !     runof = runoff
 !
-      return
 !...................................
       end subroutine smflx
 !-----------------------------------
@@ -3837,7 +3823,6 @@
       snowh  = snowhc * 0.01
 
 !
-      return
 !...................................
       end subroutine snowpack
 !-----------------------------------
@@ -3912,7 +3897,6 @@
 
       edir1 = fx * ( 1.0 - shdfac ) * etp1
 !
-      return
 !...................................
       end subroutine devap
 !-----------------------------------
@@ -4074,7 +4058,6 @@
 
       endif   ! end if_tkelv_block
 !
-      return
 !...................................
       end subroutine frh2o
 !-----------------------------------
@@ -4448,7 +4431,6 @@
       enddo   ! end do_k_loop
 
 !
-      return
 !...................................
       end subroutine hrt
 !-----------------------------------
@@ -4623,7 +4605,6 @@
 
       enddo   ! end do_k_loop
 !
-      return
 !...................................
       end subroutine hrtice
 !-----------------------------------
@@ -4723,7 +4704,6 @@
         stcout(k) = stcin(k) + ci(k)
       enddo
 !
-      return
 !...................................
       end subroutine hstep
 !-----------------------------------
@@ -4826,7 +4806,6 @@
          p(kk) = p(kk)*p(kk+1) + delta(kk)
       enddo
 !
-      return
 !...................................
       end subroutine rosr12
 !-----------------------------------
@@ -4963,7 +4942,6 @@
       tsrc = -dh2o * lsubf * dz * (xh2o - sh2o) / dt
       sh2o = xh2o
 !
-      return
 !...................................
       end subroutine snksrc
 !-----------------------------------
@@ -5277,7 +5255,6 @@ c ----------------------------------------------------------------------
         endif
       enddo   ! end do_k_loop
 !
-      return
 !...................................
       end subroutine srt
 !-----------------------------------
@@ -5425,7 +5402,6 @@ c ----------------------------------------------------------------------
       if (cmc < 1.e-20) cmc = 0.0
       cmc = min( cmc, cmcmax )
 !
-      return
 !...................................
       end subroutine sstep
 !-----------------------------------
@@ -5497,7 +5473,6 @@ c ----------------------------------------------------------------------
 
       tbnd1 = tu + (tb-tu)*(zup-zsoil(k))/(zup-zb)
 !
-      return
 !...................................
       end subroutine tbnd
 !-----------------------------------
@@ -5606,7 +5581,6 @@ c ----------------------------------------------------------------------
 
       endif   ! end if_tup_block
 !
-      return
 !...................................
       end subroutine tmpavg
 !-----------------------------------
@@ -5739,7 +5713,6 @@ c ----------------------------------------------------------------------
 !     enddo
 
 !
-      return
 !...................................
       end subroutine transp
 !-----------------------------------
@@ -5823,7 +5796,6 @@ c ----------------------------------------------------------------------
       expon = (2.0 * bexp) + 3.0
       wcnd = dksat * factr2 ** expon
 !
-      return
 !...................................
       end subroutine wdfcnd
 !-----------------------------------

--- a/physics/SFC_Models/Land/Noahmp/noahmpdrv.F90
+++ b/physics/SFC_Models/Land/Noahmp/noahmpdrv.F90
@@ -110,14 +110,16 @@
 
         !--- initialize soil vegetation
         call set_soilveg(me, isot, ivegsrc, nlunit, errmsg, errflg)
+        if(errflg/=0) return
 
         !--- read in noahmp table
         call read_mp_table_parameters(errmsg, errflg)
+        if(errflg/=0) return
 
         ! initialize psih and psim 
-
         if ( do_mynnsfclay ) then
-        call psi_init(psi_opt,errmsg,errflg)
+          call psi_init(psi_opt,errmsg,errflg)
+          if(errflg/=0) return
         endif
 
         pores (:) = maxsmc (:)

--- a/physics/SFC_Models/Land/RUC/lsm_ruc.F90
+++ b/physics/SFC_Models/Land/RUC/lsm_ruc.F90
@@ -164,6 +164,7 @@ module lsm_ruc
 
       !--- initialize soil vegetation
       call set_soilveg_ruc(me, isot, ivegsrc, nlunit, errmsg, errflg)
+      if(errflg/=0) return
 
       pores (:) = maxsmc (:)
       resid (:) = drysmc (:)
@@ -213,6 +214,7 @@ module lsm_ruc
                     zs, dzs, smc, slc, stc,                     & ! in
                     sh2o, smfrkeep, tslb, smois,                & ! out
                     wetness, errmsg, errflg)
+      if(errflg/=0) return
 
       if (lsm_cold_start) then
         do i  = 1, im ! i - horizontal loop
@@ -1622,7 +1624,6 @@ module lsm_ruc
       enddo  ! i
       enddo  ! j
 !
-      return
 !...................................
       end subroutine lsm_ruc_run
 !-----------------------------------
@@ -2021,6 +2022,5 @@ module lsm_ruc
       endif ! debug_print
 
       end subroutine rucinit
-
 
 end module lsm_ruc

--- a/physics/SFC_Models/Land/RUC/set_soilveg_ruc.F90
+++ b/physics/SFC_Models/Land/RUC/set_soilveg_ruc.F90
@@ -441,25 +441,21 @@
       LPARAM =.FALSE.
 
          IF (DEFINED_SOIL .GT. MAX_SOILTYP) THEN
-            WRITE(0,*) 'Warning: DEFINED_SOIL too large in namelist'
             errflg = 1
             errmsg = 'ERROR(set_soilveg_ruc):  DEFINED_SOIL too large in namelist'
             return
          ENDIF
          IF (DEFINED_VEG .GT. MAX_VEGTYP) THEN
-            WRITE(0,*) 'Warning: DEFINED_VEG too large in namelist'
             errflg = 1
             errmsg = 'ERROR(set_soilveg_ruc):  DEFINED_VEG too large in namelist'
             return
          ENDIF
          IF (DEFINED_SLOPE .GT. MAX_SLOPETYP) THEN
-            WRITE(0,*) 'Warning: DEFINED_SLOPE too large in namelist'
             errflg = 1
             errmsg = 'ERROR(set_soilveg_ruc):  DEFINED_SLOPE too large in namelist'
             return
          ENDIF
          
 !       if (me == 0) write(6,soil_veg_ruc)
-       return
        end subroutine set_soilveg_ruc
        end module set_soilveg_ruc_mod


### PR DESCRIPTION
## Description of Changes:
This PR combines changes from #1141, #1152, and [ufs/dev PR 304 ](https://github.com/ufs-community/ccpp-physics/pull/304)

#1141 description:
The issue: Some subroutines do not have return statements after an error occurs. Instead two variables errflg and errmsg are reset or re-initialized in subsequent calls, and if an error occurs it is not captured and the program continues without stopping. Please note that some calls already have if(errflg/=0) return in place.

This PR fixes an issue to return right after an error occurs. Subroutines that use errflg and errmsg should be checked for errflg and abort if necessary. Insert if(errflg/=0) return after such calls.

In addition the following is added:

Remove unnecessary return statements at the end of subroutines. In one case, there were actually two return statements right after each other.
Improve error messages and remove duplicate print statements if they are the same as the errmsg.
Change “can not” to “cannot” and other minor additions.
UPDATE: Thanks to reviewers' feedback, this PR also includes cleanup of GFS_phys_time_vary.fv3.F90 to remove copy_error calls from one-thread region (accessing errmsg and errflg directly).

#1152 description (issue): 
The way w3emc is used in GFS_time_vary_pre is not safe, since there is no protection against argument mismatches in case the wrong version of the library (e.g., _4 instead of _d) is used. This came up during the debugging of a w3emc build issue with Intel oneAPI ifx.

A detailed description can be found here: https://github.com/JCSDA/spack-stack/issues/1716

The issue also provides a code snippet that protects against using a wrong kind for the integer and real arguments in the w3difdat routines.

ufs/dev PR304 description:
Fix the setting of the land mask used in interpolating GLDAS soil data to the model grid. For a complete description, see https://github.com/ufs-community/ccpp-physics/issues/300,

## Tests Conducted:
These changes were combined and tested with the top of ufs/dev (only contained one additional MPAS-based PR that shouldn't affect these results). All UFS RTs passed. All SCM RTs passed.

#1141 testing in NRL: None with the current head of the repo. Only quick tests with an older hash with NEPTUNE. We would like to adopt this ccpp error (errflg and errmsg) handling on our next upgrade but we need this PR (once reviewed and approved) to be merged first.

## Dependencies:
None

## Documentation:
None

## Issue (optional):
None

## Contributors (optional):
@climbfuji @matusmartini @GeorgeGayno-NOAA 
