### PR TITLE
Multiple cumulative bucket periods for total and convective precipitation

### DIFF
--- a/physics/GWD/ugwpv1_gsldrag.F90
+++ b/physics/GWD/ugwpv1_gsldrag.F90
@@ -304,7 +304,7 @@ contains
 !! \htmlinclude ugwpv1_gsldrag_run.html
 !!
      subroutine ugwpv1_gsldrag_run(me, master, im, levs, ak, bk, ntrac, lonr, dtp,      &
-          fhzero, kdt, ldiag3d, lssav, flag_for_gwd_generic_tend, do_gsl_drag_ls_bl,    &
+          kdt, ldiag3d, lssav, flag_for_gwd_generic_tend, do_gsl_drag_ls_bl,            &
           do_gsl_drag_ss, do_gsl_drag_tofd,                                             &
           do_gwd_opt_psl, psl_gwd_dx_factor,                                            &
           do_ngw_ec, do_ugwp_v1,  do_ugwp_v1_orog_only,                                 &
@@ -366,7 +366,7 @@ contains
     logical,  intent (in) :: do_ugwp_v1_w_gsldrag                              ! combination of ORO and NGW schemes
 
     integer,                 intent(in) :: me, master, im, levs, ntrac,lonr
-    real(kind=kind_phys),    intent(in) :: dtp, fhzero
+    real(kind=kind_phys),    intent(in) :: dtp
     real(kind=kind_phys),    intent(in) :: ak(:), bk(:)
     integer,                 intent(in) :: kdt, jdat(:)
 ! option  for psl gwd

--- a/physics/GWD/ugwpv1_gsldrag.meta
+++ b/physics/GWD/ugwpv1_gsldrag.meta
@@ -352,14 +352,6 @@
   type = real
   kind = kind_phys
   intent = in
-[fhzero]
-  standard_name = period_of_diagnostics_reset
-  long_name = hours between clearing of diagnostic buckets
-  units = h
-  dimensions = ()
-  type = real
-  kind = kind_phys
-  intent = in
 [kdt]
   standard_name = index_of_timestep
   long_name = current forecast iteration

--- a/physics/GWD/unified_ugwp.F90
+++ b/physics/GWD/unified_ugwp.F90
@@ -244,7 +244,7 @@ contains
 !! \htmlinclude unified_ugwp_run.html
 !!
 ! \section det_unified_ugwp GFS Unified GWP Scheme Detailed Algorithm
-     subroutine unified_ugwp_run(me, master, im, levs, ak,bk, ntrac, dtp, fhzero, kdt, &
+     subroutine unified_ugwp_run(me, master, im, levs, ak,bk, ntrac, dtp, kdt,         &
          lonr, oro, oro_uf, hprime, nmtvr, oc, theta, sigma, gamma, elvmax, clx, oa4,  &
          varss,oc1ss,oa4ss,ol4ss,dx,dusfc_ms,dvsfc_ms,dusfc_bl,dvsfc_bl,dusfc_ss,      &
          dvsfc_ss,dusfc_fd,dvsfc_fd,dtaux2d_ms,dtauy2d_ms,dtaux2d_bl,dtauy2d_bl,       &
@@ -290,7 +290,7 @@ contains
     real(kind=kind_phys),    intent(in),    dimension(:,:)  :: del, ugrs, vgrs, tgrs, prsl, prslk, phil
     real(kind=kind_phys),    intent(in),    dimension(:,:)  :: prsi, phii
     real(kind=kind_phys),    intent(in),    dimension(:,:)  :: q1
-    real(kind=kind_phys),    intent(in) :: dtp, fhzero, cdmbgwd(:), alpha_fd
+    real(kind=kind_phys),    intent(in) :: dtp, cdmbgwd(:), alpha_fd
     integer, intent(in) :: jdat(:)
     logical, intent(in) :: do_tofd, ldiag_ugwp, ugwp_seq_update
 

--- a/physics/GWD/unified_ugwp.meta
+++ b/physics/GWD/unified_ugwp.meta
@@ -331,14 +331,6 @@
   type = real
   kind = kind_phys
   intent = in
-[fhzero]
-  standard_name = period_of_diagnostics_reset
-  long_name = hours between clearing of diagnostic buckets
-  units = h
-  dimensions = ()
-  type = real
-  kind = kind_phys
-  intent = in
 [kdt]
   standard_name = index_of_timestep
   long_name = current forecast iteration

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.meta
@@ -590,7 +590,7 @@
   standard_name = cumulative_lwe_thickness_of_convective_precipitation_amount_in_bucket
   long_name = cumulative convective precipitation in bucket
   units = m
-  dimensions = (horizontal_loop_extent)
+  dimensions = (horizontal_loop_extent,number_of_diagnostic_buckets)
   type = real
   kind = kind_phys
   intent = inout
@@ -598,7 +598,7 @@
   standard_name = accumulated_lwe_thickness_of_precipitation_amount_in_bucket
   long_name = accumulated total precipitation in bucket
   units = m
-  dimensions = (horizontal_loop_extent)
+  dimensions = (horizontal_loop_extent,number_of_diagnostic_buckets)
   type = real
   kind = kind_phys
   intent = inout
@@ -797,6 +797,13 @@
   dimensions = ()
   type = real
   kind = kind_phys
+  intent = in
+[num_diag_buckets]
+  standard_name = number_of_diagnostic_buckets
+  long_name = number of diagnostic bucket reset periods
+  units = count
+  dimensions = ()
+  type = integer
   intent = in
 [num_dfi_radar]
   standard_name = number_of_radar_derived_temperature_or_convection_suppression_intervals

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_SCNV_generic_post.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_SCNV_generic_post.F90
@@ -11,7 +11,7 @@
       subroutine GFS_SCNV_generic_post_run (im, levs, nn, lssav, ldiag3d, qdiag3d, &
         frain, gu0, gv0, gt0, gq0, save_u, save_v, save_t, save_q,                 &
         clw, shcnvcw, rain1, npdf3d, num_p3d, ncnvcld3d, cnvc, cnvw, nsamftrac,    &
-        rainc, cnvprcp, cnvprcpb, cnvw_phy_f3d, cnvc_phy_f3d,                      &
+        rainc, cnvprcp, cnvw_phy_f3d, cnvc_phy_f3d,                                &
         dtend, dtidx, index_of_temperature, index_of_x_wind, index_of_y_wind,      &
         index_of_process_scnv, ntqv, flag_for_scnv_generic_tend,                   &
         ntcw,ntiw,ntclamt,ntrw,ntsw,ntrnc,ntsnc,ntgl,ntgnc,ntsigma,                &
@@ -41,7 +41,7 @@
       logical, intent(in) :: shcnvcw
       real(kind=kind_phys), dimension(:), intent(in) :: rain1
       real(kind=kind_phys), dimension(:, :), intent(in) :: cnvw, cnvc
-      real(kind=kind_phys), dimension(:), intent(inout) :: rainc, cnvprcp, cnvprcpb
+      real(kind=kind_phys), dimension(:), intent(inout) :: rainc, cnvprcp
       ! The following arrays may not be allocated, depending on certain flags and microphysics schemes.
       ! Since Intel 15 crashes when passing unallocated arrays to arrays defined with explicit shape,
       ! use assumed-shape arrays. Note that Intel 18 and GNU 6.2.0-8.1.0 tolerate explicit-shape arrays

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_SCNV_generic_post.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_SCNV_generic_post.meta
@@ -256,14 +256,6 @@
   type = real
   kind = kind_phys
   intent = inout
-[cnvprcpb]
-  standard_name = cumulative_lwe_thickness_of_convective_precipitation_amount_in_bucket
-  long_name = cumulative convective precipitation in bucket
-  units = m
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = inout
 [cnvw_phy_f3d]
   standard_name = convective_cloud_condensate_mixing_ratio
   long_name = convective cloud water mixing ratio in the phy_f3d array

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_stochastics.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_stochastics.meta
@@ -83,6 +83,13 @@
   dimensions = ()
   type = integer
   intent = in
+[num_diag_buckets]
+  standard_name = number_of_diagnostic_buckets
+  long_name = number of diagnostic bucket reset periods
+  units = count
+  dimensions = ()
+  type = integer
+  intent = in
 [delt]
   standard_name = timestep_for_physics
   long_name = physics timestep
@@ -406,7 +413,7 @@
   standard_name = accumulated_lwe_thickness_of_precipitation_amount_in_bucket
   long_name = accumulated total precipitation in bucket
   units = m
-  dimensions = (horizontal_loop_extent)
+  dimensions = (horizontal_loop_extent,number_of_diagnostic_buckets)
   type = real
   kind = kind_phys
   intent = inout
@@ -414,7 +421,7 @@
   standard_name = cumulative_lwe_thickness_of_convective_precipitation_amount_in_bucket
   long_name = cumulative convective precipitation in bucket
   units = m
-  dimensions = (horizontal_loop_extent)
+  dimensions = (horizontal_loop_extent,number_of_diagnostic_buckets)
   type = real
   kind = kind_phys
   intent = inout


### PR DESCRIPTION
## Description of Changes:

Currently the accumulation period for clearing diagnostics can be specified by a single value in `fhzero` for all cumulative diagnostics (physics tendencies, radiative fluxes, and precipitation amounts). This PR implements multiple diagnostic reset periods for total `totprcpb` and convective `cnvprcpb` preciptitation variables by combining different accumulation amounts into an additional dimension with `number_of_diagnostic_buckets`. More bucket diagnostics (e.g., snow, ice, freezing ice, graupel) could be added to this list.

Note this PR does not affect the accumulation of physics tendencies or radiative fluxes.

This PR also removes unused bucket-related variables. No need to pass `fhzero` and `cnvprcpb` as arguments in GWD and SCNV schemes, respectively.

## Tests Conducted:
None, but used in NEPTUNE.

## Dependencies:
At minimum, this update will require following changes in https://github.com/NOAA-EMC/ufsatm

In `ccpp/data/GFS_typedefs.meta`, adding:
```
[number_of_diagnostic_buckets]
  standard_name = number_of_diagnostic_buckets
  long_name = number of diagnostic buckets
  units = count
  dimensions = ()
  type = integer
  ```
And adding the second dimension:
```
dimensions = (horizontal_dimension,number_of_diagnostic_buckets)
```
for `totprcpb` and `cnvprcpb`.

In NEPTUNE, we also added a new namelist parameter `fhzero_precip` to specify accumulations (e.g., 3, 6, 12, 24 hours):
```
[fhzero_precip]
  standard_name = period_of_precipitation_bucket_reset
  long_name = hours between clearing of precipitation buckets
  units = h
  dimensions = (number_of_diagnostic_buckets)
  type = real
  kind = kind_phys
```
and `GFS_diag_type`-bound procedure `diag_bucket_zero`.

## Documentation:
None.

## Issue:
None, but a related issue is https://github.com/ESCOMP/ESMStandardNames/issues/130 if _standard_name_ needs bucket length information as part of the diagnostics name.