### PR TITLE
 Prevent division by zero when applying free convection adjustment in NSSTM

### DIFF
--- a/physics/SFC_Layer/UFS/sfc_nst.f90
+++ b/physics/SFC_Layer/UFS/sfc_nst.f90
@@ -469,7 +469,7 @@ contains
                 endif
 
                 !  apply fca
-                if ( d_conv(i) > zero ) then
+                if ( d_conv(i) > zero .and. xt(i) > zero ) then
                    !>  - If thickness of free convection layer > 0.0, call dtm_1p_fca()
                    !! to apply free convection adjustment.
                    !>   - If \a dtl thickness >= module_nst_parameters::z_w_max(), call dtl_reset()


### PR DESCRIPTION
## Description of Changes:

Prevent division by zero when applying free convection adjustment in NSSTM. Require the heat content in diurnal thermocline `xt` to be positive. This is consistent with the earlier calculation of depth for convective adjustment `d_conv` in `convdepth` subroutine.


## Tests Conducted:
This issue was identified with recent updates to floating-point trapping in the GNU compiler within NEPTUNE. The fix has resolved the problem, and it no longer occurs. 

## Dependencies:
None.

## Documentation:
None.

## Issue (optional):
Resolved in https://github.nrlmry.navy.mil/NEPTUNE/ccpp-physics/pull/56
