### PR TITLE
 Ability to build with ip and sp library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,9 +207,13 @@ target_include_directories(ccpp_physics PUBLIC
 
 target_link_libraries(ccpp_physics PRIVATE MPI::MPI_Fortran)
 target_link_libraries(ccpp_physics PUBLIC w3emc::w3emc_d
-                                          sp::sp_d
                                           NetCDF::NetCDF_Fortran
 				             )
+if(ip_FOUND)
+  target_link_libraries(ccpp_physics PUBLIC ip::ip_d)
+else()
+  target_link_libraries(ccpp_physics PUBLIC sp::sp_d)
+endif()
 #add FMS for FV3 only
 if(FV3 OR MPAS)
   target_link_libraries(ccpp_physics PUBLIC fms)


### PR DESCRIPTION
## Description of Changes:
  - Add ability to build with `ip` library if it is found. The `sp` library is being replaced by `ip` so this is required. Note that in spack-stack the `ip` package [builds with the OpenMP flag](https://github.com/NOAA-EMC/NCEPLIBS-ip/blob/bc0048f25ee4fee9baf0a3cb21a3ff2abe62c4fb/spack/package.py#L88) so it gets turned on in the CMake build. This means the `CMAKE_Fortran_FLAGS_OPENMP_OFF` needs to be set by the host model since the RRTMGP files currently break if compiled with OpenMP flags. The `CMAKE_Fortran_FLAGS_OPENMP_OFF` environement variable will make sure OpenMP isn't used by the RRTMGP files.

## Tests Conducted:
Builds and runs with the SCM, see NCAR/ccpp-scm#662 for tests.

## Documentation:
Does this PR add new capabilities that need to be documented or require modifications to the existing documentation?  No

## Issue (optional):
Partly fixes issue mentioned in #1193, 

## Contributors (optional):
Built on work from @climbfuji in #1090 and NCAR/ccpp-scm#524
