### PR TITLE
[main] Followup for #1187 for NOAA models

### DIFF
--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.fv3.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.fv3.F90
@@ -6,6 +6,7 @@
 !! aerosol, IN&CCN and surface properties updates.
    module GFS_phys_time_vary
 
+      use mpi_f08
 #ifdef _OPENMP
       use omp_lib
 #endif
@@ -79,7 +80,7 @@
 !>\section gen_GFS_phys_time_vary_init GFS_phys_time_vary_init General Algorithm
 !> @{
       subroutine GFS_phys_time_vary_init (                                                         &
-              me, master, ntoz, h2o_phys, iaerclm, iaermdl, iccn, iflip, im, levs,                 &
+              mpicomm, mpirank, mpiroot, ntoz, h2o_phys, iaerclm, iaermdl, iccn, iflip, im, levs,  &
               nx, ny, idate, xlat_d, xlon_d,                                                       &
               jindx1_o3, jindx2_o3, ddy_o3, jindx1_h, jindx2_h, ddy_h, h2opl,fhour,                &
               jindx1_aer, jindx2_aer, ddy_aer, iindx1_aer, iindx2_aer, ddx_aer, aer_nm,            &
@@ -100,7 +101,8 @@
          implicit none
 
          ! Interface variables
-         integer,              intent(in)    :: me, master, ntoz, iccn, iflip, im, nx, ny, levs, iaermdl
+         type(MPI_Comm),       intent(in)    :: mpicomm
+         integer,              intent(in)    :: mpirank, mpiroot, ntoz, iccn, iflip, im, nx, ny, levs, iaermdl
          logical,              intent(in)    :: h2o_phys, iaerclm, lsm_cold_start
          integer,              intent(in)    :: idate(:), iopt_lake, iopt_lake_clm, iopt_lake_flake
          real(kind_phys),      intent(in)    :: fhour, lakefrac_threshold, lakedepth_threshold
@@ -230,9 +232,9 @@
          if (iaerclm) then
            ntrcaer = ntrcaerm
            if(iaermdl == 1) then
-             call read_aerdata (me,master,iflip,idate,errmsg,errflg)
+             call read_aerdata (mpicomm,mpirank,mpiroot,iflip,idate,errmsg,errflg)
            elseif (iaermdl == 6) then
-             call read_aerdata_dl(me,master,iflip,                       &
+             call read_aerdata_dl(mpicomm, mpirank, mpiroot, iflip, &
                                  idate,fhour, errmsg,errflg)
            end if
            if(errflg/=0) return
@@ -251,19 +253,19 @@
 
 !> - Call read_cidata() to read IN and CCN data
          if (iccn == 1) then
-           call read_cidata (me,master)
+           call read_cidata (mpicomm, mpirank, mpiroot)
            ! No consistency check needed for in/ccn data, all values are
            ! hardcoded in module iccn_def.F and GFS_typedefs.F90
          endif
 
 !> - Call tau_amf dats for  ugwp_v1
          if (do_ugwp_v1) then
-            call read_tau_amf(me, master, errmsg, errflg)
+            call read_tau_amf(mpicomm, mpirank, mpiroot, errmsg, errflg)
             if(errflg/=0) return
          endif
 
 !> - Initialize soil vegetation (needed for sncovr calculation further down)
-         call set_soilveg(me, isot, ivegsrc, nlunit, errmsg, errflg)
+         call set_soilveg(mpirank, isot, ivegsrc, nlunit, errmsg, errflg)
          if(errflg/=0) return
 
 !> - read in NoahMP table (needed for NoahMP init)
@@ -289,8 +291,7 @@
          if (iaerclm) then
            call setindxaer (im, xlat_d, jindx1_aer,          &
                             jindx2_aer, ddy_aer, xlon_d,     &
-                            iindx1_aer, iindx2_aer, ddx_aer, &
-                            me, master)
+                            iindx1_aer, iindx2_aer, ddx_aer)
            iamin = min(minval(iindx1_aer), iamin)
            iamax = max(maxval(iindx2_aer), iamax)
            jamin = min(minval(jindx1_aer), jamin)
@@ -306,7 +307,7 @@
 
 !> - Call  cires_indx_ugwp to read monthly-mean GW-tau diagnosed from FV3GFS-runs that can resolve GWs
          if (do_ugwp_v1) then
-            call cires_indx_ugwp (im, me, master, xlat_d, jindx1_tau, jindx2_tau,  &
+            call cires_indx_ugwp (im, mpirank, mpiroot, xlat_d, jindx1_tau, jindx2_tau,  &
                                   ddy_j1tau, ddy_j2tau)
          endif
 
@@ -322,7 +323,7 @@
 
          !--- if sncovr does not exist in the restart, need to create it
          if (all(sncovr < zero)) then
-           if (me == master ) write(*,'(a)') 'GFS_phys_time_vary_init: compute sncovr from weasd and soil vegetation parameters'
+           if (mpirank == mpiroot ) write(*,'(a)') 'GFS_phys_time_vary_init: compute sncovr from weasd and soil vegetation parameters'
            !--- compute sncovr from existing variables
            !--- code taken directly from read_fix.f
            sncovr(:) = zero
@@ -343,7 +344,7 @@
          !--- For RUC LSM: create sncovr_ice from sncovr
          if (lsm == lsm_ruc) then
            if (all(sncovr_ice < zero)) then
-             if (me == master ) write(*,'(a)') 'GFS_phys_time_vary_init: fill sncovr_ice with sncovr for RUC LSM'
+             if (mpirank == mpiroot ) write(*,'(a)') 'GFS_phys_time_vary_init: fill sncovr_ice with sncovr for RUC LSM'
              sncovr_ice(:) = sncovr(:)
            endif
          endif
@@ -353,9 +354,9 @@
          if (iaerclm) then
            ! This call is outside the OpenMP section, so it should access errmsg & errflg directly.
            if(iaermdl==1) then
-             call read_aerdataf (me, master, iflip, idate, fhour, errmsg, errflg)
+             call read_aerdataf (mpicomm, mpirank, mpiroot, iflip, idate, fhour, errmsg, errflg)
            elseif (iaermdl==6) then
-             call read_aerdataf_dl (me, master, iflip, idate, fhour, errmsg, errflg)
+             call read_aerdataf_dl (mpicomm, mpirank, mpiroot, iflip, idate, fhour, errmsg, errflg)
            end if
            ! If it is moved to an OpenMP section, it must use myerrmsg, myerrflg, and copy_error.
            if (errflg/=0) return
@@ -365,7 +366,7 @@
          !--- land and ice - not for restart runs
          lsm_init: if (lsm_cold_start) then
            if (lsm == lsm_noahmp .or. lsm == lsm_ruc) then
-             if (me == master ) write(*,'(a)') 'GFS_phys_time_vary_init: initialize albedo for land and ice'
+             if (mpirank == mpiroot ) write(*,'(a)') 'GFS_phys_time_vary_init: initialize albedo for land and ice'
              do ix=1,im
                albdvis_lnd(ix)  = 0.2_kind_phys
                albdnir_lnd(ix)  = 0.2_kind_phys
@@ -705,7 +706,7 @@
 !>\section gen_GFS_phys_time_vary_timestep_init GFS_phys_time_vary_timestep_init General Algorithm
 !> @{
       subroutine GFS_phys_time_vary_timestep_init (                                                 &
-            me, master, cnx, cny, isc, jsc, nrcm, im, levs, kdt, idate, cplflx,                     &
+            mpicomm, mpirank, mpiroot, cnx, cny, isc, jsc, nrcm, im, levs, kdt, idate, cplflx,      &
             nsswr, fhswr, lsswr, fhour,                                                             &
             imfdeepcnv, cal_pre, random_clds, nscyc, ntoz, h2o_phys, iaerclm, iaermdl, iccn, clstp, &
             jindx1_o3, jindx2_o3, ddy_o3, ozpl, jindx1_h, jindx2_h, ddy_h, h2opl, iflip,            &
@@ -724,7 +725,8 @@
          implicit none
 
          ! Interface variables
-         integer,              intent(in)    :: me, master, cnx, cny, isc, jsc, nrcm, im, levs, kdt, &
+         type(MPI_Comm),       intent(in)    :: mpicomm
+         integer,              intent(in)    :: mpirank, mpiroot, cnx, cny, isc, jsc, nrcm, im, levs, kdt, &
                                                 nsswr, imfdeepcnv, iccn, nscyc, ntoz, iflip, iaermdl
          integer,              intent(in)    :: idate(:)
          real(kind_phys),      intent(in)    :: fhswr, fhour
@@ -794,8 +796,8 @@
 !$OMP parallel num_threads(nthrds) default(none)                                         &
 !$OMP          shared(kdt,nsswr,lsswr,clstp,imfdeepcnv,cal_pre,random_clds)              &
 !$OMP          shared(fhswr,fhour,seed0,cnx,cny,nrcm,wrk,rannie,rndval, iaermdl)         &
-!$OMP          shared(rann,im,isc,jsc,imap,jmap,ntoz,me,idate,jindx1_o3,jindx2_o3)       &
-!$OMP          shared(ozpl,ddy_o3,h2o_phys,jindx1_h,jindx2_h,h2opl,ddy_h,iaerclm,master) &
+!$OMP          shared(rann,im,isc,jsc,imap,jmap,ntoz,mpirank,idate,jindx1_o3,jindx2_o3)  &
+!$OMP          shared(ozpl,ddy_o3,h2o_phys,jindx1_h,jindx2_h,h2opl,ddy_h,iaerclm,mpiroot)&
 !$OMP          shared(levs,prsl,iccn,jindx1_ci,jindx2_ci,ddy_ci,iindx1_ci,iindx2_ci)     &
 !$OMP          shared(ddx_ci,in_nm,ccn_nm,do_ugwp_v1,jindx1_tau,jindx2_tau,ddy_j1tau)    &
 !$OMP          shared(ddy_j2tau,tau_amf,iflip,ozphys,h2ophys,rjday,n1,n2,idat,jdat,rinc) &
@@ -883,7 +885,7 @@
 !$OMP section
 !> - Call ciinterpol() to make IN and CCN data interpolation
          if (iccn == 1) then
-           call ciinterpol (me, im, idate, fhour,     &
+           call ciinterpol (mpirank, im, idate, fhour,&
                             jindx1_ci, jindx2_ci,     &
                             ddy_ci, iindx1_ci,        &
                             iindx2_ci, ddx_ci,        &
@@ -893,7 +895,7 @@
 !$OMP section
 !> - Call  cires_indx_ugwp to read monthly-mean GW-tau diagnosed from FV3GFS-runs that resolve GW-activ
          if (do_ugwp_v1) then
-           call tau_amf_interp(me, master, im, idate, fhour, &
+           call tau_amf_interp(mpirank, mpiroot, im, idate, fhour, &
                                jindx1_tau, jindx2_tau,       &
                                ddy_j1tau, ddy_j2tau, tau_amf)
          endif
@@ -906,13 +908,13 @@
            ! aerinterpol is using threading inside, don't
            ! move into OpenMP parallel section above
            if (iaermdl==1) then
-             call aerinterpol (me, master, nthrds, im, idate, &
+             call aerinterpol (mpicomm, mpirank, mpiroot, nthrds, im, idate, &
                               fhour, iflip, jindx1_aer, jindx2_aer, &
                               ddy_aer, iindx1_aer,           &
                               iindx2_aer, ddx_aer,           &
                               levs, prsl, aer_nm, errmsg, errflg)
            else if (iaermdl==6) then
-             call aerinterpol_dl (me, master, nthrds, im, idate,       &
+             call aerinterpol_dl (mpicomm, mpirank, mpiroot, nthrds, im, idate, &
                                  fhour, iflip, jindx1_aer, jindx2_aer, &
                                  ddy_aer, iindx1_aer,                  &
                                  iindx2_aer, ddx_aer,                  &
@@ -924,7 +926,7 @@
 !> - Call gcycle() to repopulate specific time-varying surface properties for AMIP/forecast runs
          if (nscyc >  0) then
            if (mod(kdt,nscyc) == 1) THEN
-             call gcycle (me, nthrds, nx, ny, isc, jsc, nsst, tile_num, nlunit, fn_nml,      &
+             call gcycle (mpirank, nthrds, nx, ny, isc, jsc, nsst, tile_num, nlunit, fn_nml,      &
                  input_nml_file, lsoil, lsoil_lsm, kice, idate, ialb, isot, ivegsrc,         &
                  use_ufo, nst_anl, fhcyc, phour, landfrac, lakefrac, min_seaice, min_lakeice,&
                  frac_grid, smc, slc, stc, smois, sh2o, tslb, tiice, tg3, tref, tsfc,        &

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.fv3.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.fv3.meta
@@ -16,14 +16,21 @@
   name = GFS_phys_time_vary_init
   type = scheme
 
-[me]
+[mpicomm]
+  standard_name = mpi_communicator
+  long_name = MPI communicator
+  units = index
+  dimensions = ()
+  type = MPI_Comm
+  intent = in
+[mpirank]
   standard_name = mpi_rank
   long_name = current MPI-rank
   units = index
   dimensions = ()
   type = integer
   intent = in
-[master]
+[mpiroot]
   standard_name = mpi_root
   long_name = master MPI-rank
   units = index
@@ -1096,14 +1103,21 @@
 [ccpp-arg-table]
   name = GFS_phys_time_vary_timestep_init
   type = scheme
-[me]
+[mpicomm]
+  standard_name = mpi_communicator
+  long_name = MPI communicator
+  units = index
+  dimensions = ()
+  type = MPI_Comm
+  intent = in
+[mpirank]
   standard_name = mpi_rank
   long_name = current MPI-rank
   units = index
   dimensions = ()
   type = integer
   intent = in
-[master]
+[mpiroot]
   standard_name = mpi_root
   long_name = master MPI-rank
   units = index

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.scm.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.scm.F90
@@ -5,7 +5,8 @@
 !! This module contains GFS physics time vary subroutines including stratospheric water vapor,
 !! aerosol, IN&CCN and surface properties updates.
    module GFS_phys_time_vary
-
+      use mpi_f08
+     
       use machine, only : kind_phys, kind_dbl_prec, kind_sngl_prec
 
       use mersenne_twister, only: random_setseed, random_number
@@ -57,7 +58,7 @@
 !>\section gen_GFS_phys_time_vary_init GFS_phys_time_vary_init General Algorithm
 !> @{
       subroutine GFS_phys_time_vary_init (                                                         &
-              me, master, ntoz, h2o_phys, iaerclm, iaermdl, iccn, iflip, im, levs,                 &
+              mpicomm, mpirank, mpiroot, ntoz, h2o_phys, iaerclm, iaermdl, iccn, iflip, im, levs,  &
               nx, ny, idate, xlat_d, xlon_d,                                                       &
               jindx1_o3, jindx2_o3, ddy_o3, jindx1_h, jindx2_h, ddy_h, h2opl,fhour,                &
               jindx1_aer, jindx2_aer, ddy_aer, iindx1_aer, iindx2_aer, ddx_aer, aer_nm,            &
@@ -78,7 +79,8 @@
          implicit none
 
          ! Interface variables
-         integer,              intent(in)    :: me, master, ntoz, iccn, iflip, im, nx, ny, levs, iaermdl
+         type(MPI_Comm),       intent(in)    :: mpicomm
+         integer,              intent(in)    :: mpirank, mpiroot, ntoz, iccn, iflip, im, nx, ny, levs, iaermdl
          logical,              intent(in)    :: h2o_phys, iaerclm, lsm_cold_start
          integer,              intent(in)    :: idate(:), iopt_lake, iopt_lake_clm, iopt_lake_flake
          real(kind_phys),      intent(in)    :: fhour, lakefrac_threshold, lakedepth_threshold
@@ -201,9 +203,9 @@
          if (iaerclm) then
            ntrcaer = ntrcaerm
            if(iaermdl == 1) then
-             call read_aerdata (me,master,iflip,idate,errmsg,errflg)
+             call read_aerdata (mpicomm,mpirank,mpiroot,iflip,idate,errmsg,errflg)
            elseif (iaermdl == 6) then
-             call read_aerdata_dl(me,master,iflip,                       &
+             call read_aerdata_dl(mpicomm, mpirank, mpiroot, iflip, &
                                  idate,fhour, errmsg,errflg)
            end if
            if(errflg/=0) return
@@ -222,19 +224,19 @@
 
 !> - Call read_cidata() to read IN and CCN data
          if (iccn == 1) then
-           call read_cidata (me,master)
+           call read_cidata (mpicomm, mpirank, mpiroot)
            ! No consistency check needed for in/ccn data, all values are
            ! hardcoded in module iccn_def.F and GFS_typedefs.F90
          endif
 
 !> - Call tau_amf dats for  ugwp_v1
          if (do_ugwp_v1) then
-            call read_tau_amf(me, master, errmsg, errflg)
+            call read_tau_amf(mpicomm, mpirank, mpiroot, errmsg, errflg)
             if(errflg/=0) return
          endif
 
 !> - Initialize soil vegetation (needed for sncovr calculation further down)
-         call set_soilveg(me, isot, ivegsrc, nlunit, errmsg, errflg)
+         call set_soilveg(mpirank, isot, ivegsrc, nlunit, errmsg, errflg)
          if(errflg/=0) return
 
 !> - read in NoahMP table (needed for NoahMP init)
@@ -257,8 +259,7 @@
          if (iaerclm) then
            call setindxaer (im, xlat_d, jindx1_aer,          &
                             jindx2_aer, ddy_aer, xlon_d,     &
-                            iindx1_aer, iindx2_aer, ddx_aer, &
-                            me, master)
+                            iindx1_aer, iindx2_aer, ddx_aer)
            iamin = min(minval(iindx1_aer), iamin)
            iamax = max(maxval(iindx2_aer), iamax)
            jamin = min(minval(jindx1_aer), jamin)
@@ -274,7 +275,7 @@
 
 !> - Call  cires_indx_ugwp to read monthly-mean GW-tau diagnosed from FV3GFS-runs that can resolve GWs
          if (do_ugwp_v1) then
-            call cires_indx_ugwp (im, me, master, xlat_d, jindx1_tau, jindx2_tau,  &
+            call cires_indx_ugwp (im, mpirank, mpiroot, xlat_d, jindx1_tau, jindx2_tau,  &
                                   ddy_j1tau, ddy_j2tau)
          endif
 
@@ -290,7 +291,7 @@
 
          !--- if sncovr does not exist in the restart, need to create it
          if (all(sncovr < zero)) then
-           if (me == master ) write(*,'(a)') 'GFS_phys_time_vary_init: compute sncovr from weasd and soil vegetation parameters'
+           if (mpirank == mpiroot ) write(*,'(a)') 'GFS_phys_time_vary_init: compute sncovr from weasd and soil vegetation parameters'
            !--- compute sncovr from existing variables
            !--- code taken directly from read_fix.f
            sncovr(:) = zero
@@ -311,7 +312,7 @@
          !--- For RUC LSM: create sncovr_ice from sncovr
          if (lsm == lsm_ruc) then
            if (all(sncovr_ice < zero)) then
-             if (me == master ) write(*,'(a)') 'GFS_phys_time_vary_init: fill sncovr_ice with sncovr for RUC LSM'
+             if (mpirank == mpiroot ) write(*,'(a)') 'GFS_phys_time_vary_init: fill sncovr_ice with sncovr for RUC LSM'
              sncovr_ice(:) = sncovr(:)
            endif
          endif
@@ -320,9 +321,9 @@
 
          if (iaerclm) then
            if (iaermdl==1) then
-             call read_aerdataf (me, master, iflip, idate, fhour, errmsg, errflg)
+             call read_aerdataf (mpicomm, mpirank, mpiroot, iflip, idate, fhour, errmsg, errflg)
            elseif (iaermdl==6) then
-             call read_aerdataf_dl (me, master, iflip, idate, fhour, errmsg, errflg)
+             call read_aerdataf_dl (mpicomm, mpirank, mpiroot, iflip, idate, fhour, errmsg, errflg)
            end if
            if (errflg/=0) return
          end if
@@ -331,7 +332,7 @@
          !--- land and ice - not for restart runs
          lsm_init: if (lsm_cold_start) then
            if (lsm == lsm_noahmp .or. lsm == lsm_ruc) then
-             if (me == master ) write(*,'(a)') 'GFS_phys_time_vary_init: initialize albedo for land and ice'
+             if (mpirank == mpiroot ) write(*,'(a)') 'GFS_phys_time_vary_init: initialize albedo for land and ice'
              do ix=1,im
                albdvis_lnd(ix)  = 0.2_kind_phys
                albdnir_lnd(ix)  = 0.2_kind_phys
@@ -653,7 +654,7 @@
 !>\section gen_GFS_phys_time_vary_timestep_init GFS_phys_time_vary_timestep_init General Algorithm
 !> @{
       subroutine GFS_phys_time_vary_timestep_init (                                                 &
-            me, master, cnx, cny, isc, jsc, nrcm, im, levs, kdt, idate, nsswr, fhswr, lsswr, fhour, &
+            mpicomm, mpirank, mpiroot, cnx, cny, isc, jsc, nrcm, im, levs, kdt, idate, nsswr, fhswr, lsswr, fhour, &
             imfdeepcnv, cal_pre, random_clds, ntoz, h2o_phys, iaerclm, iaermdl, iccn, clstp,        &
             jindx1_o3, jindx2_o3, ddy_o3, ozpl, jindx1_h, jindx2_h, ddy_h, h2opl, iflip,            &
             jindx1_aer, jindx2_aer, ddy_aer, iindx1_aer, iindx2_aer, ddx_aer, aer_nm,               &
@@ -664,7 +665,8 @@
          implicit none
 
          ! Interface variables
-         integer,              intent(in)    :: me, master, cnx, cny, isc, jsc, nrcm, im, levs, kdt, &
+         type(MPI_Comm),       intent(in)    :: mpicomm
+         integer,              intent(in)    :: mpirank, mpiroot, cnx, cny, isc, jsc, nrcm, im, levs, kdt, &
                                                 nsswr, imfdeepcnv, iccn, ntoz, iflip, iaermdl
          integer,              intent(in)    :: idate(:)
          real(kind_phys),      intent(in)    :: fhswr, fhour
@@ -787,7 +789,7 @@
 
 !> - Call ciinterpol() to make IN and CCN data interpolation
          if (iccn == 1) then
-           call ciinterpol (me, im, idate, fhour,     &
+           call ciinterpol (mpirank, im, idate, fhour,     &
                             jindx1_ci, jindx2_ci,     &
                             ddy_ci, iindx1_ci,        &
                             iindx2_ci, ddx_ci,        &
@@ -796,7 +798,7 @@
 
 !> - Call  cires_indx_ugwp to read monthly-mean GW-tau diagnosed from FV3GFS-runs that resolve GW-activ
          if (do_ugwp_v1) then
-           call tau_amf_interp(me, master, im, idate, fhour, &
+           call tau_amf_interp(mpirank, mpiroot, im, idate, fhour, &
                                jindx1_tau, jindx2_tau,       &
                                ddy_j1tau, ddy_j2tau, tau_amf)
          endif
@@ -806,13 +808,13 @@
            ! aerinterpol is using threading inside, don't
            ! move into OpenMP parallel section above
            if (iaermdl==1) then
-             call aerinterpol (me, master, nthrds, im, idate, &
+             call aerinterpol (mpicomm, mpirank, mpiroot, nthrds, im, idate, &
                               fhour, iflip, jindx1_aer, jindx2_aer, &
                               ddy_aer, iindx1_aer,           &
                               iindx2_aer, ddx_aer,           &
                               levs, prsl, aer_nm, errmsg, errflg)
            else if (iaermdl==6) then
-             call aerinterpol_dl (me, master, nthrds, im, idate,       &
+             call aerinterpol_dl (mpicomm, mpirank, mpiroot, nthrds, im, idate, &
                                  fhour, iflip, jindx1_aer, jindx2_aer, &
                                  ddy_aer, iindx1_aer,                  &
                                  iindx2_aer, ddx_aer,                  &

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.scm.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.scm.meta
@@ -15,14 +15,21 @@
   name = GFS_phys_time_vary_init
   type = scheme
 
-[me]
+[mpicomm]
+  standard_name = mpi_communicator
+  long_name = MPI communicator
+  units = index
+  dimensions = ()
+  type = MPI_Comm
+  intent = in
+[mpirank]
   standard_name = mpi_rank
   long_name = current MPI-rank
   units = index
   dimensions = ()
   type = integer
   intent = in
-[master]
+[mpiroot]
   standard_name = mpi_root
   long_name = master MPI-rank
   units = index
@@ -1095,14 +1102,21 @@
 [ccpp-arg-table]
   name = GFS_phys_time_vary_timestep_init
   type = scheme
-[me]
+[mpicomm]
+  standard_name = mpi_communicator
+  long_name = MPI communicator
+  units = index
+  dimensions = ()
+  type = MPI_Comm
+  intent = in
+[mpirank]
   standard_name = mpi_rank
   long_name = current MPI-rank
   units = index
   dimensions = ()
   type = integer
   intent = in
-[master]
+[mpiroot]
   standard_name = mpi_root
   long_name = master MPI-rank
   units = index

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_setup.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_setup.F90
@@ -2,6 +2,7 @@
 !! This file initializes the RRTMGP radiation scheme
 
 module GFS_rrtmgp_setup
+  use mpi_f08
   use machine,                    only : kind_phys
   use module_radiation_astronomy, only : sol_init, sol_update
   use module_radiation_aerosols,  only : aer_init, aer_update
@@ -37,10 +38,10 @@ contains
   subroutine GFS_rrtmgp_setup_init(do_RRTMGP, imp_physics, imp_physics_fer_hires,        &
        imp_physics_gfdl, imp_physics_thompson, imp_physics_wsm6, imp_physics_zhao_carr,  &
        imp_physics_zhao_carr_pdf, imp_physics_mg,  si, levr, ictm, isol, ico2, iaer,     &
-       ntcw, ntoz, iovr, isubc_sw, isubc_lw, lalw1bd, idate,               &
-       me, aeros_file, iaermdl, iaerflg, con_pi, con_t0c, con_c, con_boltz, con_plnk,    &
-       solar_file, con_solr_2008, con_solr_2002, co2usr_file, co2cyc_file, ipsd0,        &
-       errmsg, errflg)
+       ntcw, ntoz, iovr, isubc_sw, isubc_lw, lalw1bd, idate,                             &
+       mpicomm, mpirank, mpiroot, aeros_file, iaermdl, iaerflg, con_pi, con_t0c,         &
+       con_c, con_boltz, con_plnk, solar_file, con_solr_2008, con_solr_2002, co2usr_file,&
+       co2cyc_file, ipsd0, errmsg, errflg)
 
     ! Inputs
     logical, intent(in) :: do_RRTMGP
@@ -57,7 +58,8 @@ contains
          con_pi, con_t0c, con_c, con_boltz, con_plnk, con_solr_2008, con_solr_2002
     real(kind_phys), dimension(:), intent(in) :: &
          si
-    integer, intent(in) :: levr, ictm, isol, ico2, iaer, ntcw, ntoz, iovr, isubc_sw, isubc_lw, me
+    type(MPI_Comm), intent(in) :: mpicomm
+    integer, intent(in) :: levr, ictm, isol, ico2, iaer, ntcw, ntoz, iovr, isubc_sw, isubc_lw, mpirank, mpiroot
     logical, intent(in) :: &
          lalw1bd
     integer, intent(in), dimension(:) :: &
@@ -94,7 +96,7 @@ contains
        ipsd0 = 17*idate(1)+43*idate(2)+37*idate(3)+23*idate(4)
     endif
     
-    if ( me == 0 ) then
+    if ( mpirank == mpiroot ) then
        print *,'  In rad_initialize (GFS_rrtmgp_setup_init), before calling radinit'
        print *,' si       = ',si
        print *,' levr     = ',levr,      &
@@ -109,7 +111,7 @@ contains
                ' isubc_sw = ',isubc_sw,  &
                ' isubc_lw = ',isubc_lw,  &
                ' ipsd0    = ',ipsd0,     &
-               ' me       = ',me
+               ' mpirank  = ',mpirank
     endif
 
     loz1st = (ntoz == 0)           ! first-time clim ozone data read flag
@@ -120,14 +122,14 @@ contains
     if (is_initialized) return
 
     ! Call initialization routines..
-    call sol_init ( me, isol, solar_file, con_solr_2008, con_solr_2002, con_pi )
-    call aer_init ( levr, me, iaermdl, iaerflg, lalw1bd, aeros_file, con_pi, con_t0c,    &
-         con_c, con_boltz, con_plnk, errflg, errmsg)
+    call sol_init ( mpicomm, mpirank, mpiroot, isol, solar_file, con_solr_2008, con_solr_2002, con_pi )
+    call aer_init ( levr, mpicomm, mpirank, mpiroot, iaermdl, iaerflg, lalw1bd, aeros_file, con_pi, &
+         con_t0c, con_c, con_boltz, con_plnk, errflg, errmsg)
     if(errflg/=0) return
-    call gas_init ( me, co2usr_file, co2cyc_file, ico2, ictm, con_pi, errflg, errmsg )
+    call gas_init ( mpicomm, mpirank, mpiroot, co2usr_file, co2cyc_file, ico2, ictm, con_pi, errflg, errmsg )
     if(errflg/=0) return
 
-    if ( me == 0 ) then
+    if ( mpirank == mpiroot ) then
        print *,' return from rad_initialize (GFS_rrtmgp_setup_init) - after calling radinit'
     endif
     
@@ -138,9 +140,9 @@ contains
 !> \section arg_table_GFS_rrtmgp_setup_timestep_init Argument Table
 !! \htmlinclude GFS_rrtmgp_setup_timestep_init.html
 !!
-  subroutine GFS_rrtmgp_setup_timestep_init (idate, jdate, deltsw, deltim, doSWrad, me,     &
-       iaermdl, aeros_file, isol, slag, sdec, cdec, solcon, con_pi, co2dat_file,            &
-       co2gbl_file, ictm, ico2, ntoz, ozphys, errmsg, errflg)
+  subroutine GFS_rrtmgp_setup_timestep_init (idate, jdate, deltsw, deltim, doSWrad,         &
+       mpicomm, mpirank, mpiroot, iaermdl, aeros_file, isol, slag, sdec, cdec, solcon,      &
+       con_pi, co2dat_file, co2gbl_file, ictm, ico2, ntoz, ozphys, errmsg, errflg)
      
     ! Inputs
     integer,         intent(in)  :: idate(:)
@@ -149,7 +151,8 @@ contains
     real(kind_phys), intent(in)  :: deltim
     logical,         intent(in)  :: doSWrad
     real(kind_phys), intent(in)  :: con_pi
-    integer,         intent(in)  :: me
+    type(MPI_Comm),  intent(in)  :: mpicomm
+    integer,         intent(in)  :: mpirank, mpiroot
     integer,         intent(in)  :: iaermdl,isol,ictm,ico2,ntoz
     character(len=26), intent(in) :: aeros_file,co2dat_file,co2gbl_file
     type(ty_ozphys),intent(inout) :: ozphys
@@ -217,13 +220,14 @@ contains
           lsol_chg = ( isol==4 .and. lmon_chg )
        endif
        iyear0 = iyear
-       call sol_update(jdate, kyear, deltsw, deltim, lsol_chg, me, slag, sdec, cdec, solcon, con_pi, errmsg, errflg)
+       call sol_update(jdate, kyear, deltsw, deltim, lsol_chg, mpicomm, mpirank, mpiroot, &
+                       slag, sdec, cdec, solcon, con_pi, errmsg, errflg)
        if(errflg/=0) return
     endif
 
     ! Update aerosols...
     if ( lmon_chg ) then
-       call aer_update ( iyear, imon, me, iaermdl, aeros_file, errflg, errmsg)
+       call aer_update ( iyear, imon, mpicomm, mpirank, mpiroot, iaermdl, aeros_file, errflg, errmsg)
        if(errflg/=0) return
     endif
 
@@ -234,7 +238,7 @@ contains
     else
        lco2_chg = .false.
     endif
-    call gas_update (kyear, kmon, kday, khour, lco2_chg, me, co2dat_file, co2gbl_file, ictm,&
+    call gas_update (kyear, kmon, kday, khour, lco2_chg, mpicomm, mpirank, mpiroot, co2dat_file, co2gbl_file, ictm,&
          ico2, errflg, errmsg )
     if(errflg/=0) return
     if (ntoz == 0) then

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_setup.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_setup.meta
@@ -190,9 +190,23 @@
   dimensions = (4)
   type = integer
   intent = in
-[me]
+[mpicomm]
+  standard_name = mpi_communicator
+  long_name = MPI communicator
+  units = index
+  dimensions = ()
+  type = MPI_Comm
+  intent = in
+[mpirank]
   standard_name = mpi_rank
   long_name = current MPI-rank
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+[mpiroot]
+  standard_name = mpi_root
+  long_name = master MPI-rank
   units = index
   dimensions = ()
   type = integer
@@ -339,9 +353,23 @@
   dimensions = ()
   type = logical
   intent = in
-[me]
+[mpicomm]
+  standard_name = mpi_communicator
+  long_name = MPI communicator
+  units = index
+  dimensions = ()
+  type = MPI_Comm
+  intent = in
+[mpirank]
   standard_name = mpi_rank
   long_name = current MPI-rank
+  units = index
+  dimensions = ()
+  type = integer
+  intent = in
+[mpiroot]
+  standard_name = mpi_root
+  long_name = master MPI-rank
   units = index
   dimensions = ()
   type = integer

--- a/physics/MP/Morrison_Gettelman/aerinterp.F90
+++ b/physics/MP/Morrison_Gettelman/aerinterp.F90
@@ -903,7 +903,6 @@ contains
       integer ierr
 
 !! ===================================================================
-      read_and_broadcast: if (mpirank==mpiroot) then
       allocate (buff(lonsaer, latsaer, levsw))
       allocate (pres_tmp(lonsaer, levsw))
       allocate (buffx(lonsaer, latsaer, levsw, 1))
@@ -995,10 +994,7 @@ contains
 
       deallocate (buff, pres_tmp)
       deallocate (buffx)
-      endif read_and_broadcast
       
-      call ccpp_bcast(aer_pres, mpiroot, mpicomm, ierr)
-      call ccpp_bcast(aerin,    mpiroot, mpicomm, ierr)
       END SUBROUTINE read_netfaer_dl
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       subroutine read_netfaer(mpicomm, mpirank, mpiroot, nf, iflip, nt, errmsg, errflg)
@@ -1019,7 +1015,6 @@ contains
       integer :: ierr
       
 !! ===================================================================
-      read_and_broadcast: if (mpirank==mpiroot) then
       allocate (buff(lonsaer, latsaer, levsw))
       allocate (pres_tmp(lonsaer, levsw))
       allocate (buffx(lonsaer, latsaer, levsw, 1))
@@ -1111,10 +1106,7 @@ contains
       endif
       deallocate (buff, pres_tmp)
       deallocate (buffx)
-      endif read_and_broadcast
-      
-      call ccpp_bcast(aer_pres, mpiroot, mpicomm, ierr)
-      call ccpp_bcast(aerin,    mpiroot, mpicomm, ierr)
+
       END SUBROUTINE read_netfaer
 
 end module aerinterp

--- a/physics/MP/TEMPO/mp_tempo.meta
+++ b/physics/MP/TEMPO/mp_tempo.meta
@@ -91,7 +91,7 @@
   kind = kind_phys
   intent = in
 [con_avgd]
-  standard_name = avogadro_consant
+  standard_name = avogadro_constant
   long_name = Avogadro constant
   units = mol-1
   dimensions = ()

--- a/physics/Radiation/radiation_aerosols.f
+++ b/physics/Radiation/radiation_aerosols.f
@@ -3651,7 +3651,8 @@
 
       ! DH* This will need to be implemented by a host model
       ! that actually uses this data
-      print *, 'NOTE: gocart aerosol initialization is reading input data with all MPI ranks'
+      print *, 'NOTE: gocart aerosol initialization is reading input ', &
+     &         'data with all MPI ranks'
 
       if (KCM /= ntrcaerm ) then
         print *, 'ERROR in # of gocart aer species',KCM


### PR DESCRIPTION
## Description of Changes:
These changes allow NOAA models to compile/run with the changes from #1187.

 - change calls to subroutines in NOAA-specific interstitials to reflect changes in interfaces for the added ccpp_bcast calls
 - remove ccpp_bcast calls from two subroutines in aerinterp.F90 due to hanging UFS RTs; if reinstated in the future, the overloaded ccpp_bcast subroutine will need to add interfaces for 4D and 5D integer arrays, plus the entire arrays of `aer_pres` and `aer_in` should be allocated at once so that sending/receiving MPI ranks can effectively broadcast; there may also be an issue with different size slices of the array being broadcast from different ranks. 

## Tests Conducted:
SCM RTs - see https://github.com/NCAR/ccpp-scm/pull/682
UFS RTs - see https://github.com/ufs-community/ufs-weather-model/pull/3190 (tested along with many other accumulated physics changes, but B4B for all tests that actually finished)

## Dependencies:
None

## Documentation:
None

## Issue (optional):
None

