### PR TITLE
hotfix: github actions version bump

### DIFF
--- a/.github/workflows/basic_checks.yml
+++ b/.github/workflows/basic_checks.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
     - name: Init submodules
       run: git submodule update --init --recursive
     #- name: Update packages

--- a/.github/workflows/ci_fv3_ccpp_prebuild.yml
+++ b/.github/workflows/ci_fv3_ccpp_prebuild.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout current ccpp-physics code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
@@ -41,7 +41,7 @@ jobs:
         git checkout remote_local/$GIT_REMOTE_BRANCH
 
     - name: Set up Python 3.10.13
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: 3.10.13
 

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
     - name: Checkout current ccpp-physics code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Store remote-URL for current ccpp-physics code
       run: echo "GIT_REMOTE_URL=`git remote get-url origin`" >> $GITHUB_ENV
@@ -45,7 +45,7 @@ jobs:
         git checkout remote_local/$GIT_REMOTE_BRANCH
 
     - name: Set up Python 3.10.13
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: 3.10.13
 

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -31,12 +31,12 @@ jobs:
         doxygen --version
 
     - name: Checkout current ccpp-physics code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         path: ccpp_repo
 
     - name: Checkout CCPP SCM main
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: NCAR/ccpp-scm
         path: scm_repo
@@ -123,13 +123,13 @@ jobs:
         mv html/main/* $GITHUB_WORKSPACE/physics/docs/html
 
     - name: Setup Pages
-      uses: actions/configure-pages@v5
+      uses: actions/configure-pages@v6
 
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v5
       with:
         path: physics/docs/html
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4.0.5
+      uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Description of Changes:
- [docygen.yml](https://github.com/NCAR/ccpp-physics/blob/main/.github/workflows/doxygen.yml) github action is [failing](https://github.com/NCAR/ccpp-physics/actions/runs/24528164373/job/72733350759). Seems to be because action/checkout was an old version that uses [deprecated nodejs20](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)
- bumped other github action versions to newest ones, may also be failing due to deprecated nodejs 20

## Tests Conducted:
- Limit testing locally with [act](https://github.com/nektos/act). Didn't use the Github token and some actions failed but got further than previously. 
- Test will be if PR passes CI.
