### PR TITLE
Metadata corrections from Fortran vs Metadata validation

### DIFF
--- a/physics/CONV/C3/cu_c3_driver.meta
+++ b/physics/CONV/C3/cu_c3_driver.meta
@@ -288,6 +288,7 @@
   units = none
   dimensions = ()
   type = real
+  kind = kind_phys
   intent = in
 [phil]
   standard_name = geopotential

--- a/physics/CONV/Grell_Freitas/cu_gf_driver.meta
+++ b/physics/CONV/Grell_Freitas/cu_gf_driver.meta
@@ -579,7 +579,6 @@
   type = real
   kind = kind_phys
   intent = in
-  optional = True
 [do_mynnedmf]
   standard_name = flag_for_mellor_yamada_nakanishi_niino_pbl_scheme
   long_name = flag to activate MYNN-EDMF

--- a/physics/CONV/SAMF/samfdeepcnv.meta
+++ b/physics/CONV/SAMF/samfdeepcnv.meta
@@ -517,6 +517,7 @@
   units = none
   dimensions = ()
   type = real
+  kind = kind_phys
   intent = in
 [maxMF]
   standard_name = maximum_mass_flux

--- a/physics/CONV/SAMF/samfshalcnv.meta
+++ b/physics/CONV/SAMF/samfshalcnv.meta
@@ -549,6 +549,7 @@
   units = none
   dimensions = ()
   type = real
+  kind = kind_phys
   intent = in
 [cat_adj_shal]
   standard_name = adjustment_for_convective_advection_time_for_shallow

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.meta
@@ -228,7 +228,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [gq0]
   standard_name = tracer_concentration_of_new_state
   long_name = tracer concentration updated by physics

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_SCNV_generic_pre.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_SCNV_generic_pre.meta
@@ -98,7 +98,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_tracers)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [ntqv]
   standard_name = index_of_specific_humidity_in_tracer_concentration_array
   long_name = tracer index for water vapor (specific humidity)

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rad_time_vary.scm.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rad_time_vary.scm.F90
@@ -29,19 +29,19 @@
 
          ! Interface variables
          logical,                intent(in)    :: lrseeds
-         integer,                intent(in)    :: rseeds(:,:)
+         integer,                intent(in),    optional :: rseeds(:,:)
          integer,                intent(in)    :: isubc_lw, isubc_sw, cnx, cny, isc, jsc, kdt
          integer,                intent(in)    :: imp_physics, ipsd0, ipsdlim
          logical,                intent(in)    :: lslwr, lsswr
-         integer,                intent(inout) :: icsdsw(:), icsdlw(:)
+         integer,                intent(inout), optional :: icsdsw(:), icsdlw(:)
          integer,                intent(in)    :: imap(:), jmap(:)
          real(kind_phys),        intent(in)    :: sec
-         real(kind_phys),        intent(inout) :: ps_2delt(:)
-         real(kind_phys),        intent(inout) :: ps_1delt(:)
-         real(kind_phys),        intent(inout) :: t_2delt(:,:)
-         real(kind_phys),        intent(inout) :: t_1delt(:,:)
-         real(kind_phys),        intent(inout) :: qv_2delt(:,:)
-         real(kind_phys),        intent(inout) :: qv_1delt(:,:)
+         real(kind_phys),        intent(inout), optional :: ps_2delt(:)
+         real(kind_phys),        intent(inout), optional :: ps_1delt(:)
+         real(kind_phys),        intent(inout), optional :: t_2delt(:,:)
+         real(kind_phys),        intent(inout), optional :: t_1delt(:,:)
+         real(kind_phys),        intent(inout), optional :: qv_2delt(:,:)
+         real(kind_phys),        intent(inout), optional :: qv_1delt(:,:)
          real(kind_phys),        intent(in)    :: t(:,:), qv(:,:), ps(:)
          character(len=*),       intent(out)   :: errmsg
          integer,                intent(out)   :: errflg

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_radiation_surface.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_radiation_surface.meta
@@ -334,7 +334,7 @@
   units = flag
   dimensions = (horizontal_loop_extent)
   type = integer
-  intent = inout
+  intent = in
 [alvsf]
   standard_name = vis_albedo_strong_cosz
   long_name = mean vis albedo with strong cosz dependency
@@ -390,7 +390,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [semis_ice]
   standard_name = surface_longwave_emissivity_over_ice
   long_name = surface lw emissivity in fraction over ice
@@ -398,7 +398,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [semis_wat]
   standard_name = surface_longwave_emissivity_over_water
   long_name = surface lw emissivity in fraction over water

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmg_pre.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmg_pre.meta
@@ -567,6 +567,7 @@
   units = km
   dimensions = ()
   type = real
+  kind = kind_phys
   intent = in
 [idcor]
   standard_name = flag_for_decorrelation_length_method

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_pre.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_pre.meta
@@ -362,7 +362,6 @@
   type = real
   kind = kind_phys
   intent = inout
-  optional = True
 [tsfg]
   standard_name = surface_ground_temperature_for_radiation
   long_name = surface ground temperature for radiation
@@ -517,7 +516,7 @@
   units = count
   dimensions = ()
   type = integer
-  intent = inout
+  intent = out
 [idxday]
   standard_name = daytime_points
   long_name = daytime points

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_3.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_3.meta
@@ -268,7 +268,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  intent = out
+  intent = inout
   optional = True
 [omegain]
   standard_name = prognostic_updraft_velocity_in_convection
@@ -277,7 +277,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
   optional = True
 [omegaout]
   standard_name = updraft_velocity_updated_by_physics

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_4.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_4.meta
@@ -313,7 +313,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  intent = inout
+  intent = in
 [dtidx]
   standard_name = cumulative_change_of_state_variables_outer_index
   long_name = index of state-variable and process in last dimension of diagnostic tendencies array AKA cumulative_change_index

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_pre.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_pre.meta
@@ -282,7 +282,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [tprcp]
   standard_name = nonnegative_lwe_thickness_of_precipitation_amount_on_dynamics_timestep
   long_name = total precipitation amount in each time step

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_post.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_post.meta
@@ -454,7 +454,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
   optional = True
 [epi]
   standard_name = instantaneous_surface_potential_evaporation

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/maximum_hourly_diagnostics.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/maximum_hourly_diagnostics.meta
@@ -229,7 +229,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = inout
+  intent = in
 [pratemax]
   standard_name = maximum_precipitation_rate_over_maximum_hourly_time_interval
   long_name = maximum precipitation rate over maximum hourly time interval

--- a/physics/MP/GFDL/v3_2022/gfdl_cloud_microphys_v3.meta
+++ b/physics/MP/GFDL/v3_2022/gfdl_cloud_microphys_v3.meta
@@ -385,7 +385,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = inout
+  intent = in
 [dtp]
   standard_name = timestep_for_physics
   long_name = physics timestep

--- a/physics/MP/NSSL/mp_nssl.meta
+++ b/physics/MP/NSSL/mp_nssl.meta
@@ -592,7 +592,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = inout
+  intent = out
 [rain]
   standard_name = lwe_thickness_of_explicit_rain_amount
   long_name = explicit rain fall on physics timestep
@@ -600,7 +600,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = inout
+  intent = out
 [graupel]
   standard_name = lwe_thickness_of_graupel_amount
   long_name = graupel fall on physics timestep
@@ -608,7 +608,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = inout
+  intent = out
 [ice]
   standard_name = lwe_thickness_of_ice_amount
   long_name = ice fall on physics timestep
@@ -616,7 +616,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = inout
+  intent = out
 [snow]
   standard_name = lwe_thickness_of_snow_amount
   long_name = snow fall on physics timestep
@@ -624,7 +624,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = inout
+  intent = out
 [sr]
   standard_name = ratio_of_snowfall_to_rainfall
   long_name = ratio of snowfall to large-scale rainfall
@@ -640,7 +640,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  intent = out
+  intent = inout
 [do_radar_ref]
   standard_name = flag_for_radar_reflectivity
   long_name = flag for radar reflectivity

--- a/physics/MP/TEMPO/mp_tempo.F90
+++ b/physics/MP/TEMPO/mp_tempo.F90
@@ -437,7 +437,7 @@ module mp_tempo
          real(kind_phys),           intent(in   ) :: dtp
          logical,                   intent(in   ) :: first_time_step
          integer,                   intent(in   ) :: istep, nsteps
-         real,                      intent(in   ) :: dt_inner
+         real(kind=kind_phys),      intent(in   ) :: dt_inner
          ! Precip/rain/snow/graupel fall amounts and fraction of frozen precip
          real(kind_phys),           intent(inout) :: prcp(:)
          real(kind_phys),           intent(inout), optional :: rain(:)

--- a/physics/MP/TEMPO/mp_tempo.meta
+++ b/physics/MP/TEMPO/mp_tempo.meta
@@ -774,7 +774,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  intent = out
+  intent = inout
 [max_hail_diam_sfc]
   standard_name = max_hail_diameter_sfc
   long_name = instantaneous maximum hail diameter at lowest model level
@@ -862,6 +862,7 @@
   units = 1
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
+  kind = kind_phys
   intent = in
   optional = True
 [spp_mp]

--- a/physics/MP/Thompson/mp_thompson.F90
+++ b/physics/MP/Thompson/mp_thompson.F90
@@ -425,7 +425,7 @@ module mp_thompson
          real(kind_phys),           intent(in   ) :: dtp
          logical,                   intent(in   ) :: first_time_step
          integer,                   intent(in   ) :: istep, nsteps
-         real,                      intent(in   ) :: dt_inner
+         real(kind=kind_phys),      intent(in   ) :: dt_inner
          ! Precip/rain/snow/graupel fall amounts and fraction of frozen precip
          real(kind_phys),           intent(inout) :: prcp(:)
          real(kind_phys),           intent(inout) :: rain(:)

--- a/physics/MP/Thompson/mp_thompson.meta
+++ b/physics/MP/Thompson/mp_thompson.meta
@@ -780,7 +780,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  intent = out
+  intent = inout
 [max_hail_diam_sfc]
   standard_name = max_hail_diameter_sfc
   long_name = instantaneous maximum hail diameter at lowest model level
@@ -868,6 +868,7 @@
   units = 1
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
+  kind = kind_phys
   intent = in
   optional = True
 [spp_mp]

--- a/physics/PBL/MYNN_EDMF/mynnedmf_wrapper.meta
+++ b/physics/PBL/MYNN_EDMF/mynnedmf_wrapper.meta
@@ -109,6 +109,7 @@
   units = none
   dimensions = ()
   type = real
+  kind = kind_phys
   intent = in
 [con_t0c]
   standard_name = temperature_at_zero_celsius
@@ -362,7 +363,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  intent = inout
+  intent = in
   optional = True
 [prsl]
   standard_name = air_pressure
@@ -1363,6 +1364,7 @@
   units = 1
   dimensions = ()
   type = real
+  kind = kind_phys
   intent = in
 [icloud_bl]
   standard_name = control_for_sgs_cloud_radiation_coupling_in_mellor_yamamda_nakanishi_niino_pbl_scheme

--- a/physics/PBL/YSU/ysuvdif.meta
+++ b/physics/PBL/YSU/ysuvdif.meta
@@ -110,6 +110,7 @@
   units = none
   dimensions = ()
   type = real
+  kind = kind_phys
   intent = in
 [utnp]
   standard_name = process_split_cumulative_tendency_of_x_wind

--- a/physics/PBL/saYSU/shinhongvdif.meta
+++ b/physics/PBL/saYSU/shinhongvdif.meta
@@ -110,6 +110,7 @@
   units = none
   dimensions = ()
   type = real
+  kind = kind_phys
   intent = in
 [utnp]
   standard_name = process_split_cumulative_tendency_of_x_wind

--- a/physics/SFC_Layer/GFDL/gfdl_sfc_layer.meta
+++ b/physics/SFC_Layer/GFDL/gfdl_sfc_layer.meta
@@ -98,6 +98,7 @@
   units = none
   dimensions = ()
   type = real
+  kind = kind_phys
   intent = in
 [xlat]
   standard_name = latitude

--- a/physics/SFC_Layer/UFS/sfc_diag.meta
+++ b/physics/SFC_Layer/UFS/sfc_diag.meta
@@ -91,6 +91,7 @@
   units = none
   dimensions = ()
   type = real
+  kind = kind_phys
   intent = in
 [zf]
   standard_name = height_above_ground_at_lowest_model_layer

--- a/physics/SFC_Models/Lake/CLM/clm_lake.meta
+++ b/physics/SFC_Models/Lake/CLM/clm_lake.meta
@@ -131,7 +131,7 @@
   units = flag
   dimensions = (horizontal_loop_extent)
   type = integer
-  intent = inout
+  intent = in
 [clm_lake_initialized]
   standard_name = flag_for_clm_lake_initialization
   long_name = set to true in clm_lake_run after likeini is called, as a workaround for ccpp limitation
@@ -328,7 +328,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [flag_iter]
   standard_name = flag_for_iteration
   long_name = flag for iteration
@@ -573,7 +573,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = inout
 [lake_q2m]
   standard_name =  specific_humidity_at_2m_from_clm_lake
   long_name = specific humidity at 2m from clm lake
@@ -581,7 +581,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = inout
 [weasd]
   standard_name = lwe_thickness_of_surface_snow_amount
   long_name = water equiv of acc snow depth over land and sea ice
@@ -746,7 +746,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [t1]
   standard_name = air_temperature_at_surface_adjacent_layer
   long_name = mean temperature at lowest model layer

--- a/physics/SFC_Models/Land/RUC/lsm_ruc.meta
+++ b/physics/SFC_Models/Land/RUC/lsm_ruc.meta
@@ -791,7 +791,7 @@
   units = index
   dimensions = (horizontal_loop_extent)
   type = integer
-  intent = in
+  intent = inout
 [vtype]
   standard_name = vegetation_type_classification
   long_name = vegetation type at each grid cell

--- a/physics/SFC_Models/SeaIce/CICE/sfc_sice.meta
+++ b/physics/SFC_Models/SeaIce/CICE/sfc_sice.meta
@@ -304,7 +304,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [tprcp]
   standard_name = nonnegative_lwe_thickness_of_precipitation_amount_on_dynamics_timestep_over_ice
   long_name = total precipitation amount in each time step over ice
@@ -344,7 +344,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [qss_w]
   standard_name = surface_specific_humidity_over_water
   long_name = surface air saturation specific humidity over water
@@ -352,7 +352,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [snowmt]
   standard_name = surface_snow_melt
   long_name = snow melt during timestep
@@ -392,7 +392,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [evapw]
   standard_name = kinematic_surface_upward_latent_heat_flux_over_water
   long_name = kinematic surface upward latent heat flux over water
@@ -400,7 +400,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [hflxi]
   standard_name = kinematic_surface_upward_sensible_heat_flux_over_ice
   long_name = kinematic surface upward sensible heat flux over ice
@@ -408,7 +408,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [hflxw]
   standard_name = kinematic_surface_upward_sensible_heat_flux_over_water
   long_name = kinematic surface upward sensible heat flux over water
@@ -416,7 +416,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [islmsk]
   standard_name = sea_land_ice_mask_cice
   long_name = sea/land/ice mask cice (=0/1/2)

--- a/physics/smoke_dust/rrfs_smoke_wrapper.meta
+++ b/physics/smoke_dust/rrfs_smoke_wrapper.meta
@@ -392,7 +392,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  intent = inout
+  intent = in
 [us3d]
   standard_name = x_wind_of_new_state
   long_name = updated x-direction wind
@@ -400,7 +400,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  intent = inout
+  intent = in
 [vs3d]
   standard_name = y_wind_of_new_state
   long_name = updated y-direction wind
@@ -408,7 +408,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  intent = inout
+  intent = in
 [spechum]
   standard_name = specific_humidity_of_new_state
   long_name = water vapor specific humidity updated by physics
@@ -416,7 +416,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  intent = inout
+  intent = in
 [w]
   standard_name = lagrangian_tendency_of_air_pressure
   long_name = layer mean vertical velocity
@@ -439,7 +439,7 @@
   dimensions = (horizontal_loop_extent,vertical_dimension_of_soil_internal_to_land_surface_scheme)
   type = real
   kind = kind_phys
-  intent = inout
+  intent = in
   optional = True
 [tslb]
   standard_name = soil_temperature_for_land_surface_model
@@ -896,7 +896,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = inout
   optional = True
 [hwp_ave]
   standard_name = hourly_wildfire_potential_average
@@ -939,7 +939,7 @@
  dimensions = (horizontal_loop_extent)
  type = real
  kind = kind_phys
- intent = out
+ intent = inout
  optional = True
 [lu_nofire_out]
  standard_name = sum_of_land_use_fractions_for_no_fire_pixels


### PR DESCRIPTION
## Description of Changes:

Metadata corrections from Fortran vs Metadata validation using an advanced version of the `ccpp-capgen` validator.

**Disclaimer.** I asked Claude/Opus to analyze the inconsistencies flagged by the validator, present the findings and then fix them. After that, I ran the validator again and all inconsistencies were gone.

`ufs/dev` pull request: https://github.com/ufs-community/ccpp-physics/pull/375

**Note.** This set of changes is limited to `intent`, `kind`, and `optional` corrections. Additional changes will be introduced later regarding legacy dimension names etc. These require discussion and coordination in the CCPP physics management group. For now, I am using a legacy switch to allow these inconsistencies to pass through.

## Tests Conducted:

With these changes, the Fortran vs Metadata validation succeeds, and all suites present in CCPP-SCM (latest dev code) compile.

## Dependencies:

None

## Documentation:

None

## Issue (optional):

None

## Contributors (optional):

@dustinswales 
