### PR TITLE
resubmission: Small inconsistency between metadata and fortran code

### DIFF
--- a/physics/SFC_Models/Lake/Flake/flake_driver.F90
+++ b/physics/SFC_Models/Lake/Flake/flake_driver.F90
@@ -427,8 +427,8 @@ contains
    subroutine flake_driver_post_finalize()
    end subroutine flake_driver_post_finalize
 
-!> \section arg_table_flake_driver_post Argument Table
-!! \htmlinclude flake_driver_post.html
+!> \section arg_table_flake_driver_post_run Argument Table
+!! \htmlinclude flake_driver_post_run.html
 !!
 subroutine flake_driver_post_run (im, use_lake_model, h_ML, T_wML,  &
                            Tsurf, lakedepth, xz, zm, tref, tsfco,   &

--- a/physics/SFC_Models/Lake/Flake/flake_driver.meta
+++ b/physics/SFC_Models/Lake/Flake/flake_driver.meta
@@ -409,7 +409,7 @@
 
 ########################################################################
 [ccpp-table-properties]
-  name = flake_driver_post
+  name = flake_driver_post_run
   type = scheme
   dependencies = machine.F
 ########################################################################

--- a/physics/SFC_Models/Lake/Flake/flake_driver.meta
+++ b/physics/SFC_Models/Lake/Flake/flake_driver.meta
@@ -409,9 +409,9 @@
 
 ########################################################################
 [ccpp-table-properties]
-  name = flake_driver_post_run
+  name = flake_driver_post
   type = scheme
-  dependencies = machine.F
+  dependencies = ../../../hooks/machine.F
 ########################################################################
 [ccpp-arg-table]
   name = flake_driver_post_run


### PR DESCRIPTION
## Description of Changes:
- PR is a resubmission of #1217, just targeting `main` instead of `scm/dev`. 
- Small inconsistency between metadata and fortran code

## Tests Conducted:
See NCAR/ccpp-scm#699, passes all its [CI checks](https://github.com/NCAR/ccpp-scm/pull/699/checks)

## Documentation:
No new documentation needed.

## Contributors:
Dustin Swales @dustinswales
